### PR TITLE
core: rename url-shim to url-utils, stop extending global URL

### DIFF
--- a/cli/run.js
+++ b/cli/run.js
@@ -19,7 +19,7 @@ import * as Printer from './printer.js';
 import lighthouse, {legacyNavigation} from '../core/index.js';
 import {getLhrFilenamePrefix} from '../report/generator/file-namer.js';
 import * as assetSaver from '../core/lib/asset-saver.js';
-import URL from '../core/lib/url-shim.js';
+import UrlUtils from '../core/lib/url-utils.js';
 
 /** @typedef {Error & {code: string, friendlyMessage?: string}} ExitError */
 
@@ -232,7 +232,7 @@ async function runLighthouse(url, flags, config) {
     }
 
     const shouldGather = flags.gatherMode || flags.gatherMode === flags.auditMode;
-    const shouldUseLocalChrome = URL.isLikeLocalhost(flags.hostname);
+    const shouldUseLocalChrome = UrlUtils.isLikeLocalhost(flags.hostname);
     if (shouldGather && shouldUseLocalChrome) {
       launchedChrome = await getDebuggableChrome(flags);
       flags.port = launchedChrome.port;

--- a/core/audits/byte-efficiency/modern-image-formats.js
+++ b/core/audits/byte-efficiency/modern-image-formats.js
@@ -9,7 +9,7 @@
 
 
 import {ByteEfficiencyAudit} from './byte-efficiency-audit.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
@@ -106,7 +106,7 @@ class ModernImageFormats extends ByteEfficiencyAudit {
       const imageElement = imageElementsByURL.get(image.url);
 
       if (image.failed) {
-        warnings.push(`Unable to decode ${URL.getURLDisplayName(image.url)}`);
+        warnings.push(`Unable to decode ${UrlUtils.getURLDisplayName(image.url)}`);
         continue;
       }
 
@@ -123,7 +123,7 @@ class ModernImageFormats extends ByteEfficiencyAudit {
 
       if (typeof webpSize === 'undefined') {
         if (!imageElement) {
-          warnings.push(`Unable to locate resource ${URL.getURLDisplayName(image.url)}`);
+          warnings.push(`Unable to locate resource ${UrlUtils.getURLDisplayName(image.url)}`);
           continue;
         }
 
@@ -152,8 +152,8 @@ class ModernImageFormats extends ByteEfficiencyAudit {
       const wastedBytes = image.originalSize - avifSize;
       if (wastedBytes < IGNORE_THRESHOLD_IN_BYTES) continue;
 
-      const url = URL.elideDataURI(image.url);
-      const isCrossOrigin = !URL.originsMatch(pageURL, image.url);
+      const url = UrlUtils.elideDataURI(image.url);
+      const isCrossOrigin = !UrlUtils.originsMatch(pageURL, image.url);
 
       items.push({
         node: imageElement ? ByteEfficiencyAudit.makeNodeItem(imageElement.node) : undefined,

--- a/core/audits/byte-efficiency/offscreen-images.js
+++ b/core/audits/byte-efficiency/offscreen-images.js
@@ -12,7 +12,7 @@
 import {ByteEfficiencyAudit} from './byte-efficiency-audit.js';
 import {NetworkRequest} from '../../lib/network-request.js';
 import {Sentry} from '../../lib/sentry.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 import Interactive from '../../computed/metrics/interactive.js';
 import ProcessedTrace from '../../computed/processed-trace.js';
@@ -87,7 +87,7 @@ class OffscreenImages extends ByteEfficiencyAudit {
     // If the image had its loading behavior explicitly controlled already, treat it as passed.
     if (image.loading === 'lazy' || image.loading === 'eager') return null;
 
-    const url = URL.elideDataURI(image.src);
+    const url = UrlUtils.elideDataURI(image.src);
     const totalPixels = image.displayedWidth * image.displayedHeight;
     const visiblePixels = this.computeVisiblePixels(image.clientRect, viewportDimensions);
     // Treat images with 0 area as if they're offscreen. See https://github.com/GoogleChrome/lighthouse/issues/1914

--- a/core/audits/byte-efficiency/uses-long-cache-ttl.js
+++ b/core/audits/byte-efficiency/uses-long-cache-ttl.js
@@ -8,7 +8,7 @@ import parseCacheControl from 'parse-cache-control';
 
 import {Audit} from '../audit.js';
 import {NetworkRequest} from '../../lib/network-request.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import {linearInterpolation} from '../../lib/statistics.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 import NetworkRecords from '../../computed/network-records.js';
@@ -233,7 +233,7 @@ class CacheHeaders extends Audit {
         const cacheHitProbability = CacheHeaders.getCacheHitProbability(cacheLifetimeInSeconds);
         if (cacheHitProbability > IGNORE_THRESHOLD_IN_PERCENT) continue;
 
-        const url = URL.elideDataURI(record.url);
+        const url = UrlUtils.elideDataURI(record.url);
         const totalBytes = record.transferSize || 0;
         const wastedBytes = (1 - cacheHitProbability) * totalBytes;
 

--- a/core/audits/byte-efficiency/uses-optimized-images.js
+++ b/core/audits/byte-efficiency/uses-optimized-images.js
@@ -10,7 +10,7 @@
 
 
 import {ByteEfficiencyAudit} from './byte-efficiency-audit.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
@@ -83,7 +83,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
       const imageElement = imageElementsByURL.get(image.url);
 
       if (image.failed) {
-        warnings.push(`Unable to decode ${URL.getURLDisplayName(image.url)}`);
+        warnings.push(`Unable to decode ${UrlUtils.getURLDisplayName(image.url)}`);
         continue;
       } else if (/(jpeg|bmp)/.test(image.mimeType) === false) {
         continue;
@@ -94,7 +94,7 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
 
       if (typeof jpegSize === 'undefined') {
         if (!imageElement) {
-          warnings.push(`Unable to locate resource ${URL.getURLDisplayName(image.url)}`);
+          warnings.push(`Unable to locate resource ${UrlUtils.getURLDisplayName(image.url)}`);
           continue;
         }
 
@@ -111,8 +111,8 @@ class UsesOptimizedImages extends ByteEfficiencyAudit {
 
       if (image.originalSize < jpegSize + IGNORE_THRESHOLD_IN_BYTES) continue;
 
-      const url = URL.elideDataURI(image.url);
-      const isCrossOrigin = !URL.originsMatch(pageURL, image.url);
+      const url = UrlUtils.elideDataURI(image.url);
+      const isCrossOrigin = !UrlUtils.originsMatch(pageURL, image.url);
       const jpegSavings = UsesOptimizedImages.computeSavings({...image, jpegSize});
 
       items.push({

--- a/core/audits/byte-efficiency/uses-responsive-images-snapshot.js
+++ b/core/audits/byte-efficiency/uses-responsive-images-snapshot.js
@@ -13,7 +13,7 @@
 
 import {Audit} from '../audit.js';
 import * as UsesResponsiveImages from './uses-responsive-images.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
@@ -71,7 +71,7 @@ class UsesResponsiveImagesSnapshot extends Audit {
 
       items.push({
         node: Audit.makeNodeItem(image.node),
-        url: URL.elideDataURI(image.src),
+        url: UrlUtils.elideDataURI(image.src),
         displayedDimensions: `${displayed.width}x${displayed.height}`,
         actualDimensions: `${actual.width}x${actual.height}`,
       });

--- a/core/audits/byte-efficiency/uses-responsive-images.js
+++ b/core/audits/byte-efficiency/uses-responsive-images.js
@@ -16,7 +16,7 @@
 import {ByteEfficiencyAudit} from './byte-efficiency-audit.js';
 import {NetworkRequest} from '../../lib/network-request.js';
 import ImageRecords from '../../computed/image-records.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
@@ -100,7 +100,7 @@ class UsesResponsiveImages extends ByteEfficiencyAudit {
     const displayed = this.getDisplayedDimensions(image, ViewportDimensions);
     const usedPixels = displayed.width * displayed.height;
 
-    const url = URL.elideDataURI(image.src);
+    const url = UrlUtils.elideDataURI(image.src);
     const actualPixels = image.naturalWidth * image.naturalHeight;
     const wastedRatio = 1 - (usedPixels / actualPixels);
     const totalBytes = NetworkRequest.getResourceSizeOnNetwork(networkRecord);

--- a/core/audits/byte-efficiency/uses-text-compression.js
+++ b/core/audits/byte-efficiency/uses-text-compression.js
@@ -10,7 +10,7 @@
 
 
 import {ByteEfficiencyAudit} from './byte-efficiency-audit.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
@@ -68,7 +68,7 @@ class ResponsesAreCompressed extends ByteEfficiencyAudit {
       }
 
       // remove duplicates
-      const url = URL.elideDataURI(record.url);
+      const url = UrlUtils.elideDataURI(record.url);
       const isDuplicate = items.find(item => item.url === url &&
         item.totalBytes === record.resourceSize);
       if (isDuplicate) {

--- a/core/audits/dobetterweb/uses-http2.js
+++ b/core/audits/dobetterweb/uses-http2.js
@@ -14,7 +14,7 @@
 
 import {Audit} from '../audit.js';
 import ThirdParty from '../../lib/third-party-web.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import {ByteEfficiencyAudit} from '../byte-efficiency/byte-efficiency-audit.js';
 import Interactive from '../../computed/metrics/lantern-interactive.js';
 import {NetworkRequest} from '../../lib/network-request.js';
@@ -167,7 +167,7 @@ class UsesHTTP2Audit extends Audit {
     const groupedByOrigin = new Map();
     for (const record of networkRecords) {
       if (!UsesHTTP2Audit.isStaticAsset(record)) continue;
-      if (URL.isLikeLocalhost(record.parsedURL.host)) continue;
+      if (UrlUtils.isLikeLocalhost(record.parsedURL.host)) continue;
       const existing = groupedByOrigin.get(record.parsedURL.securityOrigin) || [];
       existing.push(record);
       groupedByOrigin.set(record.parsedURL.securityOrigin, existing);

--- a/core/audits/font-display.js
+++ b/core/audits/font-display.js
@@ -5,13 +5,14 @@
  */
 
 import {Audit} from './audit.js';
-import URL from '../lib/url-shim.js';
-const PASSING_FONT_DISPLAY_REGEX = /^(block|fallback|optional|swap)$/;
-const CSS_URL_REGEX = /url\((.*?)\)/;
-const CSS_URL_GLOBAL_REGEX = new RegExp(CSS_URL_REGEX, 'g');
+import UrlUtils from '../lib/url-utils.js';
 import * as i18n from '../lib/i18n/i18n.js';
 import {Sentry} from '../lib/sentry.js';
 import NetworkRecords from '../computed/network-records.js';
+
+const PASSING_FONT_DISPLAY_REGEX = /^(block|fallback|optional|swap)$/;
+const CSS_URL_REGEX = /url\((.*?)\)/;
+const CSS_URL_GLOBAL_REGEX = new RegExp(CSS_URL_REGEX, 'g');
 
 const UIStrings = {
   /** Title of a diagnostic audit that provides detail on if all the text on a webpage was visible while the page was loading its webfonts. This descriptive title is shown to users when the amount is acceptable and no user action is required. */
@@ -98,7 +99,7 @@ class FontDisplay extends Audit {
         // Convert the relative CSS URL to an absolute URL and add it to the target set.
         for (const relativeURL of relativeURLs) {
           try {
-            const relativeRoot = URL.isValid(stylesheet.header.sourceURL) ?
+            const relativeRoot = UrlUtils.isValid(stylesheet.header.sourceURL) ?
               stylesheet.header.sourceURL : artifacts.URL.finalUrl;
             const absoluteURL = new URL(relativeURL, relativeRoot);
             targetURLSet.add(absoluteURL.href);
@@ -121,7 +122,7 @@ class FontDisplay extends Audit {
     /** @type {Map<string, number>} */
     const warningCountByOrigin = new Map();
     for (const warningUrl of warningUrls) {
-      const origin = URL.getOrigin(warningUrl);
+      const origin = UrlUtils.getOrigin(warningUrl);
       if (!origin) continue;
 
       const count = warningCountByOrigin.get(origin) || 0;

--- a/core/audits/image-aspect-ratio.js
+++ b/core/audits/image-aspect-ratio.js
@@ -12,7 +12,7 @@
 
 
 import {Audit} from './audit.js';
-import URL from '../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 import * as i18n from '../lib/i18n/i18n.js';
 
 const UIStrings = {
@@ -54,7 +54,7 @@ class ImageAspectRatio extends Audit {
    * @return {{url: string, node: LH.Audit.Details.NodeValue, displayedAspectRatio: string, actualAspectRatio: string, doRatiosMatch: boolean}}
    */
   static computeAspectRatios(image) {
-    const url = URL.elideDataURI(image.src);
+    const url = UrlUtils.elideDataURI(image.src);
     const actualAspectRatio = image.naturalDimensions.width / image.naturalDimensions.height;
     const displayedAspectRatio = image.displayedWidth / image.displayedHeight;
 
@@ -89,7 +89,7 @@ class ImageAspectRatio extends Audit {
       // - filter all svgs as they have no natural dimensions to audit
       // - filter out images that have falsy naturalWidth or naturalHeight
       return !image.isCss &&
-        URL.guessMimeType(image.src) !== 'image/svg+xml' &&
+        UrlUtils.guessMimeType(image.src) !== 'image/svg+xml' &&
         image.naturalDimensions &&
         image.naturalDimensions.height > 5 &&
         image.naturalDimensions.width > 5 &&

--- a/core/audits/image-size-responsive.js
+++ b/core/audits/image-size-responsive.js
@@ -11,7 +11,7 @@
 
 
 import {Audit} from './audit.js';
-import URL from '../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 import * as i18n from '../lib/i18n/i18n.js';
 
 /** @typedef {LH.Artifacts.ImageElement & Required<Pick<LH.Artifacts.ImageElement, 'naturalDimensions'>>} ImageWithNaturalDimensions */
@@ -96,7 +96,7 @@ function isCandidate(image) {
   ) {
     return false;
   }
-  if (URL.guessMimeType(image.src) === 'image/svg+xml') {
+  if (UrlUtils.guessMimeType(image.src) === 'image/svg+xml') {
     return false;
   }
   if (image.isCss) {
@@ -147,7 +147,7 @@ function getResult(image, DPR) {
   const [expectedWidth, expectedHeight] =
       expectedImageSize(image.displayedWidth, image.displayedHeight, DPR);
   return {
-    url: URL.elideDataURI(image.src),
+    url: UrlUtils.elideDataURI(image.src),
     node: Audit.makeNodeItem(image.node),
     displayedSize: `${image.displayedWidth} x ${image.displayedHeight}`,
     actualSize: `${image.naturalDimensions.width} x ${image.naturalDimensions.height}`,

--- a/core/audits/is-on-https.js
+++ b/core/audits/is-on-https.js
@@ -5,7 +5,7 @@
  */
 
 import {Audit} from './audit.js';
-import URL from '../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 import {NetworkRequest} from '../lib/network-request.js';
 import NetworkRecords from '../computed/network-records.js';
 import * as i18n from '../lib/i18n/i18n.js';
@@ -75,7 +75,7 @@ class HTTPS extends Audit {
     return NetworkRecords.request(devtoolsLogs, context).then(networkRecords => {
       const insecureURLs = networkRecords
           .filter(record => !NetworkRequest.isSecureRequest(record))
-          .map(record => URL.elideDataURI(record.url));
+          .map(record => UrlUtils.elideDataURI(record.url));
 
       /** @type {Array<{url: string, resolution?: LH.IcuMessage|string}>}  */
       const items = Array.from(new Set(insecureURLs)).map(url => ({url, resolution: undefined}));

--- a/core/audits/network-requests.js
+++ b/core/audits/network-requests.js
@@ -5,7 +5,7 @@
  */
 
 import {Audit} from './audit.js';
-import URL from '../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 import NetworkRecords from '../computed/network-records.js';
 import MainResource from '../computed/main-resource.js';
 
@@ -62,7 +62,7 @@ class NetworkRequests extends Audit {
         undefined;
 
       return {
-        url: URL.elideDataURI(record.url),
+        url: UrlUtils.elideDataURI(record.url),
         protocol: record.protocol,
         startTime: timeToMs(record.startTime),
         endTime: timeToMs(record.endTime),

--- a/core/audits/seo/canonical.js
+++ b/core/audits/seo/canonical.js
@@ -5,7 +5,7 @@
  */
 
 import {Audit} from '../audit.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import MainResource from '../../computed/main-resource.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
@@ -93,7 +93,7 @@ class Canonical extends Audit {
         // Links that had an hrefRaw but didn't have a valid href were invalid, flag them
         if (!link.href) invalidCanonicalLink = link;
         // Links that had a valid href but didn't have a valid hrefRaw must have been relatively resolved, flag them
-        else if (!URL.isValid(link.hrefRaw)) relativeCanonicallink = link;
+        else if (!UrlUtils.isValid(link.hrefRaw)) relativeCanonicallink = link;
         // Otherwise, it was a valid canonical URL
         else uniqueCanonicalURLs.add(link.href);
       } else if (link.rel === 'alternate') {

--- a/core/audits/seo/is-crawlable.js
+++ b/core/audits/seo/is-crawlable.js
@@ -7,7 +7,6 @@
 import robotsParser from 'robots-parser';
 
 import {Audit} from '../audit.js';
-import URL from '../../lib/url-shim.js';
 import MainResource from '../../computed/main-resource.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 

--- a/core/audits/seo/link-text.js
+++ b/core/audits/seo/link-text.js
@@ -5,7 +5,7 @@
  */
 
 import {Audit} from '../audit.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const BLOCKLIST = new Set([
@@ -121,7 +121,7 @@ class LinkText extends Audit {
           href.startsWith('mailto:') ||
           // This line prevents the audit from flagging anchor links.
           // In this case it is better to use `finalUrl` than `mainDocumentUrl`.
-          URL.equalWithExcludedFragments(link.href, artifacts.URL.finalUrl)
+          UrlUtils.equalWithExcludedFragments(link.href, artifacts.URL.finalUrl)
         ) {
           return false;
         }

--- a/core/audits/seo/plugins.js
+++ b/core/audits/seo/plugins.js
@@ -5,7 +5,6 @@
  */
 
 import {Audit} from '../audit.js';
-import URL from '../../lib/url-shim.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const JAVA_APPLET_TYPE = 'application/x-java-applet';

--- a/core/audits/seo/robots-txt.js
+++ b/core/audits/seo/robots-txt.js
@@ -12,7 +12,6 @@
  */
 
 import {Audit} from '../audit.js';
-import URL from '../../lib/url-shim.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const HTTP_CLIENT_ERROR_CODE_LOW = 400;

--- a/core/audits/service-worker.js
+++ b/core/audits/service-worker.js
@@ -4,7 +4,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import URL from '../lib/url-shim.js';
 import {Audit} from './audit.js';
 import * as i18n from '../lib/i18n/i18n.js';
 

--- a/core/audits/unsized-images.js
+++ b/core/audits/unsized-images.js
@@ -11,7 +11,7 @@
 
 import {Audit} from './audit.js';
 import * as i18n from './../lib/i18n/i18n.js';
-import URL from './../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 
 const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on whether all images have explicit width and height. This descriptive title is shown to users when every image has explicit width and height */
@@ -105,9 +105,9 @@ class UnsizedImages extends Audit {
    * @return {boolean}
    */
   static isNonNetworkSvg(image) {
-    const isSvg = URL.guessMimeType(image.src) === 'image/svg+xml';
+    const isSvg = UrlUtils.guessMimeType(image.src) === 'image/svg+xml';
     const urlScheme = image.src.slice(0, image.src.indexOf(':'));
-    const isNonNetwork = URL.isNonNetworkProtocol(urlScheme);
+    const isNonNetwork = UrlUtils.isNonNetworkProtocol(urlScheme);
     return isSvg && isNonNetwork;
   }
 
@@ -139,7 +139,7 @@ class UnsizedImages extends Audit {
       if (isNotDisplayed) continue;
 
       unsizedImages.push({
-        url: URL.elideDataURI(image.src),
+        url: UrlUtils.elideDataURI(image.src),
         node: Audit.makeNodeItem(image.node),
       });
     }

--- a/core/audits/uses-rel-preconnect.js
+++ b/core/audits/uses-rel-preconnect.js
@@ -6,7 +6,7 @@
 
 import {Audit} from './audit.js';
 import {ByteEfficiencyAudit} from './byte-efficiency/byte-efficiency-audit.js';
-import URL from '../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 import * as i18n from '../lib/i18n/i18n.js';
 import NetworkRecords from '../computed/network-records.js';
 import MainResource from '../computed/main-resource.js';
@@ -162,7 +162,8 @@ class UsesRelPreconnectAudit extends Audit {
       });
 
     const preconnectLinks = artifacts.LinkElements.filter(el => el.rel === 'preconnect');
-    const preconnectOrigins = new Set(preconnectLinks.map(link => URL.getOrigin(link.href || '')));
+    const preconnectOrigins =
+      new Set(preconnectLinks.map(link => UrlUtils.getOrigin(link.href || '')));
 
     /** @type {Array<{url: string, wastedMs: number}>}*/
     let results = [];

--- a/core/audits/uses-rel-preload.js
+++ b/core/audits/uses-rel-preload.js
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import URL from '../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 import {NetworkRequest} from '../lib/network-request.js';
 import {Audit} from './audit.js';
 import {ByteEfficiencyAudit} from './byte-efficiency/byte-efficiency-audit.js';
@@ -128,7 +128,7 @@ class UsesRelPreloadAudit extends Audit {
     // It's not a request for the main frame, it wouldn't get reused even if you did preload it.
     if (request.frameId !== mainResource.frameId) return false;
     // We survived everything else, just check that it's a first party request.
-    return URL.rootDomainsMatch(request.url, mainResource.url);
+    return UrlUtils.rootDomainsMatch(request.url, mainResource.url);
   }
 
   /**

--- a/core/computed/image-records.js
+++ b/core/computed/image-records.js
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import URL from '../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 import {makeComputedArtifact} from './computed-artifact.js';
 
 class ImageRecords {
@@ -43,7 +43,7 @@ class ImageRecords {
       // Don't change the guessed mime type if no mime type was found.
       imageRecords.push({
         ...element,
-        mimeType: mimeType ? mimeType : URL.guessMimeType(element.src),
+        mimeType: mimeType ? mimeType : UrlUtils.guessMimeType(element.src),
       });
     }
 

--- a/core/computed/resource-summary.js
+++ b/core/computed/resource-summary.js
@@ -6,7 +6,6 @@
 
 import {makeComputedArtifact} from './computed-artifact.js';
 import NetworkRecords from './network-records.js';
-import URL from '../lib/url-shim.js';
 import {NetworkRequest} from '../lib/network-request.js';
 import {Budget} from '../config/budget.js';
 import {Util} from '../util.cjs';

--- a/core/fraggle-rock/gather/navigation-runner.js
+++ b/core/fraggle-rock/gather/navigation-runner.js
@@ -19,7 +19,7 @@ import {initializeConfig} from '../config/config.js';
 import {getBaseArtifacts, finalizeArtifacts} from './base-artifacts.js';
 import * as format from '../../../shared/localization/format.js';
 import {LighthouseError} from '../../lib/lh-error.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 import {getPageLoadError} from '../../lib/navigation-error.js';
 import Trace from '../../gather/gatherers/trace.js';
 import DevtoolsLog from '../../gather/gatherers/devtools-log.js';
@@ -319,7 +319,7 @@ async function navigationGather(requestor, options) {
   const artifacts = await Runner.gather(
     async () => {
       let {page} = options;
-      const normalizedRequestor = isCallback ? requestor : URL.normalizeUrl(requestor);
+      const normalizedRequestor = isCallback ? requestor : UrlUtils.normalizeUrl(requestor);
 
       // For navigation mode, we shouldn't connect to a browser in audit mode,
       // therefore we connect to the browser in the gatherFn callback.

--- a/core/gather/driver/navigation.js
+++ b/core/gather/driver/navigation.js
@@ -10,7 +10,7 @@ import {NetworkMonitor} from './network-monitor.js';
 import {waitForFullyLoaded, waitForFrameNavigated, waitForUserToContinue} from './wait-for-condition.js'; // eslint-disable-line max-len
 import * as constants from '../../config/constants.js';
 import * as i18n from '../../lib/i18n/i18n.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 
 const UIStrings = {
   /**
@@ -130,7 +130,7 @@ async function gotoURL(driver, requestor, options) {
 
   let requestedUrl = navigationUrls.requestedUrl;
   if (typeof requestor === 'string') {
-    if (requestedUrl && !URL.equalWithExcludedFragments(requestor, requestedUrl)) {
+    if (requestedUrl && !UrlUtils.equalWithExcludedFragments(requestor, requestedUrl)) {
       log.error(
         'Navigation',
         `Provided URL (${requestor}) did not match initial navigation URL (${requestedUrl})`
@@ -169,7 +169,7 @@ function getNavigationWarnings(navigation) {
 
   if (navigation.timedOut) warnings.push(str_(UIStrings.warningTimeout));
 
-  if (!URL.equalWithExcludedFragments(requestedUrl, mainDocumentUrl)) {
+  if (!UrlUtils.equalWithExcludedFragments(requestedUrl, mainDocumentUrl)) {
     warnings.push(str_(UIStrings.warningRedirected, {
       requested: requestedUrl,
       final: mainDocumentUrl,

--- a/core/gather/driver/network-monitor.js
+++ b/core/gather/driver/network-monitor.js
@@ -15,7 +15,7 @@ import log from 'lighthouse-logger';
 
 import {NetworkRecorder} from '../../lib/network-recorder.js';
 import {NetworkRequest} from '../../lib/network-request.js';
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 
 /** @typedef {import('../../lib/network-recorder.js').NetworkRecorderEventMap} NetworkRecorderEventMap */
 /** @typedef {'network-2-idle'|'network-critical-idle'|'networkidle'|'networkbusy'|'network-critical-busy'|'network-2-busy'} NetworkMonitorEvent_ */
@@ -214,7 +214,7 @@ class NetworkMonitor extends NetworkMonitorEventEmitter {
     /** @type {Array<{time: number, isStart: boolean}>} */
     let timeBoundaries = [];
     requests.forEach(request => {
-      if (URL.isNonNetworkProtocol(request.protocol)) return;
+      if (UrlUtils.isNonNetworkProtocol(request.protocol)) return;
       if (request.protocol === 'ws' || request.protocol === 'wss') return;
 
       // convert the network timestamp to ms

--- a/core/gather/gather-runner.js
+++ b/core/gather/gather-runner.js
@@ -21,7 +21,7 @@ import InstallabilityErrors from './gatherers/installability-errors.js';
 import NetworkUserAgent from './gatherers/network-user-agent.js';
 import Stacks from './gatherers/stacks.js';
 import {finalizeArtifacts} from '../fraggle-rock/gather/base-artifacts.js';
-import URLShim from '../lib/url-shim.js';
+import UrlUtils from '../lib/url-utils.js';
 
 /** @typedef {import('../gather/driver.js').Driver} Driver */
 /** @typedef {import('../lib/arbitrary-equality-map.js').ArbitraryEqualityMap} ArbitraryEqualityMap */
@@ -494,7 +494,7 @@ class GatherRunner {
 
       // Hack for running benchmarkIndex extra times.
       // Add a `bidx=20` query param, eg: https://www.example.com/?bidx=50
-      const parsedUrl = URLShim.isValid(options.requestedUrl) && new URL(options.requestedUrl);
+      const parsedUrl = UrlUtils.isValid(options.requestedUrl) && new URL(options.requestedUrl);
       if (options.settings.channel === 'lr' && parsedUrl && parsedUrl.searchParams.has('bidx')) {
         const bidxRunCount = parsedUrl.searchParams.get('bidx') || 0;
         // Add the first bidx into the new set

--- a/core/gather/gatherers/dobetterweb/optimized-images.js
+++ b/core/gather/gatherers/dobetterweb/optimized-images.js
@@ -13,7 +13,7 @@
 import log from 'lighthouse-logger';
 
 import FRGatherer from '../../../fraggle-rock/gather/base-gatherer.js';
-import URL from '../../../lib/url-shim.js';
+import UrlUtils from '../../../lib/url-utils.js';
 import {NetworkRequest} from '../../../lib/network-request.js';
 import {Sentry} from '../../../lib/sentry.js';
 import NetworkRecords from '../../../computed/network-records.js';
@@ -139,7 +139,7 @@ class OptimizedImages extends FRGatherer {
         // want to tank the entire run due to a single image.
         Sentry.captureException(err, {
           tags: {gatherer: 'OptimizedImages'},
-          extra: {imageUrl: URL.elideDataURI(record.url)},
+          extra: {imageUrl: UrlUtils.elideDataURI(record.url)},
           level: 'warning',
         });
 

--- a/core/gather/gatherers/dobetterweb/response-compression.js
+++ b/core/gather/gatherers/dobetterweb/response-compression.js
@@ -14,7 +14,7 @@ import {Buffer} from 'buffer';
 import {gzip} from 'zlib';
 
 import FRGatherer from '../../../fraggle-rock/gather/base-gatherer.js';
-import URL from '../../../lib/url-shim.js';
+import UrlUtils from '../../../lib/url-utils.js';
 import {Sentry} from '../../../lib/sentry.js';
 import {NetworkRequest} from '../../../lib/network-request.js';
 import DevtoolsLog from '../devtools-log.js';
@@ -122,7 +122,7 @@ class ResponseCompression extends FRGatherer {
       }).catch(err => {
         Sentry.captureException(err, {
           tags: {gatherer: 'ResponseCompression'},
-          extra: {url: URL.elideDataURI(record.url)},
+          extra: {url: UrlUtils.elideDataURI(record.url)},
           level: 'warning',
         });
 

--- a/core/gather/gatherers/link-elements.js
+++ b/core/gather/gatherers/link-elements.js
@@ -7,7 +7,6 @@
 import LinkHeader from 'http-link-header';
 
 import FRGatherer from '../../fraggle-rock/gather/base-gatherer.js';
-import URL from '../../lib/url-shim.js';
 import {pageFunctions} from '../../lib/page-functions.js';
 import DevtoolsLog from './devtools-log.js';
 import MainResource from '../../computed/main-resource.js';

--- a/core/gather/gatherers/source-maps.js
+++ b/core/gather/gatherers/source-maps.js
@@ -5,7 +5,6 @@
  */
 
 import FRGatherer from '../../fraggle-rock/gather/base-gatherer.js';
-import URL from '../../lib/url-shim.js';
 
 /**
  * @fileoverview Gets JavaScript source maps.

--- a/core/index.js
+++ b/core/index.js
@@ -9,7 +9,7 @@ import log from 'lighthouse-logger';
 import {Runner} from './runner.js';
 import {CriConnection} from './gather/connections/cri.js';
 import {Config} from './config/config.js';
-import URL from './lib/url-shim.js';
+import UrlUtils from './lib/url-utils.js';
 import * as fraggleRock from './fraggle-rock/api.js';
 import {Driver} from './gather/driver.js';
 import {initializeConfig} from './fraggle-rock/config/config.js';
@@ -67,7 +67,7 @@ async function legacyNavigation(url, flags = {}, configJSON, userConnection) {
 
   // kick off a lighthouse run
   const artifacts = await Runner.gather(() => {
-    const requestedUrl = URL.normalizeUrl(url);
+    const requestedUrl = UrlUtils.normalizeUrl(url);
     return Runner._gatherArtifactsFromBrowser(requestedUrl, options, connection);
   }, options);
   return Runner.audit(artifacts, options);

--- a/core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/core/lib/dependency-graph/simulator/network-analyzer.js
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import URL from '../../url-shim.js';
+import UrlUtils from '../../url-utils.js';
 
 const INITIAL_CWD = 14 * 1024;
 
@@ -440,7 +440,7 @@ class NetworkAnalyzer {
     // equalWithExcludedFragments is expensive, so check that the resourceUrl starts with the request url first
     return records.find(request =>
       resourceUrl.startsWith(request.url) &&
-      URL.equalWithExcludedFragments(request.url, resourceUrl)
+      UrlUtils.equalWithExcludedFragments(request.url, resourceUrl)
     );
   }
 

--- a/core/lib/icons.js
+++ b/core/lib/icons.js
@@ -4,8 +4,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import URL from './url-shim.js';
-
 /**
  * @param {NonNullable<LH.Artifacts.Manifest['value']>} manifest
  * @return {boolean} Does the manifest have any icons?

--- a/core/lib/manifest-parser.js
+++ b/core/lib/manifest-parser.js
@@ -6,8 +6,6 @@
 
 import cssParsers from 'cssstyle/lib/parsers.js';
 
-import URL from './url-shim.js';
-
 const ALLOWED_DISPLAY_VALUES = [
   'fullscreen',
   'standalone',

--- a/core/lib/network-request.js
+++ b/core/lib/network-request.js
@@ -52,7 +52,7 @@
       Trace: ResourceFinish.ts
  */
 
-import URL from './url-shim.js';
+import UrlUtils from './url-utils.js';
 
 // Lightrider X-Header names for timing information.
 // See: _updateTransferSizeForLightrider and _updateTimingsForLightrider.
@@ -215,7 +215,7 @@ class NetworkRequest {
       host: url.hostname,
       securityOrigin: url.origin,
     };
-    this.isSecure = URL.isSecureScheme(this.parsedURL.scheme);
+    this.isSecure = UrlUtils.isSecureScheme(this.parsedURL.scheme);
 
     this.startTime = data.timestamp;
 
@@ -522,9 +522,9 @@ class NetworkRequest {
    */
   static isNonNetworkRequest(record) {
     // The 'protocol' field in devtools a string more like a `scheme`
-    return URL.isNonNetworkProtocol(record.protocol) ||
+    return UrlUtils.isNonNetworkProtocol(record.protocol) ||
       // But `protocol` can fail to be populated if the request fails, so fallback to scheme.
-      URL.isNonNetworkProtocol(record.parsedURL.scheme);
+      UrlUtils.isNonNetworkProtocol(record.parsedURL.scheme);
   }
 
   /**
@@ -535,9 +535,9 @@ class NetworkRequest {
    * @return {boolean}
    */
   static isSecureRequest(record) {
-    return URL.isSecureScheme(record.parsedURL.scheme) ||
-        URL.isSecureScheme(record.protocol) ||
-        URL.isLikeLocalhost(record.parsedURL.host) ||
+    return UrlUtils.isSecureScheme(record.parsedURL.scheme) ||
+        UrlUtils.isSecureScheme(record.protocol) ||
+        UrlUtils.isLikeLocalhost(record.parsedURL.host) ||
         NetworkRequest.isHstsRequest(record);
   }
 

--- a/core/lib/sd-validation/json-expander.js
+++ b/core/lib/sd-validation/json-expander.js
@@ -8,7 +8,6 @@ import fs from 'fs';
 
 import jsonld from 'jsonld';
 
-import URL from '../url-shim.js';
 import {LH_ROOT} from '../../../root.js';
 
 const SCHEMA_ORG_HOST = 'schema.org';

--- a/core/lib/url-utils.js
+++ b/core/lib/url-utils.js
@@ -39,7 +39,7 @@ function rewriteChromeInternalUrl(url) {
   return url.replace(/^chrome:\/\/chrome\//, 'chrome://');
 }
 
-class URLShim {
+class UrlUtils {
   /**
    * @param {string} url
    * @return {boolean}
@@ -259,11 +259,9 @@ class URLShim {
   }
 }
 
-URLShim.URL = URL;
-
-URLShim.INVALID_URL_DEBUG_STRING =
+UrlUtils.INVALID_URL_DEBUG_STRING =
     'Lighthouse was unable to determine the URL of some script executions. ' +
     'It\'s possible a Chrome extension or other eval\'d code is the source.';
 
 // TODO(esmodules): don't use default export
-export default URLShim;
+export default UrlUtils;

--- a/core/lib/url-utils.js
+++ b/core/lib/url-utils.js
@@ -4,12 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-/**
- * URL shim so we keep our code DRY
- */
-
 import {Util} from '../util.cjs';
-import {LighthouseError} from '../lib/lh-error.js';
+import {LighthouseError} from './lh-error.js';
 
 /** @typedef {import('./network-request.js').NetworkRequest} NetworkRequest */
 
@@ -43,8 +39,7 @@ function rewriteChromeInternalUrl(url) {
   return url.replace(/^chrome:\/\/chrome\//, 'chrome://');
 }
 
-// URL is global as of node 10. https://nodejs.org/api/globals.html#globals_url
-class URLShim extends URL {
+class URLShim {
   /**
    * @param {string} url
    * @return {boolean}

--- a/core/lib/url-utils.js
+++ b/core/lib/url-utils.js
@@ -263,5 +263,4 @@ UrlUtils.INVALID_URL_DEBUG_STRING =
     'Lighthouse was unable to determine the URL of some script executions. ' +
     'It\'s possible a Chrome extension or other eval\'d code is the source.';
 
-// TODO(esmodules): don't use default export
 export default UrlUtils;

--- a/core/scripts/gcp-collection/README.md
+++ b/core/scripts/gcp-collection/README.md
@@ -7,7 +7,7 @@ By default, the instance will be called `lighthouse-collection-$gcloudusername-i
    1. (Prerequiste) Install GCloud SDK and authenticate locally, Run `brew cask install google-cloud-sdk && gcloud auth login`
     1. (Prerequiste Googlers only) Ensure you're on the corp VPN or you won't be able to SSH into a Google-owned instance.
    1. (Optional) Run `export TARGET_GIT_REF=<a lighthouse git ref that has been pushed> ` if wanting to run on anything but master.
-   1. (Optional) Run `export TARGET_RUNS=<a number> ` if needing more than 1 run per URL.
+   1. (Optional) Run `export TARGET_RUNS=<a number> ` if needing more than 1 run per UrlUtils.
    1. (Optional) Run `export LIGHTHOUSE_FLAGS=...` to configure Lighthouse CLI.
    1. (Optional) Run `export LIGHTHOUSE_COLLECTION_GCLOUD_PROJECT=<project name> ` to set your GCloud project.
    1. Run `bash core/scripts/gcp-collection/fleet-create.sh path/to/your/url/list.txt` from the repo root.

--- a/core/scripts/gcp-collection/README.md
+++ b/core/scripts/gcp-collection/README.md
@@ -7,7 +7,7 @@ By default, the instance will be called `lighthouse-collection-$gcloudusername-i
    1. (Prerequiste) Install GCloud SDK and authenticate locally, Run `brew cask install google-cloud-sdk && gcloud auth login`
     1. (Prerequiste Googlers only) Ensure you're on the corp VPN or you won't be able to SSH into a Google-owned instance.
    1. (Optional) Run `export TARGET_GIT_REF=<a lighthouse git ref that has been pushed> ` if wanting to run on anything but master.
-   1. (Optional) Run `export TARGET_RUNS=<a number> ` if needing more than 1 run per UrlUtils.
+   1. (Optional) Run `export TARGET_RUNS=<a number> ` if needing more than 1 run per URL.
    1. (Optional) Run `export LIGHTHOUSE_FLAGS=...` to configure Lighthouse CLI.
    1. (Optional) Run `export LIGHTHOUSE_COLLECTION_GCLOUD_PROJECT=<project name> ` to set your GCloud project.
    1. Run `bash core/scripts/gcp-collection/fleet-create.sh path/to/your/url/list.txt` from the repo root.

--- a/core/scripts/gcp-collection/gcp-run-on-url.sh
+++ b/core/scripts/gcp-collection/gcp-run-on-url.sh
@@ -27,7 +27,7 @@ EXTRA_LIGHTHOUSE_FLAGS=${BASE_LIGHTHOUSE_FLAGS:-}
 for (( i = 0; i < $NUMBER_OF_RUNS; i++ ))
 do
   FOLDER_NAME="$SAFE_URL/$i"
-  echo "Run $i on $URL..."
+  echo "Run $i on $UrlUtils..."
   if [[ -f "$FOLDER_NAME" ]]; then
     echo "$FOLDER_NAME already exists, skipping"
     continue

--- a/core/scripts/gcp-collection/gcp-run-on-url.sh
+++ b/core/scripts/gcp-collection/gcp-run-on-url.sh
@@ -27,7 +27,7 @@ EXTRA_LIGHTHOUSE_FLAGS=${BASE_LIGHTHOUSE_FLAGS:-}
 for (( i = 0; i < $NUMBER_OF_RUNS; i++ ))
 do
   FOLDER_NAME="$SAFE_URL/$i"
-  echo "Run $i on $UrlUtils..."
+  echo "Run $i on $URL..."
   if [[ -f "$FOLDER_NAME" ]]; then
     echo "$FOLDER_NAME already exists, skipping"
     continue

--- a/core/test/audits/service-worker-test.js
+++ b/core/test/audits/service-worker-test.js
@@ -7,7 +7,6 @@
 import {strict as assert} from 'assert';
 
 import ServiceWorker from '../../audits/service-worker.js';
-import URL from '../../lib/url-shim.js';
 import {parseManifest} from '../../lib/manifest-parser.js';
 
 function getBaseDirectory(urlStr) {

--- a/core/test/lib/url-utils-test.js
+++ b/core/test/lib/url-utils-test.js
@@ -6,12 +6,12 @@
 
 import {strict as assert} from 'assert';
 
-import URL from '../../lib/url-shim.js';
+import UrlUtils from '../../lib/url-utils.js';
 
 const superLongName =
     'https://example.com/thisIsASuperLongURLThatWillTriggerFilenameTruncationWhichWeWantToTest.js';
 
-describe('URL Shim', () => {
+describe('UrlUtils', () => {
   it('handles URLs beginning with multiple digits', () => {
     // from https://github.com/GoogleChrome/lighthouse/issues/1186
     const url = 'http://5321212.fls.doubleclick.net/activityi;src=5321212;type=unvsn_un;cat=unvsn_uv;ord=7762287885264.98?';
@@ -25,72 +25,72 @@ describe('URL Shim', () => {
   });
 
   it('safely identifies valid URLs', () => {
-    assert.ok(URL.isValid('https://5321212.fls.net/page?query=string#hash'));
-    assert.ok(URL.isValid('https://localhost:8080/page?query=string#hash'));
-    assert.ok(URL.isValid('https://google.co.uk/deep/page?query=string#hash'));
+    assert.ok(UrlUtils.isValid('https://5321212.fls.net/page?query=string#hash'));
+    assert.ok(UrlUtils.isValid('https://localhost:8080/page?query=string#hash'));
+    assert.ok(UrlUtils.isValid('https://google.co.uk/deep/page?query=string#hash'));
   });
 
   it('safely identifies invalid URLs', () => {
-    assert.equal(URL.isValid(''), false);
-    assert.equal(URL.isValid('eval(<context>):45:16'), false);
+    assert.equal(UrlUtils.isValid(''), false);
+    assert.equal(UrlUtils.isValid('eval(<context>):45:16'), false);
   });
 
   it('safely identifies allowed URL protocols', () => {
-    assert.ok(URL.isProtocolAllowed('http://google.com/'));
-    assert.ok(URL.isProtocolAllowed('https://google.com/'));
-    assert.ok(URL.isProtocolAllowed('chrome://version'));
-    assert.ok(URL.isProtocolAllowed('chrome-extension://blipmdconlkpinefehnmjammfjpmpbjk/popup.html'));
+    assert.ok(UrlUtils.isProtocolAllowed('http://google.com/'));
+    assert.ok(UrlUtils.isProtocolAllowed('https://google.com/'));
+    assert.ok(UrlUtils.isProtocolAllowed('chrome://version'));
+    assert.ok(UrlUtils.isProtocolAllowed('chrome-extension://blipmdconlkpinefehnmjammfjpmpbjk/popup.html'));
   });
 
   it('safely identifies disallowed URL protocols', () => {
-    assert.equal(URL.isProtocolAllowed('file:///i/am/a/fake/file.html'), false);
-    assert.equal(URL.isProtocolAllowed('ftp://user:password@private.ftp.example.com/index.html'), false);
-    assert.equal(URL.isProtocolAllowed('gopher://underground:9090/path'), false);
+    assert.equal(UrlUtils.isProtocolAllowed('file:///i/am/a/fake/file.html'), false);
+    assert.equal(UrlUtils.isProtocolAllowed('ftp://user:password@private.ftp.example.com/index.html'), false);
+    assert.equal(UrlUtils.isProtocolAllowed('gopher://underground:9090/path'), false);
   });
 
   it('safely identifies same hosts', () => {
     const urlA = 'https://5321212.fls.net/page?query=string#hash';
     const urlB = 'http://5321212.fls.net/deeply/nested/page';
-    assert.ok(URL.hostsMatch(urlA, urlB));
+    assert.ok(UrlUtils.hostsMatch(urlA, urlB));
   });
 
   it('safely identifies different hosts', () => {
     const urlA = 'https://google.com/page?query=string#hash';
     const urlB = 'http://google.co.uk/deeply/nested/page';
-    assert.equal(URL.hostsMatch(urlA, urlB), false);
+    assert.equal(UrlUtils.hostsMatch(urlA, urlB), false);
   });
 
   it('safely identifies invalid hosts', () => {
     const urlA = 'https://google.com/page?query=string#hash';
     const urlB = 'anonymous:45';
-    assert.equal(URL.hostsMatch(urlA, urlB), false);
+    assert.equal(UrlUtils.hostsMatch(urlA, urlB), false);
   });
 
   it('safely identifies same origins', () => {
     const urlA = 'https://5321212.fls.net/page?query=string#hash';
     const urlB = 'https://5321212.fls.net/deeply/nested/page';
-    assert.ok(URL.originsMatch(urlA, urlB));
+    assert.ok(UrlUtils.originsMatch(urlA, urlB));
   });
 
   it('safely identifies different origins', () => {
     const urlA = 'https://5321212.fls.net/page?query=string#hash';
     const urlB = 'http://5321212.fls.net/deeply/nested/page';
-    assert.equal(URL.originsMatch(urlA, urlB), false);
+    assert.equal(UrlUtils.originsMatch(urlA, urlB), false);
   });
 
   it('safely identifies different invalid origins', () => {
     const urlA = 'https://google.com/page?query=string#hash';
     const urlB = 'anonymous:90';
-    assert.equal(URL.originsMatch(urlA, urlB), false);
+    assert.equal(UrlUtils.originsMatch(urlA, urlB), false);
   });
 
   it('safely gets valid origins', () => {
     const urlA = 'https://google.com/page?query=string#hash';
     const urlB = 'https://5321212.fls.net/page?query=string#hash';
     const urlC = 'http://example.com/deeply/nested/page';
-    assert.equal(URL.getOrigin(urlA), 'https://google.com');
-    assert.equal(URL.getOrigin(urlB), 'https://5321212.fls.net');
-    assert.equal(URL.getOrigin(urlC), 'http://example.com');
+    assert.equal(UrlUtils.getOrigin(urlA), 'https://google.com');
+    assert.equal(UrlUtils.getOrigin(urlB), 'https://5321212.fls.net');
+    assert.equal(UrlUtils.getOrigin(urlC), 'http://example.com');
   });
 
   it('safely gets URLs with no origin', () => {
@@ -98,10 +98,10 @@ describe('URL Shim', () => {
     const urlB = 'anonymous:90';
     const urlC = '!!garbage';
     const urlD = 'file:///opt/lighthouse/index.js';
-    assert.equal(URL.getOrigin(urlA), null);
-    assert.equal(URL.getOrigin(urlB), null);
-    assert.equal(URL.getOrigin(urlC), null);
-    assert.equal(URL.getOrigin(urlD), null);
+    assert.equal(UrlUtils.getOrigin(urlA), null);
+    assert.equal(UrlUtils.getOrigin(urlB), null);
+    assert.equal(UrlUtils.getOrigin(urlC), null);
+    assert.equal(UrlUtils.getOrigin(urlD), null);
   });
 
   describe('rootDomainsMatch', () => {
@@ -111,10 +111,10 @@ describe('URL Shim', () => {
       const urlC = 'http://sub.example.com/js/test.js';
       const urlD = 'http://sub.otherdomain.com/js/test.js';
 
-      assert.ok(URL.rootDomainsMatch(urlA, urlB));
-      assert.ok(URL.rootDomainsMatch(urlA, urlC));
-      assert.ok(!URL.rootDomainsMatch(urlA, urlD));
-      assert.ok(!URL.rootDomainsMatch(urlB, urlD));
+      assert.ok(UrlUtils.rootDomainsMatch(urlA, urlB));
+      assert.ok(UrlUtils.rootDomainsMatch(urlA, urlC));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlA, urlD));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlB, urlD));
     });
 
     it(`doesn't break on urls without a valid host`, () => {
@@ -124,13 +124,13 @@ describe('URL Shim', () => {
       const urlD = '!!garbage';
       const urlE = 'file:///opt/lighthouse/index.js';
 
-      assert.ok(!URL.rootDomainsMatch(urlA, urlB));
-      assert.ok(!URL.rootDomainsMatch(urlA, urlC));
-      assert.ok(!URL.rootDomainsMatch(urlA, urlD));
-      assert.ok(!URL.rootDomainsMatch(urlA, urlE));
-      assert.ok(!URL.rootDomainsMatch(urlB, urlC));
-      assert.ok(!URL.rootDomainsMatch(urlB, urlD));
-      assert.ok(!URL.rootDomainsMatch(urlB, urlE));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlA, urlB));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlA, urlC));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlA, urlD));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlA, urlE));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlB, urlC));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlB, urlD));
+      assert.ok(!UrlUtils.rootDomainsMatch(urlB, urlE));
     });
 
     it(`matches tld plus domains`, () => {
@@ -143,71 +143,71 @@ describe('URL Shim', () => {
       const privAtA = 'http://examplepriv.at/js/test.js';
       const privAtB = 'http://sub.examplepriv.at/js/test.js';
 
-      assert.ok(URL.rootDomainsMatch(coUkA, coUkB));
-      assert.ok(URL.rootDomainsMatch(testUkA, testUkB));
-      assert.ok(URL.rootDomainsMatch(ltdBrA, ltdBrB));
-      assert.ok(URL.rootDomainsMatch(privAtA, privAtB));
+      assert.ok(UrlUtils.rootDomainsMatch(coUkA, coUkB));
+      assert.ok(UrlUtils.rootDomainsMatch(testUkA, testUkB));
+      assert.ok(UrlUtils.rootDomainsMatch(ltdBrA, ltdBrB));
+      assert.ok(UrlUtils.rootDomainsMatch(privAtA, privAtB));
     });
   });
 
   describe('getURLDisplayName', () => {
     it('respects numPathParts option', () => {
       const url = 'http://example.com/a/deep/nested/file.css';
-      const result = URL.getURLDisplayName(url, {numPathParts: 3});
+      const result = UrlUtils.getURLDisplayName(url, {numPathParts: 3});
       assert.equal(result, '\u2026deep/nested/file.css');
     });
 
     it('respects preserveQuery option', () => {
       const url = 'http://example.com/file.css?aQueryString=true';
-      const result = URL.getURLDisplayName(url, {preserveQuery: false});
+      const result = UrlUtils.getURLDisplayName(url, {preserveQuery: false});
       assert.equal(result, '/file.css');
     });
 
     it('respects preserveHost option', () => {
       const url = 'http://example.com/file.css';
-      const result = URL.getURLDisplayName(url, {preserveHost: true});
+      const result = UrlUtils.getURLDisplayName(url, {preserveHost: true});
       assert.equal(result, 'example.com/file.css');
     });
 
     it('Elides hashes', () => {
       const url = 'http://example.com/file-f303dec6eec305a4fab8025577db3c2feb418148ac75ba378281399fb1ba670b.css';
-      const result = URL.getURLDisplayName(url);
+      const result = UrlUtils.getURLDisplayName(url);
       assert.equal(result, '/file-f303dec\u2026.css');
     });
 
     it('Elides hashes in the middle', () => {
       const url = 'http://example.com/file-f303dec6eec305a4fab80378281399fb1ba670b-somethingmore.css';
-      const result = URL.getURLDisplayName(url);
+      const result = UrlUtils.getURLDisplayName(url);
       assert.equal(result, '/file-f303dec\u2026-somethingmore.css');
     });
 
     it('Elides google-fonts hashes', () => {
       const url = 'https://fonts.gstatic.com/s/droidsans/v8/s-BiyweUPV0v-yRb-cjciAzyDMXhdD8sAj6OAJTFsBI.woff2';
-      const result = URL.getURLDisplayName(url);
+      const result = UrlUtils.getURLDisplayName(url);
       assert.equal(result, '\u2026v8/s-BiyweUP\u2026.woff2');
     });
 
     it('Elides long number sequences', () => {
       const url = 'http://cdn.cnn.com/cnnnext/dam/assets/150507173438-11-week-in-photos-0508-large-169.jpg';
-      const result = URL.getURLDisplayName(url);
+      const result = UrlUtils.getURLDisplayName(url);
       assert.equal(result, '\u2026assets/150\u2026-11-week-in-photos-0508-large-169.jpg');
     });
 
 
     it('Elides query strings when can first parameter', () => {
       const url = 'http://example.com/file.css?aQueryString=true&other_long_query_stuff=false&some_other_super_long_query';
-      const result = URL.getURLDisplayName(url);
+      const result = UrlUtils.getURLDisplayName(url);
       assert.equal(result, '/file.css?aQueryString=\u2026');
     });
 
     it('Elides query strings when cannot preserve first parameter', () => {
       const url = 'http://example.com/file.css?superDuperNoGoodVeryLongExtraSpecialOnlyTheBestEnourmousQueryString=true';
-      const result = URL.getURLDisplayName(url);
+      const result = UrlUtils.getURLDisplayName(url);
       assert.equal(result, '/file.css?\u2026');
     });
 
     it('Elides long names', () => {
-      const result = URL.getURLDisplayName(superLongName);
+      const result = UrlUtils.getURLDisplayName(superLongName);
       const expected = '/thisIsASuperLongURLThatWillTriggerFilenameTruncationWhichWe\u2026.js';
       assert.equal(result, expected);
     });
@@ -215,20 +215,20 @@ describe('URL Shim', () => {
     it('Elides long names with hash', () => {
       const url = superLongName.slice(0, -3) +
           '-f303dec6eec305a4fab8025577db3c2feb418148ac75ba378281399fb1ba670b.css';
-      const result = URL.getURLDisplayName(url);
+      const result = UrlUtils.getURLDisplayName(url);
       const expected = '/thisIsASu\u2026.css';
       assert.equal(result, expected);
     });
 
     it('Elides path parts properly', () => {
-      assert.equal(URL.getURLDisplayName('http://example.com/file.css'), '/file.css');
-      assert.equal(URL.getURLDisplayName('http://t.co//file.css'), '//file.css');
-      assert.equal(URL.getURLDisplayName('http://t.co/a/file.css'), '/a/file.css');
-      assert.equal(URL.getURLDisplayName('http://t.co/a/b/file.css'), '\u2026b/file.css');
+      assert.equal(UrlUtils.getURLDisplayName('http://example.com/file.css'), '/file.css');
+      assert.equal(UrlUtils.getURLDisplayName('http://t.co//file.css'), '//file.css');
+      assert.equal(UrlUtils.getURLDisplayName('http://t.co/a/file.css'), '/a/file.css');
+      assert.equal(UrlUtils.getURLDisplayName('http://t.co/a/b/file.css'), '\u2026b/file.css');
     });
 
     it('Elides path parts properly when used with preserveHost', () => {
-      const getResult = path => URL.getURLDisplayName(`http://g.co${path}`, {preserveHost: true});
+      const getResult = path => UrlUtils.getURLDisplayName(`http://g.co${path}`, {preserveHost: true});
       assert.equal(getResult('/file.css'), 'g.co/file.css');
       assert.equal(getResult('/img/logo.jpg'), 'g.co/img/logo.jpg');
       assert.equal(getResult('//logo.jpg'), 'g.co//logo.jpg');
@@ -243,7 +243,7 @@ describe('URL Shim', () => {
         longDataURI += 'abcde';
       }
 
-      const elided = URL.elideDataURI(`data:image/jpeg;base64,${longDataURI}`);
+      const elided = UrlUtils.elideDataURI(`data:image/jpeg;base64,${longDataURI}`);
       assert.ok(elided.length < longDataURI.length, 'did not shorten string');
     });
 
@@ -256,7 +256,7 @@ describe('URL Shim', () => {
         'blob://something',
       ];
 
-      urls.forEach(url => assert.equal(URL.elideDataURI(url), url));
+      urls.forEach(url => assert.equal(UrlUtils.elideDataURI(url), url));
     });
   });
 
@@ -267,7 +267,7 @@ describe('URL Shim', () => {
         ['https://example.com/', 'https://example.com/#/login?_k=dt915a'],
         ['https://example.com/', 'https://example.com#anchor'],
       ];
-      equalPairs.forEach(pair => assert.ok(URL.equalWithExcludedFragments(...pair)));
+      equalPairs.forEach(pair => assert.ok(UrlUtils.equalWithExcludedFragments(...pair)));
     });
 
     it('correctly checks inequality of URLs regardless of fragment', () => {
@@ -277,7 +277,7 @@ describe('URL Shim', () => {
         ['https://example.com/#/login?_k=dt915a', 'https://example.com/index.html#/login?_k=dt915a'],
         ['https://example.com#anchor', 'https://example.com?t=1#anchor'],
       ];
-      unequalPairs.forEach(pair => assert.ok(!URL.equalWithExcludedFragments(...pair)));
+      unequalPairs.forEach(pair => assert.ok(!UrlUtils.equalWithExcludedFragments(...pair)));
     });
 
     // Bug #1776
@@ -286,7 +286,7 @@ describe('URL Shim', () => {
         'chrome://settings/',
         'chrome://chrome/settings/',
       ];
-      assert.ok(URL.equalWithExcludedFragments(...pair));
+      assert.ok(UrlUtils.equalWithExcludedFragments(...pair));
     });
 
     // https://github.com/GoogleChrome/lighthouse/pull/3941#discussion_r154026009
@@ -295,103 +295,103 @@ describe('URL Shim', () => {
         'chrome://version/',
         'chrome://version',
       ];
-      assert.ok(URL.equalWithExcludedFragments(...pair));
+      assert.ok(UrlUtils.equalWithExcludedFragments(...pair));
     });
 
     it('returns false for invalid URLs', () => {
-      assert.ok(!URL.equalWithExcludedFragments('utter nonsense', 'http://example.com'));
+      assert.ok(!UrlUtils.equalWithExcludedFragments('utter nonsense', 'http://example.com'));
     });
   });
 
   it('isLikeLocalhost', () => {
-    assert.ok(URL.isLikeLocalhost(new URL('http://localhost/').hostname));
-    assert.ok(URL.isLikeLocalhost(new URL('http://localhost:10200/').hostname));
-    assert.ok(URL.isLikeLocalhost(new URL('http://127.0.0.1/page.html').hostname));
-    assert.ok(URL.isLikeLocalhost(new URL('https://localhost/').hostname));
-    assert.ok(URL.isLikeLocalhost(new URL('https://dev.localhost/').hostname));
+    assert.ok(UrlUtils.isLikeLocalhost(new URL('http://localhost/').hostname));
+    assert.ok(UrlUtils.isLikeLocalhost(new URL('http://localhost:10200/').hostname));
+    assert.ok(UrlUtils.isLikeLocalhost(new URL('http://127.0.0.1/page.html').hostname));
+    assert.ok(UrlUtils.isLikeLocalhost(new URL('https://localhost/').hostname));
+    assert.ok(UrlUtils.isLikeLocalhost(new URL('https://dev.localhost/').hostname));
 
-    assert.ok(!URL.isLikeLocalhost(new URL('http://8.8.8.8/').hostname));
-    assert.ok(!URL.isLikeLocalhost(new URL('http://example.com/').hostname));
+    assert.ok(!UrlUtils.isLikeLocalhost(new URL('http://8.8.8.8/').hostname));
+    assert.ok(!UrlUtils.isLikeLocalhost(new URL('http://example.com/').hostname));
   });
 
   it('isSecureScheme', () => {
-    assert.ok(URL.isSecureScheme('wss'));
-    assert.ok(URL.isSecureScheme('about'));
-    assert.ok(URL.isSecureScheme('data'));
-    assert.ok(URL.isSecureScheme('filesystem'));
+    assert.ok(UrlUtils.isSecureScheme('wss'));
+    assert.ok(UrlUtils.isSecureScheme('about'));
+    assert.ok(UrlUtils.isSecureScheme('data'));
+    assert.ok(UrlUtils.isSecureScheme('filesystem'));
 
-    assert.ok(!URL.isSecureScheme('http'));
-    assert.ok(!URL.isSecureScheme('ws'));
+    assert.ok(!UrlUtils.isSecureScheme('http'));
+    assert.ok(!UrlUtils.isSecureScheme('ws'));
   });
 
   it('isNonNetworkProtocol', () => {
-    assert.ok(URL.isNonNetworkProtocol('blob'));
-    assert.ok(URL.isNonNetworkProtocol('data'));
-    assert.ok(URL.isNonNetworkProtocol('data:'));
-    assert.ok(URL.isNonNetworkProtocol('intent:'));
-    assert.ok(URL.isNonNetworkProtocol('file:'));
-    assert.ok(URL.isNonNetworkProtocol('filesystem:'));
-    assert.ok(URL.isNonNetworkProtocol('filesystem'));
+    assert.ok(UrlUtils.isNonNetworkProtocol('blob'));
+    assert.ok(UrlUtils.isNonNetworkProtocol('data'));
+    assert.ok(UrlUtils.isNonNetworkProtocol('data:'));
+    assert.ok(UrlUtils.isNonNetworkProtocol('intent:'));
+    assert.ok(UrlUtils.isNonNetworkProtocol('file:'));
+    assert.ok(UrlUtils.isNonNetworkProtocol('filesystem:'));
+    assert.ok(UrlUtils.isNonNetworkProtocol('filesystem'));
 
-    assert.ok(!URL.isNonNetworkProtocol('https:'));
-    assert.ok(!URL.isNonNetworkProtocol('http'));
-    assert.ok(!URL.isNonNetworkProtocol('ws'));
+    assert.ok(!UrlUtils.isNonNetworkProtocol('https:'));
+    assert.ok(!UrlUtils.isNonNetworkProtocol('http'));
+    assert.ok(!UrlUtils.isNonNetworkProtocol('ws'));
   });
 
   describe('guessMimeType', () => {
     it('handles invalid url', () => {
-      expect(URL.guessMimeType('')).toEqual(undefined);
-      expect(URL.guessMimeType('I_AM_NO_URL')).toEqual(undefined);
+      expect(UrlUtils.guessMimeType('')).toEqual(undefined);
+      expect(UrlUtils.guessMimeType('I_AM_NO_URL')).toEqual(undefined);
     });
 
     it('uses mime type from data URI', () => {
-      expect(URL.guessMimeType('data:image/png;DATA')).toEqual('image/png');
-      expect(URL.guessMimeType('data:image/jpeg;DATA')).toEqual('image/jpeg');
-      expect(URL.guessMimeType('data:image/svg+xml;DATA')).toEqual('image/svg+xml');
-      expect(URL.guessMimeType('data:image/svg+xml,DATA')).toEqual('image/svg+xml');
-      expect(URL.guessMimeType('data:text/html;DATA')).toEqual(undefined);
-      expect(URL.guessMimeType('data:image/jpg;DATA')).toEqual(undefined);
-      expect(URL.guessMimeType('data:text/plain,image/png;base64,DATA')).toEqual(undefined);
+      expect(UrlUtils.guessMimeType('data:image/png;DATA')).toEqual('image/png');
+      expect(UrlUtils.guessMimeType('data:image/jpeg;DATA')).toEqual('image/jpeg');
+      expect(UrlUtils.guessMimeType('data:image/svg+xml;DATA')).toEqual('image/svg+xml');
+      expect(UrlUtils.guessMimeType('data:image/svg+xml,DATA')).toEqual('image/svg+xml');
+      expect(UrlUtils.guessMimeType('data:text/html;DATA')).toEqual(undefined);
+      expect(UrlUtils.guessMimeType('data:image/jpg;DATA')).toEqual(undefined);
+      expect(UrlUtils.guessMimeType('data:text/plain,image/png;base64,DATA')).toEqual(undefined);
     });
 
     it('uses path extension for normal files', () => {
-      expect(URL.guessMimeType('https://example.com/img.png')).toEqual('image/png');
-      expect(URL.guessMimeType('https://example.com/img.png?test')).toEqual('image/png');
-      expect(URL.guessMimeType('https://example.com/IMG.PNG')).toEqual('image/png');
-      expect(URL.guessMimeType('https://example.com/img.jpeg')).toEqual('image/jpeg');
-      expect(URL.guessMimeType('https://example.com/img.jpg')).toEqual('image/jpeg');
-      expect(URL.guessMimeType('https://example.com/img.svg')).toEqual('image/svg+xml');
-      expect(URL.guessMimeType('https://example.com/page.html')).toEqual(undefined);
-      expect(URL.guessMimeType('https://example.com/')).toEqual(undefined);
+      expect(UrlUtils.guessMimeType('https://example.com/img.png')).toEqual('image/png');
+      expect(UrlUtils.guessMimeType('https://example.com/img.png?test')).toEqual('image/png');
+      expect(UrlUtils.guessMimeType('https://example.com/IMG.PNG')).toEqual('image/png');
+      expect(UrlUtils.guessMimeType('https://example.com/img.jpeg')).toEqual('image/jpeg');
+      expect(UrlUtils.guessMimeType('https://example.com/img.jpg')).toEqual('image/jpeg');
+      expect(UrlUtils.guessMimeType('https://example.com/img.svg')).toEqual('image/svg+xml');
+      expect(UrlUtils.guessMimeType('https://example.com/page.html')).toEqual(undefined);
+      expect(UrlUtils.guessMimeType('https://example.com/')).toEqual(undefined);
     });
   });
 
   describe('normalizeUrl', () => {
     it('returns normalized URL', () => {
-      expect(URL.normalizeUrl('https://example.com')).toEqual('https://example.com/');
+      expect(UrlUtils.normalizeUrl('https://example.com')).toEqual('https://example.com/');
     });
 
     it('rejects when not given a URL', () => {
       expect(() => {
-        URL.normalizeUrl(undefined);
+        UrlUtils.normalizeUrl(undefined);
       }).toThrow('INVALID_URL');
     });
 
     it('rejects when given a URL of zero length', () => {
       expect(() => {
-        URL.normalizeUrl('');
+        UrlUtils.normalizeUrl('');
       }).toThrow('INVALID_URL');
     });
 
     it('rejects when given a URL without protocol', () => {
       expect(() => {
-        URL.normalizeUrl('localhost');
+        UrlUtils.normalizeUrl('localhost');
       }).toThrow('INVALID_URL');
     });
 
     it('rejects when given a URL without hostname', () => {
       expect(() => {
-        URL.normalizeUrl('https://');
+        UrlUtils.normalizeUrl('https://');
       }).toThrow('INVALID_URL');
     });
   });

--- a/report/test/renderer/performance-category-renderer-test.js
+++ b/report/test/renderer/performance-category-renderer-test.js
@@ -10,7 +10,6 @@ import jsdom from 'jsdom';
 
 import {Util} from '../../renderer/util.js';
 import {I18n} from '../../renderer/i18n.js';
-import URL from '../../../core/lib/url-shim.js';
 import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {PerformanceCategoryRenderer} from '../../renderer/performance-category-renderer.js';

--- a/report/test/renderer/report-renderer-test.js
+++ b/report/test/renderer/report-renderer-test.js
@@ -10,7 +10,6 @@ import jsdom from 'jsdom';
 import jestMock from 'jest-mock';
 
 import {Util} from '../../renderer/util.js';
-import URL from '../../../core/lib/url-shim.js';
 import {DOM} from '../../renderer/dom.js';
 import {DetailsRenderer} from '../../renderer/details-renderer.js';
 import {CategoryRenderer} from '../../renderer/category-renderer.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,7 +99,7 @@
     "core/test/lib/tracehouse/task-summary-test.js",
     "core/test/lib/tracehouse/trace-processor-test.js",
     "core/test/lib/traces/metrics-trace-events-test.js",
-    "core/test/lib/url-shim-test.js",
+    "core/test/lib/url-utils-test.js",
     "core/test/network-records-to-devtools-log-test.js",
     "core/test/runner-test.js",
     "core/test/scoring-test.js",


### PR DESCRIPTION
ref https://github.com/GoogleChrome/lighthouse/pull/14353#discussion_r962046577

Since URL is now a Node global, we don't have to import it from our utility class to use it anywhere. Removing `extends URL` from `url-shim` and changing the fews places where `new URL` (aka our "shim") was being called was straight forward. The rest of the changes here are dropping some imports (files that only need the global `URL`) and renames (it's not a shim any more so.... `UrlUtils` seems fine as a name?)