### PR TITLE
core(csp-xss): prevent meta warning if header CSPs are secure

### DIFF
--- a/core/audits/csp-xss.js
+++ b/core/audits/csp-xss.js
@@ -139,8 +139,11 @@ class CspXss extends Audit {
       ...warnings.map(f => this.findingToTableItem(f, str_(i18n.UIStrings.itemSeverityMedium))),
     ];
 
-    // Add extra warning for a CSP defined in a meta tag.
-    if (cspMetaTags.length) {
+    const headerOnlyBypasses = evaluateRawCspsForXss(cspHeaders).bypasses;
+    const headerOnlyIsInsecure = headerOnlyBypasses.length > 0 || cspHeaders.length === 0;
+
+    // Warn if there is a meta tag CSP and the header CSPs are not strict enough on their own.
+    if (cspMetaTags.length > 0 && headerOnlyIsInsecure) {
       results.push({
         severity: str_(i18n.UIStrings.itemSeverityMedium),
         description: str_(UIStrings.metaTagMessage),

--- a/core/audits/csp-xss.js
+++ b/core/audits/csp-xss.js
@@ -22,7 +22,8 @@ const UIStrings = {
   noCsp: 'No CSP found in enforcement mode',
   /** Message shown when one or more CSPs are defined in a <meta> tag. Shown in a table with a list of other CSP bypasses and warnings. "CSP" stands for "Content Security Policy". "CSP" and "HTTP" do not need to be translated. */
   metaTagMessage: 'The page contains a CSP defined in a <meta> tag. ' +
-    'Consider defining the CSP in an HTTP header if you can.',
+    'Consider moving the CSP to an HTTP header or ' +
+    'defining another strict CSP in an HTTP header.',
   /** Label for a column in a data table; entries will be a directive of a CSP. "CSP" stands for "Content Security Policy". */
   columnDirective: 'Directive',
   /** Label for a column in a data table; entries will be the severity of an issue with the CSP. "CSP" stands for "Content Security Policy". */

--- a/core/test/audits/csp-xss-test.js
+++ b/core/test/audits/csp-xss-test.js
@@ -318,11 +318,23 @@ describe('constructResults', () => {
   });
 
   it('adds item for CSP in meta tag', () => {
-    const {score, results} = CspXss.constructResults([], [
+    const {score, results} = CspXss.constructResults([
+      `script-src https://example.com; object-src 'none'`,
+    ], [
       `script-src 'none'; object-src 'none'; report-uri https://example.com`,
     ]);
     expect(score).toEqual(1);
     expect(results).toMatchObject([STATIC_RESULTS.metaTag]);
+  });
+
+  it('does not add item for a meta CSP if header CSPs are secure', () => {
+    const {score, results} = CspXss.constructResults([
+      `script-src 'nonce-00000000' 'unsafe-inline'; object-src 'none'; base-uri 'none'`,
+    ], [
+      `script-src 'none'; object-src 'none'; report-uri https://example.com`,
+    ]);
+    expect(score).toEqual(1);
+    expect(results).toMatchObject([]);
   });
 
   it('single item for no CSP', () => {

--- a/core/test/audits/csp-xss-test.js
+++ b/core/test/audits/csp-xss-test.js
@@ -46,7 +46,8 @@ const STATIC_RESULTS = {
     description: {
       formattedDefault:
         'The page contains a CSP defined in a <meta> tag. ' +
-        'Consider defining the CSP in an HTTP header if you can.',
+        'Consider moving the CSP to an HTTP header or ' +
+        'defining another strict CSP in an HTTP header.',
     },
     directive: undefined,
   },

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -594,7 +594,7 @@
     "message": "Syntax"
   },
   "core/audits/csp-xss.js | metaTagMessage": {
-    "message": "The page contains a CSP defined in a <meta> tag. Consider defining the CSP in an HTTP header if you can."
+    "message": "The page contains a CSP defined in a <meta> tag. Consider moving the CSP to an HTTP header or defining another strict CSP in an HTTP header."
   },
   "core/audits/csp-xss.js | noCsp": {
     "message": "No CSP found in enforcement mode"

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -594,7 +594,7 @@
     "message": "Ŝýn̂t́âx́"
   },
   "core/audits/csp-xss.js | metaTagMessage": {
-    "message": "T̂h́ê ṕâǵê ćôńt̂áîńŝ á ĈŚP̂ d́êf́îńêd́ îń â <ḿêt́â> t́âǵ. Ĉón̂śîd́êŕ d̂éf̂ín̂ín̂ǵ t̂h́ê ĆŜṔ îń âń ĤT́T̂Ṕ ĥéâd́êŕ îf́ ŷóû ćâń."
+    "message": "T̂h́ê ṕâǵê ćôńt̂áîńŝ á ĈŚP̂ d́êf́îńêd́ îń â <ḿêt́â> t́âǵ. Ĉón̂śîd́êŕ m̂óv̂ín̂ǵ t̂h́ê ĆŜṔ t̂ó âń ĤT́T̂Ṕ ĥéâd́êŕ ôŕ d̂éf̂ín̂ín̂ǵ âńôt́ĥér̂ śt̂ŕîćt̂ ĆŜṔ îń âń ĤT́T̂Ṕ ĥéâd́êŕ."
   },
   "core/audits/csp-xss.js | noCsp": {
     "message": "N̂ó ĈŚP̂ f́ôún̂d́ îń êńf̂ór̂ćêḿêńt̂ ḿôd́ê"


### PR DESCRIPTION
Fixes #14489
