### PR TITLE
core: save lhr to latest-run/ for -A, not just -GA

### DIFF
--- a/core/runner.js
+++ b/core/runner.js
@@ -121,8 +121,7 @@ class Runner {
       // LHR has now been localized.
       const lhr = /** @type {LH.Result} */ (i18nLhr);
 
-      // Save lhr to ./latest-run, but only if -GA is used.
-      if (settings.gatherMode && settings.auditMode) {
+      if (settings.auditMode) {
         const path = Runner._getDataSavePath(settings);
         assetSaver.saveLhr(lhr, path);
       }

--- a/core/test/runner-test.js
+++ b/core/test/runner-test.js
@@ -144,7 +144,7 @@ describe('Runner', () => {
         expect(loadArtifactsSpy).toHaveBeenCalled();
         expect(gatherRunnerRunSpy).not.toHaveBeenCalled();
         expect(saveArtifactsSpy).not.toHaveBeenCalled();
-        expect(saveLhrSpy).not.toHaveBeenCalled();
+        expect(saveLhrSpy).toHaveBeenCalled();
         expect(runAuditSpy).toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
Added in #11509, but undone in #11519

I think it was undone because it was adding unwanted lhr files from runner-test. However... I don't see that happening anymore?

This is very useful because `-GA` gathering takes too long when you just want to iterate on audit code, and it's simple to just look at this lhr.report.json file.