### PR TITLE
core(page-functions): remove all `*String` exports

### DIFF
--- a/core/gather/driver/execution-context.js
+++ b/core/gather/driver/execution-context.js
@@ -110,7 +110,7 @@ class ExecutionContext {
         return new Promise(function (resolve) {
           return Promise.resolve()
             .then(_ => ${expression})
-            .catch(${pageFunctions.wrapRuntimeEvalErrorInBrowserString})
+            .catch(${pageFunctions.wrapRuntimeEvalErrorInBrowser})
             .then(resolve);
         });
       }())

--- a/core/gather/driver/execution-context.js
+++ b/core/gather/driver/execution-context.js
@@ -187,7 +187,7 @@ class ExecutionContext {
    */
   evaluate(mainFn, options) {
     const argsSerialized = ExecutionContext.serializeArguments(options.args);
-    const depsSerialized = ExecutionContext.serializeDependencies(options.deps);
+    const depsSerialized = options.deps ? options.deps.join('\n') : '';
     const expression = `(() => {
       ${depsSerialized}
       return (${mainFn})(${argsSerialized});
@@ -206,7 +206,7 @@ class ExecutionContext {
    */
   async evaluateOnNewDocument(mainFn, options) {
     const argsSerialized = ExecutionContext.serializeArguments(options.args);
-    const depsSerialized = ExecutionContext.serializeDependencies(options.deps);
+    const depsSerialized = options.deps ? options.deps.join('\n') : '';
 
     const expression = `(() => {
       ${ExecutionContext._cachedNativesPreamble};
@@ -262,37 +262,6 @@ class ExecutionContext {
    */
   static serializeArguments(args) {
     return args.map(arg => arg === undefined ? 'undefined' : JSON.stringify(arg)).join(',');
-  }
-
-  /**
-   * Serializes an array of dependency functions.
-   * Function dependencies can have a `.dependencies` array declaring their sub-dependencies.
-   * @param {Array<(Function)|string>=} deps
-   * @return {string}
-   */
-  static serializeDependencies(deps) {
-    if (!deps) return '';
-
-    const allDeps = new Set(deps);
-    const active = [...allDeps];
-    while (active.length) {
-      const dep = active.pop();
-      if (!(dep instanceof Function)) continue;
-
-      /** @type {Function[]} */
-      // @ts-expect-error
-      const subDependencies = dep.dependencies;
-      if (!subDependencies) continue;
-
-      for (const subDep of subDependencies) {
-        if (allDeps.has(subDep)) continue;
-
-        allDeps.add(subDep);
-        active.push(subDep);
-      }
-    }
-
-    return [...allDeps].join('\n');
   }
 }
 

--- a/core/gather/driver/execution-context.js
+++ b/core/gather/driver/execution-context.js
@@ -187,7 +187,7 @@ class ExecutionContext {
    */
   evaluate(mainFn, options) {
     const argsSerialized = ExecutionContext.serializeArguments(options.args);
-    const depsSerialized = options.deps ? options.deps.join('\n') : '';
+    const depsSerialized = ExecutionContext.serializeDependencies(options.deps);
     const expression = `(() => {
       ${depsSerialized}
       return (${mainFn})(${argsSerialized});
@@ -206,7 +206,7 @@ class ExecutionContext {
    */
   async evaluateOnNewDocument(mainFn, options) {
     const argsSerialized = ExecutionContext.serializeArguments(options.args);
-    const depsSerialized = options.deps ? options.deps.join('\n') : '';
+    const depsSerialized = ExecutionContext.serializeDependencies(options.deps);
 
     const expression = `(() => {
       ${ExecutionContext._cachedNativesPreamble};
@@ -262,6 +262,37 @@ class ExecutionContext {
    */
   static serializeArguments(args) {
     return args.map(arg => arg === undefined ? 'undefined' : JSON.stringify(arg)).join(',');
+  }
+
+  /**
+   * Serializes an array of dependency functions.
+   * Function dependencies can have a `.dependencies` array declaring their sub-dependencies.
+   * @param {Array<(Function)|string>=} deps
+   * @return {string}
+   */
+  static serializeDependencies(deps) {
+    if (!deps) return '';
+
+    const allDeps = new Set(deps);
+    const active = [...allDeps];
+    while (active.length) {
+      const dep = active.pop();
+      if (!(dep instanceof Function)) continue;
+
+      /** @type {Function[]} */
+      // @ts-expect-error
+      const subDependencies = dep.dependencies;
+      if (!subDependencies) continue;
+
+      for (const subDep of subDependencies) {
+        if (allDeps.has(subDep)) continue;
+
+        allDeps.add(subDep);
+        active.push(subDep);
+      }
+    }
+
+    return [...allDeps].join('\n');
   }
 }
 

--- a/core/gather/gatherers/accessibility.js
+++ b/core/gather/gatherers/accessibility.js
@@ -173,7 +173,7 @@ class Accessibility extends FRGatherer {
       useIsolation: true,
       deps: [
         axeSource,
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getNodeDetails,
         createAxeRuleResultArtifact,
       ],
     });

--- a/core/gather/gatherers/anchor-elements.js
+++ b/core/gather/gatherers/anchor-elements.js
@@ -106,8 +106,8 @@ class AnchorElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getElementsInDocumentString,
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getElementsInDocument,
+        pageFunctions.getNodeDetails,
       ],
     });
     await session.sendCommand('DOM.enable');

--- a/core/gather/gatherers/dobetterweb/domstats.js
+++ b/core/gather/gatherers/dobetterweb/domstats.js
@@ -92,7 +92,7 @@ class DOMStats extends FRGatherer {
     const results = await driver.executionContext.evaluate(getDOMStats, {
       args: [],
       useIsolation: true,
-      deps: [pageFunctions.getNodeDetailsString],
+      deps: [pageFunctions.getNodeDetails],
     });
     await driver.defaultSession.sendCommand('DOM.disable');
     return results;

--- a/core/gather/gatherers/dobetterweb/domstats.js
+++ b/core/gather/gatherers/dobetterweb/domstats.js
@@ -92,7 +92,7 @@ class DOMStats extends FRGatherer {
     const results = await driver.executionContext.evaluate(getDOMStats, {
       args: [],
       useIsolation: true,
-      deps: [pageFunctions.getNodeDetails],
+      deps: [pageFunctions.getNodeDetailsString],
     });
     await driver.defaultSession.sendCommand('DOM.disable');
     return results;

--- a/core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
+++ b/core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
@@ -40,7 +40,7 @@ class PasswordInputsWithPreventedPaste extends FRGatherer {
   getArtifact(passContext) {
     return passContext.driver.executionContext.evaluate(findPasswordInputsWithPreventedPaste, {
       args: [],
-      deps: [pageFunctions.getNodeDetailsString],
+      deps: [pageFunctions.getNodeDetails],
     });
   }
 }

--- a/core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
+++ b/core/gather/gatherers/dobetterweb/password-inputs-with-prevented-paste.js
@@ -40,7 +40,7 @@ class PasswordInputsWithPreventedPaste extends FRGatherer {
   getArtifact(passContext) {
     return passContext.driver.executionContext.evaluate(findPasswordInputsWithPreventedPaste, {
       args: [],
-      deps: [pageFunctions.getNodeDetails],
+      deps: [pageFunctions.getNodeDetailsString],
     });
   }
 }

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -163,7 +163,7 @@ class FullPageScreenshot extends FRGatherer {
       return context.driver.executionContext.evaluate(resolveNodes, {
         args: [],
         useIsolation,
-        deps: [pageFunctions.getBoundingClientRectString],
+        deps: [pageFunctions.getBoundingClientRect],
       });
     }
 

--- a/core/gather/gatherers/iframe-elements.js
+++ b/core/gather/gatherers/iframe-elements.js
@@ -55,9 +55,9 @@ class IFrameElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getElementsInDocumentString,
-        pageFunctions.isPositionFixedString,
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getElementsInDocument,
+        pageFunctions.isPositionFixed,
+        pageFunctions.getNodeDetails,
       ],
     });
     return iframeElements;

--- a/core/gather/gatherers/image-elements.js
+++ b/core/gather/gatherers/image-elements.js
@@ -344,9 +344,9 @@ class ImageElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getElementsInDocumentString,
-        pageFunctions.getBoundingClientRectString,
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getElementsInDocument,
+        pageFunctions.getBoundingClientRect,
+        pageFunctions.getNodeDetails,
         getClientRect,
         getPosition,
         getHTMLImages,

--- a/core/gather/gatherers/inputs.js
+++ b/core/gather/gatherers/inputs.js
@@ -102,8 +102,8 @@ class Inputs extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getElementsInDocumentString,
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getElementsInDocument,
+        pageFunctions.getNodeDetails,
       ],
     });
   }

