### PR TITLE
docs: fix multiline xvfb-run command

### DIFF
--- a/docs/headless-chrome.md
+++ b/docs/headless-chrome.md
@@ -46,7 +46,7 @@ TMP_PROFILE_DIR=$(mktemp -d -t lighthouse.XXXXXXXXXX)
 
 # start up chromium inside xvfb
 xvfb-run --server-args='-screen 0, 1024x768x16' \
-    chromium-browser --user-data-dir=$TMP_PROFILE_DIR
+    chromium-browser --user-data-dir=$TMP_PROFILE_DIR \
     --start-maximized \
     --no-first-run \
     --remote-debugging-port=9222 "about:blank"


### PR DESCRIPTION
**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

This is a documentation fix as the xvfb-run command for headless chromium does not currently work.

<!-- Describe the need for this change -->

This PR adds a trailing backslash to a multiline command.  Without the trailing backslash, the command is incomplete when pasted.

Output without the change looks something like this (There are other warnings that can be ignored):

```
/etc/chromium.d/README: line 1: Any: command not found                                                                                      
dpkg-query: no packages found matching bluealsa
[17369:17369:1027/092051.805408:ERROR:component_loader.cc(193)] Failed to parse extension manifest.
[17435:17435:1027/092052.296294:ERROR:gpu_init.cc(486)] Passthrough is not supported, GL is egl, ANGLE is
[17435:17435:1027/092052.369356:ERROR:viz_main_impl.cc(186)] Exiting GPU process due to errors during initialization
[17521:17521:1027/092052.734923:ERROR:gpu_init.cc(486)] Passthrough is not supported, GL is egl, ANGLE is
[17521:17521:1027/092052.807645:ERROR:viz_main_impl.cc(186)] Exiting GPU process due to errors during initialization
[17547:17547:1027/092052.935525:ERROR:gpu_memory_buffer_support_x11.cc(44)] dri3 extension not supported.
[17513:7:1027/092052.949790:ERROR:command_buffer_proxy_impl.cc(128)] ContextResult::kTransientFailure: Failed to send GpuControl.CreateComma
ndBuffer.
^C[17547:17547:1027/092531.004289:ERROR:connection.cc(46)] X connection error received.
[17547:17558:1027/092531.013258:ERROR:connection.cc(46)] X connection error received.
-bash: --start-maximized: command not found
```

lighthouse then looks like this when it tries to connect (There are other warnings that can be ignored):

```
  LH:ChromeLauncher No debugging port found on port 9222, launching a new Chrome. +0ms
  LH:ChromeLauncher Waiting for browser. +88ms
  LH:ChromeLauncher Waiting for browser... +1ms
...
  LH:ChromeLauncher Waiting for browser.....................................................................................................
.. +503ms
  LH:ChromeLauncher:error connect ECONNREFUSED 127.0.0.1:9222 +4ms
  LH:ChromeLauncher:error Logging contents of /tmp/lighthouse.OycuoNt/chrome-err.log +0ms
  LH:ChromeLauncher:error /etc/chromium.d/README: line 1: Any: command not found
  LH:ChromeLauncher:error dpkg-query: no packages found matching bluealsa
  LH:ChromeLauncher:error [17757:17757:1027/092133.850895:ERROR:ozone_platform_x11.cc(247)] Missing X server or $DISPLAY
  LH:ChromeLauncher:error [17757:17757:1027/092133.851052:ERROR:env.cc(226)] The platform failed to initialize.  Exiting.
  LH:ChromeLauncher:error  +1ms
Unable to connect to Chrome
```

With the change the xvfb-run command succeeds (There are other warnings that can be ignored):

```
/etc/chromium.d/README: line 1: Any: command not found
dpkg-query: no packages found matching bluealsa
[18975:18975:1027/092559.171562:ERROR:component_loader.cc(193)] Failed to parse extension manifest.

DevTools listening on ws://127.0.0.1:9222/devtools/browser/08b41b3e-1299-4582-9d54-bea461031b55
[19041:19041:1027/092559.335451:ERROR:gpu_memory_buffer_support_x11.cc(44)] dri3 extension not supported.
[18975:18975:1027/092611.879392:ERROR:devtools_http_handler.cc(636)] Using unsafe HTTP verb GET to invoke /json/new. This action will stop supporting GET and POST verbs in future versions.
```

lighthouse is then able to connect and generate reports.

Tested on an arm processor without X11 using node v18.12.0 (npm v8.19.2).

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
