### PR TITLE
report: remove extra space from screenshot preview

### DIFF
--- a/report/renderer/element-screenshot-renderer.js
+++ b/report/renderer/element-screenshot-renderer.js
@@ -239,7 +239,12 @@ export class ElementScreenshotRenderer {
       width: maxRenderSizeDC.width / zoomFactor,
       height: maxRenderSizeDC.height / zoomFactor,
     };
-    elementPreviewSizeSC.width = Math.min(screenshot.width, elementPreviewSizeSC.width);
+
+    if (screenshot.width < elementPreviewSizeSC.width) {
+      elementPreviewSizeSC.width = screenshot.width;
+      elementPreviewSizeSC.height = screenshot.height;
+    }
+
     /* This preview size is either the size of the thumbnail or size of the Lightbox */
     const elementPreviewSizeDC = {
       width: elementPreviewSizeSC.width * zoomFactor,


### PR DESCRIPTION
Before:

<img width="787" alt="Screen Shot 2022-10-04 at 2 43 03 PM" src="https://user-images.githubusercontent.com/6752989/193935878-002d6271-824e-4c86-8283-ad4297402051.png">

After:

<img width="787" alt="Screen Shot 2022-10-04 at 2 43 18 PM" src="https://user-images.githubusercontent.com/6752989/193935920-d34d1dc2-4819-4dfd-8e7e-eeef92c537b1.png">