--- a/core/gather/gatherers/link-elements.js
+++ b/core/gather/gatherers/link-elements.js
@@ -104,7 +104,7 @@ class LinkElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getNodeDetails,
         pageFunctions.getElementsInDocument,
       ],
     });

--- a/core/gather/gatherers/meta-elements.js
+++ b/core/gather/gatherers/meta-elements.js
@@ -58,7 +58,7 @@ class MetaElements extends FRGatherer {
       useIsolation: true,
       deps: [
         pageFunctions.getElementsInDocument,
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getNodeDetails,
       ],
     });
   }

--- a/core/gather/gatherers/meta-elements.js
+++ b/core/gather/gatherers/meta-elements.js
@@ -58,7 +58,7 @@ class MetaElements extends FRGatherer {
       useIsolation: true,
       deps: [
         pageFunctions.getElementsInDocument,
-        pageFunctions.getNodeDetails,
+        pageFunctions.getNodeDetailsString,
       ],
     });
   }

--- a/core/gather/gatherers/script-elements.js
+++ b/core/gather/gatherers/script-elements.js
@@ -58,7 +58,7 @@ class ScriptElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getNodeDetails,
         pageFunctions.getElementsInDocument,
       ],
     });

--- a/core/gather/gatherers/script-elements.js
+++ b/core/gather/gatherers/script-elements.js
@@ -58,7 +58,7 @@ class ScriptElements extends FRGatherer {
       args: [],
       useIsolation: true,
       deps: [
-        pageFunctions.getNodeDetails,
+        pageFunctions.getNodeDetailsString,
         pageFunctions.getElementsInDocument,
       ],
     });

