### PR TITLE
core(fetcher): return response headers

### DIFF
--- a/core/test/gather/fetcher-test.js
+++ b/core/test/gather/fetcher-test.js
@@ -116,6 +116,25 @@ describe('._fetchResourceOverProtocol', () => {
     });
   });
 
+  it('returns empty headers if nothing requested', async () => {
+    connectionStub.sendCommand = createMockSendCommandFn()
+      .mockResponse('Page.getFrameTree', {frameTree: {frame: {id: 'FRAME'}}})
+      .mockResponse('Network.loadNetworkResource', {
+        resource: {success: true, httpStatusCode: 200, stream: '1', headers: {
+          'x_some_header': 'a',
+          'x_some_header_2': 'b',
+        }},
+      });
+
+    const data = await fetcher._fetchResourceOverProtocol('https://example.com', {
+      timeout: 500, responseHeaders: []});
+    expect(data).toStrictEqual({
+      content: streamContents,
+      headers: {},
+      status: 200,
+    });
+  });
+
   it('returns null when resource could not be fetched', async () => {
     connectionStub.sendCommand = createMockSendCommandFn()
       .mockResponse('Page.getFrameTree', {frameTree: {frame: {id: 'FRAME'}}})


### PR DESCRIPTION
Adds `headers` to the fetcher result.

To avoid wasteful processing due to incompatibility between Node and browser (for LR) fetching, gotta declare what headers we care about (otherwise would need to copy all headers from browser Headers object to share same interface). Another approach would be to wrap both `Headers` and `LH.Crdp.Network.Headers` (just `Record<string,string>`) in callback function `get(key: string): string|null`.

Example use case would be [`x_google_ignoreList`](https://developer.chrome.com/blog/devtools-better-angular-debugging/), for whenever we show stack traces processed with source maps