### PR TITLE
deps: update quibble fork to work with new loader api

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,7 +10,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        node: ['14', '16.16', '17']
+        node: ['14', '16', '17']
       fail-fast: false
     runs-on: ubuntu-latest
     name: node ${{ matrix.node }}

--- a/core/test/runner-test.js
+++ b/core/test/runner-test.js
@@ -809,7 +809,7 @@ describe('Runner', () => {
       audits: [WarningAudit],
     };
 
-    it.only('includes a top-level runtimeError when a gatherer throws one', async () => {
+    it('includes a top-level runtimeError when a gatherer throws one', async () => {
       const config = await Config.fromJson(configJson);
       const {lhr} = await runGatherAndAudit(createGatherFn('https://example.com/'), {config, driverMock});
 

--- a/core/test/runner-test.js
+++ b/core/test/runner-test.js
@@ -809,7 +809,7 @@ describe('Runner', () => {
       audits: [WarningAudit],
     };
 
-    it('includes a top-level runtimeError when a gatherer throws one', async () => {
+    it.only('includes a top-level runtimeError when a gatherer throws one', async () => {
       const config = await Config.fromJson(configJson);
       const {lhr} = await runGatherAndAudit(createGatherFn('https://example.com/'), {config, driverMock});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6156,8 +6156,8 @@ query-string@^4.1.0:
 
 quibble@^0.6.7, quibble@connorjclark/quibble#mod-cache:
   version "0.6.14"
-  uid "444ce4ddcdf11c1705fc188e4054764040bc63cd"
-  resolved "https://codeload.github.com/connorjclark/quibble/tar.gz/444ce4ddcdf11c1705fc188e4054764040bc63cd"
+  uid "68d53b087d4c9117cc86c7e5f19e7953a219582b"
+  resolved "https://codeload.github.com/connorjclark/quibble/tar.gz/68d53b087d4c9117cc86c7e5f19e7953a219582b"
   dependencies:
     lodash "^4.17.21"
     resolve "^1.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6155,8 +6155,9 @@ query-string@^4.1.0:
     strict-uri-encode "^1.0.0"
 
 quibble@^0.6.7, quibble@connorjclark/quibble#mod-cache:
-  version "0.6.9"
-  resolved "https://codeload.github.com/connorjclark/quibble/tar.gz/b228a4ddbbad5061d36b465db2f364bb7c3291d3"
+  version "0.6.14"
+  uid "444ce4ddcdf11c1705fc188e4054764040bc63cd"
+  resolved "https://codeload.github.com/connorjclark/quibble/tar.gz/444ce4ddcdf11c1705fc188e4054764040bc63cd"
   dependencies:
     lodash "^4.17.21"
     resolve "^1.20.0"


### PR DESCRIPTION
ref https://github.com/testdouble/testdouble.js/issues/498#issuecomment-1239750218

Restores 16.17+ support #14345 (also, latest 18.x wrt the loader api)