### PR TITLE
core(types): use union of `puppeteer` and `puppeteer-core`

### DIFF
--- a/core/scripts/benchmark-plus-extras.js
+++ b/core/scripts/benchmark-plus-extras.js
@@ -16,9 +16,9 @@ import {getChromePath} from 'chrome-launcher';
 
 import {pageFunctions} from '../lib/page-functions.js';
 
-/** @param {LH.Puppeteer.Page} page */
+/** @param {puppeteer.Page} page */
 async function runOctane(page) {
-  /** @param {LH.Puppeteer.ConsoleMessage} message */
+  /** @param {puppeteer.ConsoleMessage} message */
   const pageLogger = message => process.stdout.write(`  ${message.text()}\n`);
 
   process.stdout.write(`Running Octane...\n`);
@@ -43,7 +43,7 @@ async function runOctane(page) {
   page.off('console', pageLogger);
 }
 
-/** @param {LH.Puppeteer.Page} page */
+/** @param {puppeteer.Page} page */
 async function runSpeedometer(page) {
   process.stdout.write(`Running Speedometer...\n`);
   await page.goto('https://browserbench.org/Speedometer2.0/', {waitUntil: 'networkidle0'});

--- a/core/scripts/update-flow-fixtures.js
+++ b/core/scripts/update-flow-fixtures.js
@@ -41,7 +41,7 @@ const args = yargs(process.argv.slice(2))
   })
   .parseSync();
 
-/** @param {LH.Puppeteer.Page} page */
+/** @param {puppeteer.Page} page */
 async function waitForImagesToLoad(page) {
   const TIMEOUT = 30_000;
   const QUIET_WINDOW = 3_000;

--- a/core/test/scenarios/pptr-test-utils.js
+++ b/core/test/scenarios/pptr-test-utils.js
@@ -29,8 +29,8 @@ function createTestState() {
   }});
 
   return {
-    browser: /** @type {LH.Puppeteer.Browser} */ (any('browser')),
-    page: /** @type {LH.Puppeteer.Page} */ (any('page')),
+    browser: /** @type {puppeteer.Browser} */ (any('browser')),
+    page: /** @type {puppeteer.Page} */ (any('page')),
     server: /** @type {StaticServer} */ (any('server')),
     secondaryServer: /** @type {StaticServer} */ (any('server')),
     serverBaseUrl: '',

--- a/types/global-lh.d.ts
+++ b/types/global-lh.d.ts
@@ -21,7 +21,7 @@ import Protocol_ from './protocol';
 import * as Settings from './lhr/settings';
 import Treemap_ from './lhr/treemap';
 import UserFlow_ from './user-flow';
-import puppeteer from 'puppeteer-core';
+import Puppeteer_ from './puppeteer';
 
 // Construct hierarchy of global types under the LH namespace.
 declare global {
@@ -29,7 +29,7 @@ declare global {
     export type ArbitraryEqualityMap = ArbitraryEqualityMap_;
     export type NavigationRequestor = string | (() => Promise<void> | void);
 
-    export import Puppeteer = puppeteer;
+    export import Puppeteer = Puppeteer_;
 
     // artifacts.d.ts
     export import Artifacts = Artifacts_.Artifacts;

--- a/types/puppeteer.d.ts
+++ b/types/puppeteer.d.ts
@@ -1,3 +1,9 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
 import puppeteer from 'puppeteer';
 import puppeteerCore from 'puppeteer-core';
 

--- a/types/puppeteer.d.ts
+++ b/types/puppeteer.d.ts
@@ -1,0 +1,16 @@
+import puppeteer from 'puppeteer';
+import puppeteerCore from 'puppeteer-core';
+
+/**
+ * @fileoverview Lighthouse should be compatible with puppeteer and puppeteer-core even though the types can be slightly different between the two packages.
+ * Anytime we want to use a Puppeteer type within Lighthouse, we should pull the union type from here rather than one of the packages directly.
+ */
+
+declare module Puppeteer {
+  export type Browser = puppeteerCore.Browser | puppeteer.Browser;
+  export type Page = puppeteerCore.Page | puppeteer.Page;
+  export type CDPSession = puppeteerCore.CDPSession | puppeteer.CDPSession;
+  export type Connection = puppeteerCore.Connection | puppeteer.Connection;
+}
+
+export default Puppeteer;


### PR DESCRIPTION
The types between these two packages are independent https://github.com/puppeteer/puppeteer/issues/9018

If we want to support both, we should use the union between them to ensure proper type safety.

Some scripts import puppeteer themselves but use the types in `LH.Puppeteer`. These scripts should now be using the types from whatever puppeteer they pull in.