### PR TITLE
tests: add missing await on promise assertions

### DIFF
--- a/core/test/computed/metrics/cumulative-layout-shift-test.js
+++ b/core/test/computed/metrics/cumulative-layout-shift-test.js
@@ -31,7 +31,7 @@ describe('Metrics: CLS', () => {
     });
 
     it('throws if layout shift events are found without weighted_score_delta', async () => {
-      expect(_ => CumulativeLayoutShift.request(oldMetricsTrace, context)).rejects
+      await expect(CumulativeLayoutShift.request(oldMetricsTrace, context)).rejects
           .toThrow('CLS missing weighted_score_delta');
     });
 

--- a/core/test/computed/metrics/largest-contentful-paint-all-frames-test.js
+++ b/core/test/computed/metrics/largest-contentful-paint-all-frames-test.js
@@ -25,7 +25,7 @@ describe('Metrics: LCP from all frames', () => {
     const resultPromise = LargestContentfulPaintAllFrames.request({gatherContext, trace: traceAllFrames, devtoolsLog: devtoolsLogAllFrames, settings}, context); // eslint-disable-line max-len
 
     // TODO: Implement lantern solution for LCP all frames.
-    expect(resultPromise).rejects.toThrow();
+    await expect(resultPromise).rejects.toThrow();
   });
 
   it('should compute an observed value', async () => {

--- a/core/test/config/config-helpers-test.js
+++ b/core/test/config/config-helpers-test.js
@@ -232,22 +232,23 @@ describe('.mergePlugins', () => {
     expect(config.categories).toHaveProperty('lighthouse-plugin-no-groups');
   });
 
-  it('validate plugin name', () => {
+  it('validate plugin name', async () => {
     const configJson = {audits: ['installable-manifest', 'metrics']};
     const flags = {plugins: ['not-a-plugin']};
-    expect(mergePlugins(configJson, configDir, flags)).rejects.toThrow(/does not start/);
+    await expect(mergePlugins(configJson, configDir, flags)).rejects.toThrow(/does not start/);
   });
 
-  it('validate plugin existence', () => {
+  it('validate plugin existence', async () => {
     const configJson = {audits: ['installable-manifest', 'metrics']};
     const flags = {plugins: ['lighthouse-plugin-missing']};
-    expect(mergePlugins(configJson, configDir, flags)).rejects.toThrow(/Unable to locate plugin/);
+    await expect(mergePlugins(configJson, configDir, flags)).rejects
+      .toThrow(/Unable to locate plugin/);
   });
 
-  it('validate plugin structure', () => {
+  it('validate plugin structure', async () => {
     const configJson = {audits: ['installable-manifest', 'metrics']};
     const flags = {plugins: ['lighthouse-plugin-no-category']};
-    expect(mergePlugins(configJson, configDir, flags)).rejects.toThrow(/no valid category/);
+    await expect(mergePlugins(configJson, configDir, flags)).rejects.toThrow(/no valid category/);
   });
 });
 
@@ -367,8 +368,8 @@ describe('.resolveGathererToDefn', () => {
     });
   });
 
-  it('throws for invalid gathererDefn', () => {
-    expect(resolveGathererToDefn({})).rejects.toThrow(/Invalid Gatherer type/);
+  it('throws for invalid gathererDefn', async () => {
+    await expect(resolveGathererToDefn({})).rejects.toThrow(/Invalid Gatherer type/);
   });
 });
 
@@ -407,8 +408,8 @@ describe('.resolveAuditsToDefns', () => {
     ]);
   });
 
-  it('throws for invalid auditDefns', () => {
-    expect(resolveAuditsToDefns([new Gatherer()])).rejects.toThrow(/Invalid Audit type/);
+  it('throws for invalid auditDefns', async () => {
+    await expect(resolveAuditsToDefns([new Gatherer()])).rejects.toThrow(/Invalid Audit type/);
   });
 });
 

--- a/core/test/config/config-test.js
+++ b/core/test/config/config-test.js
@@ -25,7 +25,7 @@ describe('Fraggle Rock Config', () => {
   });
 
   it('should throw if the config path is not absolute', async () => {
-    expect(initializeConfig(gatherMode, undefined, {configPath: '../relative/path'}))
+    await expect(initializeConfig(gatherMode, undefined, {configPath: '../relative/path'}))
       .rejects.toThrow(/must be an absolute path/);
   });
 
@@ -85,11 +85,11 @@ describe('Fraggle Rock Config', () => {
     });
   });
 
