### PR TITLE
core(fr): always run NetworkUserAgent gatherer

### DIFF
--- a/cli/test/cli/__snapshots__/index-test.js.snap
+++ b/cli/test/cli/__snapshots__/index-test.js.snap
@@ -12,6 +12,10 @@ Object {
       "id": "Trace",
     },
     Object {
+      "gatherer": "network-user-agent",
+      "id": "NetworkUserAgent",
+    },
+    Object {
       "gatherer": "stacks",
       "id": "Stacks",
     },
@@ -140,6 +144,7 @@ Object {
       "artifacts": Array [
         "DevtoolsLog",
         "Trace",
+        "NetworkUserAgent",
         "Stacks",
         "devtoolsLogs",
         "traces",

--- a/core/fraggle-rock/config/filters.js
+++ b/core/fraggle-rock/config/filters.js
@@ -31,7 +31,13 @@ const filterResistantAuditIds = ['full-page-screenshot'];
 
 // Some artifacts are used by the report for additional information.
 // Always run these artifacts even if audits do not request them.
-const filterResistantArtifactIds = ['HostUserAgent', 'HostFormFactor', 'Stacks', 'GatherContext'];
+const filterResistantArtifactIds = [
+  'HostUserAgent',
+  'HostFormFactor',
+  'Stacks',
+  'GatherContext',
+  'NetworkUserAgent',
+];
 
 /**
  * Returns the set of audit IDs used in the list of categories.

--- a/core/fraggle-rock/config/filters.js
+++ b/core/fraggle-rock/config/filters.js
@@ -31,13 +31,8 @@ const filterResistantAuditIds = ['full-page-screenshot'];
 
 // Some artifacts are used by the report for additional information.
 // Always run these artifacts even if audits do not request them.
-const filterResistantArtifactIds = [
-  'HostUserAgent',
-  'HostFormFactor',
-  'Stacks',
-  'GatherContext',
-  'NetworkUserAgent',
-];
+// These are similar to base artifacts but they cannot be run in all 3 modes.
+const filterResistantArtifactIds = ['Stacks', 'NetworkUserAgent'];
 
 /**
  * Returns the set of audit IDs used in the list of categories.


### PR DESCRIPTION
This was a base artifact in legacy mode but it's a normal artifact in FR.

It wasn't being run because no audits depend on it. This PR avoids the audit dependency filter for this artifact.
