### PR TITLE
misc: drop support for node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
         GITHUB_CONTEXT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-all

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -22,10 +22,10 @@ jobs:
       with:
         path: lighthouse
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - name: Generate cache hash
       run: bash $GITHUB_WORKSPACE/lighthouse/.github/scripts/generate-devtools-hash.sh > cdt-test-hash.txt
@@ -86,10 +86,10 @@ jobs:
       with:
         path: lighthouse
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - run: yarn --frozen-lockfile --network-timeout 1000000
       working-directory: ${{ github.workspace }}/lighthouse
@@ -129,10 +129,10 @@ jobs:
       with:
         path: lighthouse
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - name: Load build artifacts
       id: devtools-build-artifacts

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -14,10 +14,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
@@ -36,10 +36,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: https://registry.npmjs.org/
       - run: yarn --frozen-lockfile
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,10 +31,10 @@ jobs:
         # Depth of at least 2 for codecov coverage diffs. See https://github.com/GoogleChrome/lighthouse/pull/12079
         fetch-depth: 2
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - name: Define ToT chrome path
       if: matrix.chrome-channel == 'ToT'
@@ -86,10 +86,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - name: Define ToT chrome path
       run: echo "CHROME_PATH=${env:GITHUB_WORKSPACE}\chrome-win\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
@@ -132,10 +132,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
@@ -179,10 +179,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
@@ -226,10 +226,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,7 +10,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['16', '18']
       fail-fast: false
     runs-on: ubuntu-latest
     name: node ${{ matrix.node }}

--- a/docs/headless-chrome.md
+++ b/docs/headless-chrome.md
@@ -5,7 +5,7 @@
 Setup:
 
 ```sh
-# Lighthouse requires Node 14 LTS (14.x) or later.
+# Lighthouse requires Node 16 LTS (16.x) or later.
 curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - &&\
 sudo apt-get install -y nodejs npm
 
@@ -27,8 +27,8 @@ lighthouse --chrome-flags="--headless" https://github.com
 Alternatively, you can run full Chrome + xvfb instead of headless mode. These steps worked on Debian Jessie:
 
 ```sh
-# get node 14
-curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+# get node 16
+curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
 sudo apt-get install -y nodejs npm
 
 # get chromium (stable) and Xvfb

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "smokehouse": "./cli/test/smokehouse/frontends/smokehouse-bin.js"
   },
   "engines": {
-    "node": ">=14.15"
+    "node": ">=16.17"
   },
   "scripts": {
     "prepack": "yarn build-report --standalone --flow --esm",

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The Chrome extension was available prior to Lighthouse being available in Chrome
 
 The Node CLI provides the most flexibility in how Lighthouse runs can be configured and reported. Users who want more advanced usage, or want to run Lighthouse in an automated fashion should use the Node CLI.
 
-_Lighthouse requires Node 14 LTS (14.x) or later._
+_Lighthouse requires Node 16 LTS (16.x) or later._
 
 **Installation**:
 


### PR DESCRIPTION
From #14345, we are ok with dropping node 14 for 2022-10-18. It's unlikely we'd wish to release 10.0 before then, so this is safe to land.

New node features, if curious:

https://betterprogramming.pub/whats-new-in-node-js-15-fc24e87e2590
https://betterprogramming.pub/a-quick-look-at-the-node-js-16-features-d616e8b2f29