-  it('should throw on invalid artifact definitions', () => {
+  it('should throw on invalid artifact definitions', async () => {
     const nonFRGatherer = new BaseGatherer();
     nonFRGatherer.getArtifact = jestMock.fn();
     const configJson = {artifacts: [{id: 'LegacyGather', gatherer: {instance: nonFRGatherer}}]};
-    expect(initializeConfig(gatherMode, configJson)).rejects.toThrow(/FRGatherer gatherer/);
+    await expect(initializeConfig(gatherMode, configJson)).rejects.toThrow(/FRGatherer gatherer/);
   });
 
   it('should filter configuration by gatherMode', async () => {
@@ -206,24 +206,24 @@ describe('Fraggle Rock Config', () => {
       });
     });
 
-    it('should throw when dependencies are out of order in artifacts', () => {
+    it('should throw when dependencies are out of order in artifacts', async () => {
       if (!configJson.artifacts) throw new Error('Failed to run beforeEach');
       configJson.artifacts = [configJson.artifacts[1], configJson.artifacts[0]];
-      expect(initializeConfig('snapshot', configJson))
+      await expect(initializeConfig('snapshot', configJson))
         .rejects.toThrow(/Failed to find dependency/);
     });
 
-    it('should throw when timespan needs snapshot', () => {
+    it('should throw when timespan needs snapshot', async () => {
       dependentGatherer.meta.supportedModes = ['timespan'];
       dependencyGatherer.meta.supportedModes = ['snapshot'];
-      expect(initializeConfig('navigation', configJson))
+      await expect(initializeConfig('navigation', configJson))
         .rejects.toThrow(/Dependency.*is invalid/);
     });
 
-    it('should throw when timespan needs navigation', () => {
+    it('should throw when timespan needs navigation', async () => {
       dependentGatherer.meta.supportedModes = ['timespan'];
       dependencyGatherer.meta.supportedModes = ['navigation'];
-      expect(initializeConfig('navigation', configJson))
+      await expect(initializeConfig('navigation', configJson))
         .rejects.toThrow(/Dependency.*is invalid/);
     });
   });
@@ -432,7 +432,7 @@ describe('Fraggle Rock Config', () => {
     };
 
     // https://github.com/facebook/jest/issues/11438
-    // expect(initializeConfig(extensionConfig, {gatherMode: 'navigation'}))
+    // await expect(initializeConfig(extensionConfig, {gatherMode: 'navigation'}))
     //   .rejects.toThrow(/did not support any gather modes/);
     try {
       await initializeConfig('navigation', extensionConfig);

--- a/core/test/config/config-test.js
+++ b/core/test/config/config-test.js
@@ -431,15 +431,8 @@ describe('Fraggle Rock Config', () => {
       artifacts: [{id: 'artifact', gatherer: {instance: new BaseGatherer()}}],
     };
 
-    // https://github.com/facebook/jest/issues/11438
-    // await expect(initializeConfig(extensionConfig, {gatherMode: 'navigation'}))
-    //   .rejects.toThrow(/did not support any gather modes/);
-    try {
-      await initializeConfig('navigation', extensionConfig);
-      throw new Error('did not throw');
-    } catch (err) {
-      expect(err.message).toMatch(/did not support any gather modes/);
-    }
+    await expect(initializeConfig('navigation', extensionConfig)).rejects
+      .toThrow(/did not support any gather modes/);
   });
 });
 

--- a/core/test/legacy/config/config-test.js
+++ b/core/test/legacy/config/config-test.js
@@ -132,7 +132,7 @@ describe('Config', () => {
     );
   });
 
-  it('throws when an audit requires an artifact with no gatherer supplying it', () => {
+  it('throws when an audit requires an artifact with no gatherer supplying it', async () => {
     class NeedsWhatYouCantGive extends Audit {
       static get meta() {
         return {
@@ -153,7 +153,7 @@ describe('Config', () => {
       static audit() {}
     }
 
-    expect(Config.fromJson({
+    await expect(Config.fromJson({
       extends: 'lighthouse:default',
       audits: [NeedsWhatYouCantGive],
     // eslint-disable-next-line max-len
@@ -805,12 +805,12 @@ describe('Config', () => {
     assert.equal(config.passes[0].networkQuietThresholdMs, 10003);
   });
 
-  it('only supports `lighthouse:default` extension', () => {
+  it('only supports `lighthouse:default` extension', async () => {
     const createConfig = extendsValue => Config.fromJson({extends: extendsValue});
 
-    expect(createConfig(true)).rejects.toThrow(/default` is the only valid extension/);
-    expect(createConfig('lighthouse')).rejects.toThrow(/default` is the only valid/);
-    expect(createConfig('lighthouse:full')).rejects.toThrow(/default` is the only valid/);
+    await expect(createConfig(true)).rejects.toThrow(/default` is the only valid extension/);
+    await expect(createConfig('lighthouse')).rejects.toThrow(/default` is the only valid/);
+    await expect(createConfig('lighthouse:full')).rejects.toThrow(/default` is the only valid/);
   });
 
   it('merges settings with correct priority', async () => {


### PR DESCRIPTION
If these statements aren't `awaited`, the result of the promise has no impact on the test.