### PR TITLE
core(build): inline-fs error if file missing, ignorePaths

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -192,7 +192,12 @@ async function buildBundle(entryPath, distPath, opts = {minify: true}) {
       }),
       rollupPlugins.json(),
       rollupPlugins.removeModuleDirCalls(),
-      rollupPlugins.inlineFs({verbose: Boolean(process.env.DEBUG)}),
+      rollupPlugins.inlineFs({
+        verbose: Boolean(process.env.DEBUG),
+        ignorePaths: [
+          require.resolve('puppeteer-core/lib/esm/puppeteer/common/Page.js'),
+        ],
+      }),
       rollupPlugins.commonjs({
         // https://github.com/rollup/plugins/issues/922
         ignoreGlobal: true,

--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -192,7 +192,7 @@ async function buildBundle(entryPath, distPath, opts = {minify: true}) {
       }),
       rollupPlugins.json(),
       rollupPlugins.removeModuleDirCalls(),
-      rollupPlugins.inlineFs({verbose: false}),
+      rollupPlugins.inlineFs({verbose: Boolean(process.env.DEBUG)}),
       rollupPlugins.commonjs({
         // https://github.com/rollup/plugins/issues/922
         ignoreGlobal: true,

--- a/build/build-extension.js
+++ b/build/build-extension.js
@@ -40,7 +40,7 @@ async function buildEntryPoint() {
         '___BROWSER_BRAND___': browserBrand,
       }),
       rollupPlugins.nodeResolve(),
-      rollupPlugins.inlineFs({verbose: false}),
+      rollupPlugins.inlineFs({verbose: Boolean(process.env.DEBUG)}),
       rollupPlugins.terser(),
     ],
   });

--- a/build/plugins/inline-fs.js
+++ b/build/plugins/inline-fs.js
@@ -75,8 +75,8 @@ async function inlineFs(code, filepath) {
     }
     if (maybeInBlockComment) {
       const err = new Error('ignoring potential match because likely inside a block comment');
-      const line = code.substring(0, foundIndex).split(/\r\n|\r|\n/).length;
-      warnings.push(createWarning(err, filepath, {line, column: 1}));
+      const location = acorn.getLineInfo(code, foundIndex);
+      warnings.push(createWarning(err, filepath, location));
       continue;
     }
 

--- a/build/plugins/inline-fs.js
+++ b/build/plugins/inline-fs.js
@@ -64,22 +64,6 @@ async function inlineFs(code, filepath) {
   for (const foundIndex of foundIndices) {
     if (foundIndex === undefined) continue; // https://github.com/microsoft/TypeScript/issues/36788
 
-    // First iterate backwards until a newline to determine if we are in a block comment.
-    let maybeInBlockComment = false;
-    for (let i = foundIndex; i > 0; i--) {
-      if (code[i] === '*') {
-        maybeInBlockComment = true;
-        break;
-      }
-      if (code[i] === '\n') break;
-    }
-    if (maybeInBlockComment) {
-      const err = new Error('ignoring potential match because likely inside a block comment');
-      const location = acorn.getLineInfo(code, foundIndex);
-      warnings.push(createWarning(err, filepath, location));
-      continue;
-    }
-
     let parsed;
     try {
       parsed = parseExpressionAt(code, foundIndex, {ecmaVersion: 'latest'});

--- a/build/plugins/rollup-plugin-inline-fs.js
+++ b/build/plugins/rollup-plugin-inline-fs.js
@@ -14,6 +14,7 @@ import {LH_ROOT} from '../../root.js';
 /**
  * @typedef Options
  * @property {boolean} [verbose] If true, turns on verbose logging, e.g. log instances where fs methods could not be inlined.
+ * @property {string[]} [ignorePaths] Absoulte paths of files to not process for inlining.
  */
 
 /**
@@ -29,9 +30,13 @@ function rollupInlineFs(options = {}) {
     /**
      * @param {string} originalCode
      * @param {string} filepath
-     * @return {Promise<string|null>}
+     * @return {Promise<import('rollup').TransformResult>}
      */
     async transform(originalCode, filepath) {
+      if (options.ignorePaths?.includes(filepath)) {
+        return;
+      }
+
       // TODO(bckenny): add source maps, watch files.
       const {code, warnings} = await inlineFs(originalCode, filepath);
 

--- a/build/test/plugins/inline-fs-test.js
+++ b/build/test/plugins/inline-fs-test.js
@@ -270,33 +270,6 @@ describe('inline-fs', () => {
         await expect(inlineFs(content, filepath)).rejects.toThrow('ENOENT');
       });
 
-      it('ignores matches inside block comment', async () => {
-        fs.writeFileSync(tmpPath, 'contents');
-        const content = `
-        /**
-         * fs.readFileSync('i-never-exist.lol', 'utf8');
-         */
-        const myTextContent = fs.readFileSync('${tmpPath}', 'utf8');
-        `;
-        const result = await inlineFs(content, filepath);
-        expect(result).toEqual({
-          code: `
-        /**
-         * fs.readFileSync('i-never-exist.lol', 'utf8');
-         */
-        const myTextContent = "contents";
-        `,
-          warnings: [{
-            text: 'ignoring potential match because likely inside a block comment',
-            location: {
-              file: filepath,
-              line: 3,
-              column: 11,
-            },
-          }],
-        });
-      });
-
       it('inlines multiple fs.readFileSync calls', async () => {
         fs.writeFileSync(tmpPath, 'some text content');
         // eslint-disable-next-line max-len

--- a/build/test/plugins/inline-fs-test.js
+++ b/build/test/plugins/inline-fs-test.js
@@ -279,14 +279,21 @@ describe('inline-fs', () => {
         const myTextContent = fs.readFileSync('${tmpPath}', 'utf8');
         `;
         const result = await inlineFs(content, filepath);
-        expect(result).toMatchObject({
+        expect(result).toEqual({
           code: `
         /**
          * fs.readFileSync('i-never-exist.lol', 'utf8');
          */
         const myTextContent = "contents";
         `,
-          warnings: [{text: /ignoring potential match/}],
+          warnings: [{
+            text: 'ignoring potential match because likely inside a block comment',
+            location: {
+              file: filepath,
+              line: 3,
+              column: 11,
+            },
+          }],
         });
       });
 


### PR DESCRIPTION
I noticed this when I tried to run `yarn build-lr` in a clean checkout, which silently messes up because there is no `dist/report` so the JS inlining fails by simply emitting code that tried to read the file with `fs`. Instead, the plugin should throw a fatal error.

In doing this, I had to skip a case the plugin came across in `node_modules/puppeteer-core/lib/esm/puppeteer/common/Page.js`:
<img width="588" alt="image" src="https://user-images.githubusercontent.com/4071474/194404058-cf2f8f14-4a11-49c7-87b7-cfb41a9ae0de.png">
