### PR TITLE
report(flow): fix ui strings not being bundled

### DIFF
--- a/build/build-report.js
+++ b/build/build-report.js
@@ -14,9 +14,9 @@ import {locales} from '../shared/localization/locales.js';
 import {UIStrings as FlowUIStrings} from '../flow-report/src/i18n/ui-strings.js';
 
 /**
- * Extract only the strings needed for the flow report into
- * a script that sets a global variable `strings`, whose keys
- * are locale codes (en-US, es, etc.) and values are localized UIStrings.
+ * Extract only the strings needed for the flow report. Code generated is
+ * an object whose keys are locale codes (en-US, es, etc.) and values are localized UIStrings.
+ * For flow-report/src/i18n/localized-strings.js
  */
 function buildFlowStrings() {
   const strings = /** @type {Record<LH.Locale, string>} */ ({});

--- a/flow-report/src/i18n/i18n.tsx
+++ b/flow-report/src/i18n/i18n.tsx
@@ -11,7 +11,7 @@ import {formatMessage} from '../../../shared/localization/format';
 import {I18n} from '../../../report/renderer/i18n';
 import {UIStrings} from './ui-strings';
 import {useFlowResult} from '../util';
-import strings from './localized-strings';
+import strings from './localized-strings.js';
 import {Util} from '../../../report/renderer/util';
 
 const I18nContext = createContext(new I18n('en-US', {...Util.UIStrings, ...UIStrings}));

--- a/flow-report/test/flow-report-pptr-test.ts
+++ b/flow-report/test/flow-report-pptr-test.ts
@@ -7,6 +7,7 @@
 import puppeteer, {Browser, Page} from 'puppeteer';
 
 import {ReportGenerator} from '../../report/generator/report-generator.js';
+import {swapFlowLocale} from '../../shared/localization/swap-flow-locale.js';
 import {flowResult} from './sample-flow';
 
 describe('Lighthouse Flow Report', () => {
@@ -38,6 +39,21 @@ describe('Lighthouse Flow Report', () => {
 
     it('should load with no errors', async () => {
       expect(pageErrors).toHaveLength(0);
+    });
+  });
+
+  describe('Renders the flow report (i18n)', () => {
+    before(async () => {
+      const html = ReportGenerator.generateFlowReportHtml(swapFlowLocale(flowResult, 'es'));
+      await page.setContent(html);
+    });
+
+    it('should load with no errors', async () => {
+      expect(pageErrors).toHaveLength(0);
+      const el = await page.$('.SummarySectionHeader__content');
+      if (!el) throw new Error();
+      const text = await el.evaluate(el => el.textContent);
+      expect(text).toEqual('Todos los informes');
     });
   });
 }).timeout(35_000);

--- a/report/generator/report-generator.js
+++ b/report/generator/report-generator.js
@@ -65,10 +65,13 @@ class ReportGenerator {
    */
   static generateFlowReportHtml(flow) {
     const sanitizedJson = ReportGenerator.sanitizeJson(flow);
+    // terser does its own sanitization, but keep this basic replace for when
+    // we want to generate a report without minification.
+    const sanitizedJavascript = reportAssets.FLOW_REPORT_JAVASCRIPT.replace(/<\//g, '\\u003c/');
     return ReportGenerator.replaceStrings(reportAssets.FLOW_REPORT_TEMPLATE, [
       /* eslint-disable max-len */
       {search: '%%LIGHTHOUSE_FLOW_JSON%%', replacement: sanitizedJson},
-      {search: '%%LIGHTHOUSE_FLOW_JAVASCRIPT%%', replacement: reportAssets.FLOW_REPORT_JAVASCRIPT},
+      {search: '%%LIGHTHOUSE_FLOW_JAVASCRIPT%%', replacement: sanitizedJavascript},
       {search: '/*%%LIGHTHOUSE_FLOW_CSS%%*/', replacement: reportAssets.FLOW_REPORT_CSS},
       /* eslint-enable max-len */
     ]);


### PR DESCRIPTION
This regressed in b7658 because the extension in the build script was modified without changing the way the mocked module was being imported.

I added a test to prevent this in the future.

Also, a drive-by fix for the flow report generation when `terser` is not in use (I disabled it while debugging, and was confused when the pptr tests failed to parse the HTML...). The fix is exactly the same for what's done for the standalone report.