--- a/core/gather/gatherers/seo/embedded-content.js
+++ b/core/gather/gatherers/seo/embedded-content.js
@@ -54,7 +54,7 @@ class EmbeddedContent extends FRGatherer {
       args: [],
       deps: [
         pageFunctions.getElementsInDocument,
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getNodeDetails,
       ],
     });
   }

--- a/core/gather/gatherers/seo/embedded-content.js
+++ b/core/gather/gatherers/seo/embedded-content.js
@@ -54,7 +54,7 @@ class EmbeddedContent extends FRGatherer {
       args: [],
       deps: [
         pageFunctions.getElementsInDocument,
-        pageFunctions.getNodeDetails,
+        pageFunctions.getNodeDetailsString,
       ],
     });
   }

--- a/core/gather/gatherers/seo/tap-targets.js
+++ b/core/gather/gatherers/seo/tap-targets.js
@@ -341,7 +341,7 @@ class TapTargets extends FRGatherer {
       args: [tapTargetsSelector, className],
       useIsolation: true,
       deps: [
-        pageFunctions.getNodeDetailsString,
+        pageFunctions.getNodeDetails,
         pageFunctions.getElementsInDocument,
         disableFixedAndStickyElementPointerEvents,
         elementIsVisible,

--- a/core/gather/gatherers/seo/tap-targets.js
+++ b/core/gather/gatherers/seo/tap-targets.js
@@ -341,7 +341,7 @@ class TapTargets extends FRGatherer {
       args: [tapTargetsSelector, className],
       useIsolation: true,
       deps: [
-        pageFunctions.getNodeDetails,
+        pageFunctions.getNodeDetailsString,
         pageFunctions.getElementsInDocument,
         disableFixedAndStickyElementPointerEvents,
         elementIsVisible,

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -295,7 +295,7 @@ class TraceElements extends FRGatherer {
             objectId,
             functionDeclaration: `function () {
               ${getNodeDetailsData.toString()};
-              ${pageFunctions.getNodeDetailsString};
+              ${pageFunctions.getNodeDetails};
               return getNodeDetailsData.call(this);
             }`,
             returnByValue: true,

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -22,6 +22,7 @@ import {ProcessedTrace} from '../../computed/processed-trace.js';
 import {ProcessedNavigation} from '../../computed/processed-navigation.js';
 import {LighthouseError} from '../../lib/lh-error.js';
 import {Responsiveness} from '../../computed/metrics/responsiveness.js';
+import {ExecutionContext} from '../driver/execution-context.js';
 
 /** @typedef {{nodeId: number, score?: number, animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[], type?: string}} TraceElementData */
 
@@ -294,8 +295,8 @@ class TraceElements extends FRGatherer {
           response = await session.sendCommand('Runtime.callFunctionOn', {
             objectId,
             functionDeclaration: `function () {
-              ${getNodeDetailsData.toString()};
-              ${pageFunctions.getNodeDetailsString};
+              ${getNodeDetailsData};
+              ${ExecutionContext.serializeDependencies([pageFunctions.getNodeDetails])};
               return getNodeDetailsData.call(this);
             }`,
             returnByValue: true,

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -22,7 +22,6 @@ import {ProcessedTrace} from '../../computed/processed-trace.js';
 import {ProcessedNavigation} from '../../computed/processed-navigation.js';
 import {LighthouseError} from '../../lib/lh-error.js';
 import {Responsiveness} from '../../computed/metrics/responsiveness.js';
-import {ExecutionContext} from '../driver/execution-context.js';
 
 /** @typedef {{nodeId: number, score?: number, animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[], type?: string}} TraceElementData */
 
@@ -295,8 +294,8 @@ class TraceElements extends FRGatherer {
           response = await session.sendCommand('Runtime.callFunctionOn', {
             objectId,
             functionDeclaration: `function () {
-              ${getNodeDetailsData};
-              ${ExecutionContext.serializeDependencies([pageFunctions.getNodeDetails])};
+              ${getNodeDetailsData.toString()};
+              ${pageFunctions.getNodeDetailsString};
               return getNodeDetailsData.call(this);
             }`,
             returnByValue: true,

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -539,14 +539,13 @@ function getNodeDetails(element) {
   return details;
 }
 
-const getNodeDetailsString = `function getNodeDetails(element) {
-  ${getNodePath.toString()};
-  ${getNodeSelector.toString()};
-  ${getBoundingClientRect.toString()};
-  ${getOuterHTMLSnippet.toString()};
-  ${getNodeLabel.toString()};
-  return (${getNodeDetails.toString()})(element);
-}`;
+getNodeDetails.dependencies = [
+  getNodePath,
+  getNodeSelector,
+  getBoundingClientRect,
+  getOuterHTMLSnippet,
+  getNodeLabel,
+];
 
 // TODO(esmodules): should this be refactored to export each function individually?
 export const pageFunctions = {
@@ -556,7 +555,6 @@ export const pageFunctions = {
   computeBenchmarkIndex,
   getMaxTextureSize,
   getNodeDetails,
-  getNodeDetailsString,
   getNodePath,
   getNodeSelector,
   getNodeLabel,

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -550,24 +550,17 @@ const getNodeDetailsString = `function getNodeDetails(element) {
 
 // TODO(esmodules): should this be refactored to export each function individually?
 export const pageFunctions = {
-  wrapRuntimeEvalErrorInBrowserString: wrapRuntimeEvalErrorInBrowser.toString(),
   wrapRuntimeEvalErrorInBrowser,
   getElementsInDocument,
-  getElementsInDocumentString: getElementsInDocument.toString(),
-  getOuterHTMLSnippetString: getOuterHTMLSnippet.toString(),
   getOuterHTMLSnippet,
   computeBenchmarkIndex,
-  computeBenchmarkIndexString: computeBenchmarkIndex.toString(),
   getMaxTextureSize,
-  getNodeDetailsString,
   getNodeDetails,
-  getNodePathString: getNodePath.toString(),
-  getNodeSelectorString: getNodeSelector.toString(),
+  getNodeDetailsString,
   getNodePath,
   getNodeSelector,
   getNodeLabel,
-  getNodeLabelString: getNodeLabel.toString(),
-  isPositionFixedString: isPositionFixed.toString(),
+  isPositionFixed,
   wrapRequestIdleCallback,
-  getBoundingClientRectString: getBoundingClientRect.toString(),
+  getBoundingClientRect,
 };

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -539,7 +539,8 @@ function getNodeDetails(element) {
   return details;
 }
 
-const getNodeDetailsString = `function getNodeDetails(element) {
+// @ts-expect-error
+getNodeDetails.toString = () => `function getNodeDetails(element) {
   ${getNodePath.toString()};
   ${getNodeSelector.toString()};
   ${getBoundingClientRect.toString()};
@@ -555,7 +556,6 @@ export const pageFunctions = {
   computeBenchmarkIndex,
   getMaxTextureSize,
   getNodeDetails,
-  getNodeDetailsString,
   getNodePath,
   getNodeSelector,
   getNodeLabel,

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -539,14 +539,15 @@ function getNodeDetails(element) {
   return details;
 }
 
-// @ts-expect-error
+/** @type {string} */
+const getNodeDetailsRawString = getNodeDetails.toString();
 getNodeDetails.toString = () => `function getNodeDetails(element) {
   ${getNodePath.toString()};
   ${getNodeSelector.toString()};
   ${getBoundingClientRect.toString()};
   ${getOuterHTMLSnippet.toString()};
   ${getNodeLabel.toString()};
-  return (${getNodeDetails.toString()})(element);
+  return (${getNodeDetailsRawString})(element);
 }`;
 
 export const pageFunctions = {

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -539,13 +539,14 @@ function getNodeDetails(element) {
   return details;
 }
 
-getNodeDetails.dependencies = [
-  getNodePath,
-  getNodeSelector,
-  getBoundingClientRect,
-  getOuterHTMLSnippet,
-  getNodeLabel,
-];
+const getNodeDetailsString = `function getNodeDetails(element) {
+  ${getNodePath.toString()};
+  ${getNodeSelector.toString()};
+  ${getBoundingClientRect.toString()};
+  ${getOuterHTMLSnippet.toString()};
+  ${getNodeLabel.toString()};
+  return (${getNodeDetails.toString()})(element);
+}`;
 
 export const pageFunctions = {
   wrapRuntimeEvalErrorInBrowser,
@@ -554,6 +555,7 @@ export const pageFunctions = {
   computeBenchmarkIndex,
   getMaxTextureSize,
   getNodeDetails,
+  getNodeDetailsString,
   getNodePath,
   getNodeSelector,
   getNodeLabel,

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -547,7 +547,6 @@ getNodeDetails.dependencies = [
   getNodeLabel,
 ];
 
-// TODO(esmodules): should this be refactored to export each function individually?
 export const pageFunctions = {
   wrapRuntimeEvalErrorInBrowser,
   getElementsInDocument,

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -542,11 +542,11 @@ function getNodeDetails(element) {
 /** @type {string} */
 const getNodeDetailsRawString = getNodeDetails.toString();
 getNodeDetails.toString = () => `function getNodeDetails(element) {
-  ${getNodePath.toString()};
-  ${getNodeSelector.toString()};
-  ${getBoundingClientRect.toString()};
-  ${getOuterHTMLSnippet.toString()};
-  ${getNodeLabel.toString()};
+  ${getNodePath};
+  ${getNodeSelector};
+  ${getBoundingClientRect};
+  ${getOuterHTMLSnippet};
+  ${getNodeLabel};
   return (${getNodeDetailsRawString})(element);
 }`;
 

--- a/core/test/gather/driver/execution-context-test.js
+++ b/core/test/gather/driver/execution-context-test.js
@@ -350,32 +350,3 @@ describe('.serializeArguments', () => {
     );
   });
 });
-
-describe('.serializeDependencies', () => {
-  it('should serialize a list of dependencies and their sub-dependencies', () => {
-    function a() {}
-    function b() {}
-    function c() {}
-    function d() {}
-    function e() {}
-
-    c.dependencies = [d, a];
-    d.dependencies = [e];
-
-    const args = [
-      a,
-      'function str() {}',
-      b,
-      c,
-    ];
-    expect(ExecutionContext.serializeDependencies(args)).toEqual(`
-function a() {}
-function str() {}
-function b() {}
-function c() {}
-function d() {}
-function e() {}
-`.trim()
-    );
-  });
-});

--- a/core/test/gather/driver/execution-context-test.js
+++ b/core/test/gather/driver/execution-context-test.js
@@ -350,3 +350,32 @@ describe('.serializeArguments', () => {
     );
   });
 });
+
+describe('.serializeDependencies', () => {
+  it('should serialize a list of dependencies and their sub-dependencies', () => {
+    function a() {}
+    function b() {}
+    function c() {}
+    function d() {}
+    function e() {}
+
+    c.dependencies = [d, a];
+    d.dependencies = [e];
+
+    const args = [
+      a,
+      'function str() {}',
+      b,
+      c,
+    ];
+    expect(ExecutionContext.serializeDependencies(args)).toEqual(`
+function a() {}
+function str() {}
+function b() {}
+function c() {}
+function d() {}
+function e() {}
+`.trim()
+    );
+  });
+});

--- a/core/test/gather/gatherers/accessibility-test.js
+++ b/core/test/gather/gatherers/accessibility-test.js
@@ -13,6 +13,7 @@ import AccessibilityGather from '../../../gather/gatherers/accessibility.js';
 import {LH_ROOT} from '../../../../root.js';
 import {axeSource} from '../../../../core/lib/axe.js';
 import {pageFunctions} from '../../../../core/lib/page-functions.js';
+import {ExecutionContext} from '../../../gather/driver/execution-context.js';
 
 describe('Accessibility gatherer', () => {
   let accessibilityGather;
@@ -52,7 +53,7 @@ describe('a11y audits + aXe', () => {
     const page = await browser.newPage();
     page.setContent(`<!doctype html><meta charset="utf8"><title>hi</title>valid.`);
     await page.evaluate(axeSource);
-    await page.evaluate(pageFunctions.getNodeDetailsString);
+    await page.evaluate(ExecutionContext.serializeDependencies([pageFunctions.getNodeDetails]));
     await page.evaluate(AccessibilityGather.pageFns.runA11yChecks.toString());
     await page.evaluate(AccessibilityGather.pageFns.createAxeRuleResultArtifact.toString());
 

--- a/core/test/gather/gatherers/accessibility-test.js
+++ b/core/test/gather/gatherers/accessibility-test.js
@@ -13,7 +13,6 @@ import AccessibilityGather from '../../../gather/gatherers/accessibility.js';
 import {LH_ROOT} from '../../../../root.js';
 import {axeSource} from '../../../../core/lib/axe.js';
 import {pageFunctions} from '../../../../core/lib/page-functions.js';
-import {ExecutionContext} from '../../../gather/driver/execution-context.js';
 
 describe('Accessibility gatherer', () => {
   let accessibilityGather;
@@ -53,7 +52,7 @@ describe('a11y audits + aXe', () => {
     const page = await browser.newPage();
     page.setContent(`<!doctype html><meta charset="utf8"><title>hi</title>valid.`);
     await page.evaluate(axeSource);
-    await page.evaluate(ExecutionContext.serializeDependencies([pageFunctions.getNodeDetails]));
+    await page.evaluate(pageFunctions.getNodeDetailsString);
     await page.evaluate(AccessibilityGather.pageFns.runA11yChecks.toString());
     await page.evaluate(AccessibilityGather.pageFns.createAxeRuleResultArtifact.toString());
 

--- a/core/test/gather/gatherers/accessibility-test.js
+++ b/core/test/gather/gatherers/accessibility-test.js
@@ -52,7 +52,7 @@ describe('a11y audits + aXe', () => {
     const page = await browser.newPage();
     page.setContent(`<!doctype html><meta charset="utf8"><title>hi</title>valid.`);
     await page.evaluate(axeSource);
-    await page.evaluate(pageFunctions.getNodeDetailsString);
+    await page.evaluate(pageFunctions.getNodeDetails);
     await page.evaluate(AccessibilityGather.pageFns.runA11yChecks.toString());
     await page.evaluate(AccessibilityGather.pageFns.createAxeRuleResultArtifact.toString());
 

--- a/core/test/gather/gatherers/accessibility-test.js
+++ b/core/test/gather/gatherers/accessibility-test.js
@@ -52,7 +52,7 @@ describe('a11y audits + aXe', () => {
     const page = await browser.newPage();
     page.setContent(`<!doctype html><meta charset="utf8"><title>hi</title>valid.`);
     await page.evaluate(axeSource);
-    await page.evaluate(pageFunctions.getNodeDetails);
+    await page.evaluate(pageFunctions.getNodeDetails.toString());
     await page.evaluate(AccessibilityGather.pageFns.runA11yChecks.toString());
     await page.evaluate(AccessibilityGather.pageFns.createAxeRuleResultArtifact.toString());
 


### PR DESCRIPTION
All but one of these can be dropped just by using their function directly.

`getNodeDetails` is special because it has a number of other page-functions that must be included to work, which was solved by making its `*String` export wrap those deps (so callers wouldn't have to remember to). Instead, ~I introduce `ExecutionContext.serializeDependencies` and `someFn.dependencies` to do the same.~ we set `toString`