### PR TITLE
WIP: bfcache audit

### DIFF
--- a/core/audits/bf-cache.js
+++ b/core/audits/bf-cache.js
@@ -1,0 +1,116 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {Audit} from './audit.js';
+import * as i18n from '../lib/i18n/i18n.js';
+import {NotRestoredReasonDescription} from '../lib/bfcache-strings.js';
+
+/* eslint-disable max-len */
+const UIStrings = {
+  /** TODO */
+  title: 'Back/forward cache is used',
+  /** TODO */
+  failureTitle: 'Back/forward cache is not used',
+  /** TODO */
+  description: 'The back/forward cache can speed up the page load after navigating away.',
+  /** TODO */
+  failureColumn: 'Failure reason',
+  /**
+   * @description [ICU Syntax] Label for an audit identifying the number of back/forward cache failure reasons found in the page.
+   */
+  displayValue: `{itemCount, plural,
+    =1 {1 failure reason}
+    other {# failure reasons}
+    }`,
+  /**
+   * @description Error message describing a DevTools error id that was found and has not been identified by this audit.
+   * @example {platform-not-supported-on-android} reason
+   */
+  unknownReason: `Back/forward cache failure reason '{reason}' is not recognized`,
+};
+/* eslint-enable max-len */
+
+const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
+
+class BFCache extends Audit {
+  /**
+   * @return {LH.Audit.Meta}
+   */
+  static get meta() {
+    return {
+      id: 'bf-cache',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      supportedModes: ['navigation'],
+      requiredArtifacts: ['BFCacheErrors'],
+    };
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @return {Array<LH.IcuMessage | string>}
+   */
+  static getBfCacheErrors(artifacts) {
+    const bfCacheErrors = artifacts.BFCacheErrors.errors;
+    const i18nErrors = [];
+
+    for (const err of bfCacheErrors) {
+      // Only show errors which can be addressed by the user.
+      if (err.type !== 'PageSupportNeeded') continue;
+
+
+      const matchingString = NotRestoredReasonDescription[err.reason];
+
+      // Handle an errorId we don't recognize.
+      if (matchingString === undefined) {
+        i18nErrors.push(str_(UIStrings.unknownReason, {reason: err.reason}));
+        continue;
+      }
+
+      i18nErrors.push(matchingString.name);
+    }
+
+    return i18nErrors;
+  }
+
+  /**
+   * @param {LH.Artifacts} artifacts
+   * @return {Promise<LH.Audit.Product>}
+   *
+   */
+  static async audit(artifacts) {
+    const i18nErrors = BFCache.getBfCacheErrors(artifacts);
+
+    /** @type {LH.Audit.Details.Table['headings']} */
+    const headings = [
+      {key: 'reason', valueType: 'text', label: str_(UIStrings.failureColumn)},
+    ];
+
+    /** @type {LH.Audit.Details.Table['items']} */
+    const errorReasons = i18nErrors.map(reason => {
+      return {reason};
+    });
+
+    const details = Audit.makeTableDetails(headings, errorReasons);
+
+    if (errorReasons.length === 0) {
+      return {
+        score: 1,
+        details,
+      };
+    }
+
+    return {
+      score: 0,
+      displayValue: str_(UIStrings.displayValue, {itemCount: errorReasons.length}),
+      details,
+    };
+  }
+}
+
+export default BFCache;
+export {UIStrings};

--- a/core/config/default-config.js
+++ b/core/config/default-config.js
@@ -128,6 +128,7 @@ const artifacts = {
   Trace: '',
   Accessibility: '',
   AnchorElements: '',
+  BFCacheErrors: '',
   CacheContents: '',
   ConsoleMessages: '',
   CSSUsage: '',
@@ -216,8 +217,11 @@ const defaultConfig = {
     {id: artifacts.devtoolsLogs, gatherer: 'devtools-log-compat'},
     {id: artifacts.traces, gatherer: 'trace-compat'},
 
-    // FullPageScreenshot comes at the very end so all other node analysis is captured.
+    // FullPageScreenshot comes at the end so all other node analysis is captured.
     {id: artifacts.FullPageScreenshot, gatherer: 'full-page-screenshot'},
+
+    // BFCacheErrors comes at the very end because it can perform a page navigation.
+    {id: artifacts.BFCacheErrors, gatherer: 'bf-cache-errors'},
   ],
   audits: [
     'is-on-https',
@@ -373,6 +377,7 @@ const defaultConfig = {
     'seo/canonical',
     'seo/manual/structured-data',
     'work-during-interaction',
+    'bf-cache',
   ],
   groups: {
     'metrics': {
@@ -515,6 +520,7 @@ const defaultConfig = {
         {id: 'no-unload-listeners', weight: 0},
         {id: 'uses-responsive-images-snapshot', weight: 0},
         {id: 'work-during-interaction', weight: 0},
+        {id: 'bf-cache', weight: 0},
 
         // Budget audits.
         {id: 'performance-budget', weight: 0, group: 'budgets'},

--- a/core/config/filters.js
+++ b/core/config/filters.js
@@ -32,7 +32,7 @@ const filterResistantAuditIds = ['full-page-screenshot'];
 // Some artifacts are used by the report for additional information.
 // Always run these artifacts even if audits do not request them.
 // These are similar to base artifacts but they cannot be run in all 3 modes.
-const filterResistantArtifactIds = ['Stacks', 'NetworkUserAgent'];
+const filterResistantArtifactIds = ['Stacks', 'NetworkUserAgent', 'BFCacheErrors'];
 
 /**
  * Returns the set of audit IDs used in the list of categories.

--- a/core/gather/driver.js
+++ b/core/gather/driver.js
@@ -84,7 +84,7 @@ class Driver {
   /** @return {Promise<void>} */
   async disconnect() {
     if (this.defaultSession === throwingSession) return;
-    this._targetManager?.disable();
+    await this._targetManager?.disable();
     await this.defaultSession.dispose();
   }
 }

--- a/core/gather/gatherers/bf-cache-errors.js
+++ b/core/gather/gatherers/bf-cache-errors.js
@@ -1,0 +1,57 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import FRGatherer from '../base-gatherer.js';
+import {waitForFrameNavigated, waitForLoadEvent} from '../driver/wait-for-condition.js';
+
+class BFCacheErrors extends FRGatherer {
+  /** @type {LH.Gatherer.GathererMeta} */
+  meta = {
+    supportedModes: ['navigation'],
+  };
+
+  /**
+   * @param {LH.Gatherer.FRTransitionalContext} context
+   * @return {Promise<LH.Artifacts.BFCacheErrors>} All visible tap targets with their positions and sizes
+   */
+  async getArtifact(context) {
+    const session = context.driver.defaultSession;
+
+    /**
+     * @type {LH.Crdp.Page.BackForwardCacheNotRestoredExplanation[]}
+     */
+    let errors = [];
+
+    /**
+     * @param {LH.Crdp.Page.BackForwardCacheNotUsedEvent} event
+     */
+    function onBfCacheNotUsed(event) {
+      errors = event.notRestoredExplanations;
+    }
+
+    session.on('Page.backForwardCacheNotUsed', onBfCacheNotUsed);
+
+    const history = await session.sendCommand('Page.getNavigationHistory');
+    const entry = history.entries[history.currentIndex];
+
+    await Promise.all([
+      session.sendCommand('Page.navigate', {url: 'chrome://terms'}),
+      waitForLoadEvent(session, 0).promise,
+    ]);
+
+    await Promise.all([
+      session.sendCommand('Page.navigateToHistoryEntry', {entryId: entry.id}),
+      waitForFrameNavigated(session).promise,
+    ]);
+
+    session.off('Page.backForwardCacheNotUsed', onBfCacheNotUsed);
+
+    return {errors};
+  }
+}
+
+export default BFCacheErrors;
+

--- a/core/scripts/i18n/collect-strings.js
+++ b/core/scripts/i18n/collect-strings.js
@@ -718,6 +718,8 @@ function checkKnownFixedCollisions(strings) {
       'Document has a valid $MARKDOWN_SNIPPET_0$',
       'Failing Elements',
       'Failing Elements',
+      'Failure reason',
+      'Failure reason',
       'Name',
       'Name',
       'Pages that use portals are not currently eligible for back/forward cache.',

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -3675,6 +3675,14 @@
             "description": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more about Structured Data](https://web.dev/structured-data/).",
             "score": null,
             "scoreDisplayMode": "manual"
+          },
+          "bf-cache": {
+            "id": "bf-cache",
+            "title": "Back/forward cache is used",
+            "description": "The back/forward cache can speed up the page load after navigating away.",
+            "score": null,
+            "scoreDisplayMode": "error",
+            "errorMessage": "Required BFCacheErrors gatherer did not run."
           }
         },
         "configSettings": {
@@ -3979,6 +3987,10 @@
               },
               {
                 "id": "no-unload-listeners",
+                "weight": 0
+              },
+              {
+                "id": "bf-cache",
                 "weight": 0
               },
               {
@@ -6024,12 +6036,18 @@
             },
             {
               "startTime": 226,
+              "name": "lh:audit:bf-cache",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 227,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 227
+          "total": 228
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -7208,6 +7226,21 @@
             ],
             "core/audits/seo/manual/structured-data.js | description": [
               "audits[structured-data].description"
+            ],
+            "core/audits/bf-cache.js | title": [
+              "audits[bf-cache].title"
+            ],
+            "core/audits/bf-cache.js | description": [
+              "audits[bf-cache].description"
+            ],
+            "core/lib/lh-error.js | missingRequiredArtifact": [
+              {
+                "values": {
+                  "errorCode": "MISSING_REQUIRED_ARTIFACT",
+                  "artifactName": "BFCacheErrors"
+                },
+                "path": "audits[bf-cache].errorMessage"
+              }
             ],
             "core/config/default-config.js | performanceCategoryTitle": [
               "categories.performance.title"
@@ -17807,6 +17840,14 @@
             "description": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more about Structured Data](https://web.dev/structured-data/).",
             "score": null,
             "scoreDisplayMode": "manual"
+          },
+          "bf-cache": {
+            "id": "bf-cache",
+            "title": "Back/forward cache is used",
+            "description": "The back/forward cache can speed up the page load after navigating away.",
+            "score": null,
+            "scoreDisplayMode": "error",
+            "errorMessage": "Required BFCacheErrors gatherer did not run."
           }
         },
         "configSettings": {
@@ -18111,6 +18152,10 @@
               },
               {
                 "id": "no-unload-listeners",
+                "weight": 0
+              },
+              {
+                "id": "bf-cache",
                 "weight": 0
               },
               {
@@ -20138,12 +20183,18 @@
             },
             {
               "startTime": 223,
+              "name": "lh:audit:bf-cache",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 224,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 224
+          "total": 225
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -21338,6 +21389,21 @@
             ],
             "core/audits/seo/manual/structured-data.js | description": [
               "audits[structured-data].description"
+            ],
+            "core/audits/bf-cache.js | title": [
+              "audits[bf-cache].title"
+            ],
+            "core/audits/bf-cache.js | description": [
+              "audits[bf-cache].description"
+            ],
+            "core/lib/lh-error.js | missingRequiredArtifact": [
+              {
+                "values": {
+                  "errorCode": "MISSING_REQUIRED_ARTIFACT",
+                  "artifactName": "BFCacheErrors"
+                },
+                "path": "audits[bf-cache].errorMessage"
+              }
             ],
             "core/config/default-config.js | performanceCategoryTitle": [
               "categories.performance.title"

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -5819,6 +5819,14 @@
       "description": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more about Structured Data](https://web.dev/structured-data/).",
       "score": null,
       "scoreDisplayMode": "manual"
+    },
+    "bf-cache": {
+      "id": "bf-cache",
+      "title": "Back/forward cache is used",
+      "description": "The back/forward cache can speed up the page load after navigating away.",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required BFCacheErrors gatherer did not run."
     }
   },
   "configSettings": {
@@ -6225,6 +6233,10 @@
         },
         {
           "id": "no-unload-listeners",
+          "weight": 0
+        },
+        {
+          "id": "bf-cache",
           "weight": 0
         },
         {
@@ -8282,6 +8294,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:audit:bf-cache",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:runner:generate",
         "duration": 100,
         "entryType": "measure"
@@ -9693,6 +9711,21 @@
       ],
       "core/audits/seo/manual/structured-data.js | description": [
         "audits[structured-data].description"
+      ],
+      "core/audits/bf-cache.js | title": [
+        "audits[bf-cache].title"
+      ],
+      "core/audits/bf-cache.js | description": [
+        "audits[bf-cache].description"
+      ],
+      "core/lib/lh-error.js | missingRequiredArtifact": [
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "BFCacheErrors"
+          },
+          "path": "audits[bf-cache].errorMessage"
+        }
       ],
       "core/config/default-config.js | performanceCategoryTitle": [
         "categories.performance.title"

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -425,6 +425,24 @@
   "core/audits/autocomplete.js | warningOrder": {
     "message": "Review order of tokens: \"{tokens}\" in {snippet}"
   },
+  "core/audits/bf-cache.js | description": {
+    "message": "The back/forward cache can speed up the page load after navigating away."
+  },
+  "core/audits/bf-cache.js | displayValue": {
+    "message": "{itemCount, plural,\n    =1 {1 failure reason}\n    other {# failure reasons}\n    }"
+  },
+  "core/audits/bf-cache.js | failureColumn": {
+    "message": "Failure reason"
+  },
+  "core/audits/bf-cache.js | failureTitle": {
+    "message": "Back/forward cache is not used"
+  },
+  "core/audits/bf-cache.js | title": {
+    "message": "Back/forward cache is used"
+  },
+  "core/audits/bf-cache.js | unknownReason": {
+    "message": "Back/forward cache failure reason '{reason}' is not recognized"
+  },
   "core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Chrome extensions negatively affected this page's load performance. Try auditing the page in incognito mode or from a Chrome profile without extensions."
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -425,6 +425,24 @@
   "core/audits/autocomplete.js | warningOrder": {
     "message": "R̂év̂íêẃ ôŕd̂ér̂ óf̂ t́ôḱêńŝ: \"{tokens}\" ín̂ {snippet}"
   },
+  "core/audits/bf-cache.js | description": {
+    "message": "T̂h́ê b́âćk̂/f́ôŕŵár̂d́ ĉáĉh́ê ćâń ŝṕêéd̂ úp̂ t́ĥé p̂áĝé l̂óâd́ âf́t̂ér̂ ńâv́îǵât́îńĝ áŵáŷ."
+  },
+  "core/audits/bf-cache.js | displayValue": {
+    "message": "{itemCount, plural,\n    =1 {1 f̂áîĺûŕê ŕêáŝón̂}\n    other {# f́âíl̂úr̂é r̂éâśôńŝ}\n    }"
+  },
+  "core/audits/bf-cache.js | failureColumn": {
+    "message": "F̂áîĺûŕê ŕêáŝón̂"
+  },
+  "core/audits/bf-cache.js | failureTitle": {
+    "message": "B̂áĉḱ/f̂ór̂ẃâŕd̂ ćâćĥé îś n̂ót̂ úŝéd̂"
+  },
+  "core/audits/bf-cache.js | title": {
+    "message": "B̂áĉḱ/f̂ór̂ẃâŕd̂ ćâćĥé îś ûśêd́"
+  },
+  "core/audits/bf-cache.js | unknownReason": {
+    "message": "B̂áĉḱ/f̂ór̂ẃâŕd̂ ćâćĥé f̂áîĺûŕê ŕêáŝón̂ '{reason}' íŝ ńôt́ r̂éĉóĝńîźêd́"
+  },
   "core/audits/bootup-time.js | chromeExtensionsWarning": {
     "message": "Ĉh́r̂óm̂é êx́t̂én̂śîón̂ś n̂éĝát̂ív̂él̂ý âf́f̂éĉt́êd́ t̂h́îś p̂áĝé'ŝ ĺôád̂ ṕêŕf̂ór̂ḿâńĉé. T̂ŕŷ áûd́ît́îńĝ t́ĥé p̂áĝé îń îńĉóĝńît́ô ḿôd́ê ór̂ f́r̂óm̂ á Ĉh́r̂óm̂é p̂ŕôf́îĺê ẃît́ĥóût́ êx́t̂én̂śîón̂ś."
   },

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -122,6 +122,7 @@ export interface GathererArtifacts extends PublicGathererArtifacts,LegacyBaseArt
   Accessibility: Artifacts.Accessibility;
   /** Array of all anchors on the page. */
   AnchorElements: Artifacts.AnchorElement[];
+  BFCacheErrors: Artifacts.BFCacheErrors;
   /** Array of all URLs cached in CacheStorage. */
   CacheContents: string[];
   /** CSS coverage information for styles used by page's final state. */
@@ -408,6 +409,10 @@ declare module Artifacts {
     listeners?: Array<{
       type: LH.Crdp.DOMDebugger.EventListener['type']
     }>
+  }
+
+  interface BFCacheErrors {
+    errors: LH.Crdp.Page.BackForwardCacheNotRestoredExplanation[];
   }
 
   interface Font {


### PR DESCRIPTION

Example result on https://www.espn.com/:

<img width="683" alt="Screen Shot 2022-10-24 at 3 26 37 PM" src="https://user-images.githubusercontent.com/6752989/197641493-27019b60-0fbc-4876-8d9b-bbdc0e39209f.png">

<img width="791" alt="Screen Shot 2022-10-24 at 3 17 46 PM" src="https://user-images.githubusercontent.com/6752989/197640891-3e8f4620-97e7-4126-87bb-0c1e154a6182.png">

Changes we should consider:
- Using the [explanations tree](https://chromedevtools.github.io/devtools-protocol/tot/Page/#type-BackForwardCacheNotRestoredExplanationTree) to identify which frame the errors are referring to. We can provide more insight than "The page has an unload handler in a sub frame".
- Right now, the audit only fails when there are *actionable* failures ([PageSupportNeeded reason type](https://chromedevtools.github.io/devtools-protocol/tot/Page/#type-BackForwardCacheNotRestoredReasonType)). It's common for bf cache to fail for reasons related to the browser. Perhaps we should still surface these "non actionable" errors but still pass the audit. The DT panel lists them under "Pending support" and "Not Actionable" sections.

Ref
https://github.com/GoogleChrome/lighthouse/issues/13960
