### PR TITLE
core: expose error stack on errored audits

### DIFF
--- a/core/audits/audit.js
+++ b/core/audits/audit.js
@@ -321,12 +321,14 @@ class Audit {
   /**
    * @param {typeof Audit} audit
    * @param {string | LH.IcuMessage} errorMessage
+   * @param {string=} errorStack
    * @return {LH.RawIcu<LH.Audit.Result>}
    */
-  static generateErrorAuditResult(audit, errorMessage) {
+  static generateErrorAuditResult(audit, errorMessage, errorStack) {
     return Audit.generateAuditResult(audit, {
       score: null,
       errorMessage,
+      errorStack,
     });
   }
 
@@ -380,6 +382,7 @@ class Audit {
       displayValue: product.displayValue,
       explanation: product.explanation,
       errorMessage: product.errorMessage,
+      errorStack: product.errorStack,
       warnings: product.warnings,
 
       details: product.details,

--- a/core/lib/lh-error.js
+++ b/core/lib/lh-error.js
@@ -102,17 +102,18 @@ const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 const LHERROR_SENTINEL = '__LighthouseErrorSentinel';
 const ERROR_SENTINEL = '__ErrorSentinel';
 /**
- * @typedef {{sentinel: '__LighthouseErrorSentinel', code: string, stack?: string, [p: string]: string|undefined}} SerializedLighthouseError
- * @typedef {{sentinel: '__ErrorSentinel', message: string, code?: string, stack?: string}} SerializedBaseError
+ * @typedef {{sentinel: '__LighthouseErrorSentinel', code: string, stack?: string, cause?: SerializedBaseError|SerializedLighthouseError, properties?: {[p: string]: string|undefined}}} SerializedLighthouseError
+ * @typedef {{sentinel: '__ErrorSentinel', message: string, code?: string, stack?: string, cause?: SerializedBaseError|SerializedLighthouseError}} SerializedBaseError
  */
 
 class LighthouseError extends Error {
   /**
    * @param {LighthouseErrorDefinition} errorDefinition
    * @param {Record<string, string|undefined>=} properties
+   * @param {Error=} cause
    */
-  constructor(errorDefinition, properties) {
-    super(errorDefinition.code);
+  constructor(errorDefinition, properties, cause) {
+    super(errorDefinition.code, {cause});
     this.name = 'LighthouseError';
     this.code = errorDefinition.code;
     // Add additional properties to be ICU replacements in the error string.
@@ -158,19 +159,26 @@ class LighthouseError extends Error {
     if (err instanceof LighthouseError) {
       // Remove class props so that remaining values were what was passed in as `properties`.
       // eslint-disable-next-line no-unused-vars
-      const {name, code, message, friendlyMessage, lhrRuntimeError, stack, ...properties} = err;
+      const {name, code, message, friendlyMessage, lhrRuntimeError, stack, cause, ...properties} = err;
+      const serializedCause = cause ?
+        LighthouseError.stringifyReplacer(/** @type {Error} */ (cause)) :
+        undefined;
 
       return {
         sentinel: LHERROR_SENTINEL,
         code,
         stack,
-        ...properties,
+        cause: serializedCause,
+        properties: /** @type {{ [p: string]: string | undefined }} */ (properties),
       };
     }
 
     // Unexpected errors won't be LighthouseErrors, but we want them serialized as well.
     if (err instanceof Error) {
       const {message, stack} = err;
+      const serializedCause = err.cause ?
+        LighthouseError.stringifyReplacer(/** @type {Error} */ (err.cause)) :
+        undefined;
       // @ts-expect-error - code can be helpful for e.g. node errors, so preserve it if it's present.
       const code = err.code;
       return {
@@ -178,6 +186,7 @@ class LighthouseError extends Error {
         message,
         code,
         stack,
+        cause: serializedCause,
       };
     }
 
@@ -198,17 +207,20 @@ class LighthouseError extends Error {
       if (possibleError.sentinel === LHERROR_SENTINEL) {
         // Include sentinel in destructuring so it doesn't end up in `properties`.
         // eslint-disable-next-line no-unused-vars
-        const {sentinel, code, stack, ...properties} = /** @type {SerializedLighthouseError} */ (possibleError);
+        const {code, stack, cause, properties} = /** @type {SerializedLighthouseError} */ (possibleError);
+        const causeRevived = cause ? LighthouseError.parseReviver(key, cause) : undefined;
         const errorDefinition = LighthouseError.errors[/** @type {keyof typeof ERRORS} */ (code)];
-        const lhError = new LighthouseError(errorDefinition, properties);
+        const lhError = new LighthouseError(errorDefinition, properties, causeRevived);
         lhError.stack = stack;
 
         return lhError;
       }
 
       if (possibleError.sentinel === ERROR_SENTINEL) {
-        const {message, code, stack} = /** @type {SerializedBaseError} */ (possibleError);
-        const error = new Error(message);
+        const {message, code, stack, cause} = /** @type {SerializedBaseError} */ (possibleError);
+        const causeRevived = cause ? LighthouseError.parseReviver(key, cause) : undefined;
+        const opts = causeRevived ? {cause: causeRevived} : undefined;
+        const error = new Error(message, opts);
         Object.assign(error, {code, stack});
         return error;
       }

--- a/core/runner.js
+++ b/core/runner.js
@@ -383,7 +383,7 @@ class Runner {
 
           // Create a friendlier display error and mark it as expected to avoid duplicates in Sentry
           const error = new LighthouseError(LighthouseError.errors.ERRORED_REQUIRED_ARTIFACT,
-              {artifactName, errorMessage: artifactError.message});
+              {artifactName, errorMessage: artifactError.message}, artifactError);
           // @ts-expect-error Non-standard property added to Error
           error.expected = true;
           throw error;
@@ -422,7 +422,9 @@ class Runner {
       Sentry.captureException(err, {tags: {audit: audit.meta.id}, level: 'error'});
       // Errors become error audit result.
       const errorMessage = err.friendlyMessage ? err.friendlyMessage : err.message;
-      auditResult = Audit.generateErrorAuditResult(audit, errorMessage);
+      // Prefer the stack trace closest to the error.
+      const stack = err.cause?.stack ?? err.stack;
+      auditResult = Audit.generateErrorAuditResult(audit, errorMessage, stack);
     }
 
     log.timeEnd(status);

--- a/core/test/lib/asset-saver-test.js
+++ b/core/test/lib/asset-saver-test.js
@@ -295,7 +295,7 @@ describe('asset-saver helper', () => {
       // Use an LighthouseError that has an ICU replacement.
       const protocolMethod = 'Page.getFastness';
       const lhError = new LighthouseError(
-        LighthouseError.errors.PROTOCOL_TIMEOUT, {protocolMethod});
+        LighthouseError.errors.PROTOCOL_TIMEOUT, {protocolMethod}, new Error());
 
       const artifacts = {
         traces: {},
@@ -310,6 +310,7 @@ describe('asset-saver helper', () => {
       expect(roundTripArtifacts.ScriptElements).toBeInstanceOf(LighthouseError);
       expect(roundTripArtifacts.ScriptElements.code).toEqual('PROTOCOL_TIMEOUT');
       expect(roundTripArtifacts.ScriptElements.protocolMethod).toEqual(protocolMethod);
+      expect(roundTripArtifacts.ScriptElements.cause).toBeInstanceOf(Error);
       expect(roundTripArtifacts.ScriptElements.stack).toMatch(
           /^LighthouseError: PROTOCOL_TIMEOUT.*test[\\/]lib[\\/]asset-saver-test\.js/s);
       expect(roundTripArtifacts.ScriptElements.friendlyMessage)

--- a/core/test/runner-test.js
+++ b/core/test/runner-test.js
@@ -591,6 +591,37 @@ describe('Runner', () => {
         assert.strictEqual(auditResult.score, null);
         assert.strictEqual(auditResult.scoreDisplayMode, 'error');
         assert.ok(auditResult.errorMessage.includes(errorMessage));
+        assert.ok(auditResult.errorStack.includes('at Function.audit'));
+      });
+    });
+
+    it('produces an error audit result that prefers cause stack', async () => {
+      const errorMessage = 'Audit yourself';
+      const config = await Config.fromJson({
+        settings: {
+          auditMode: moduleDir + '/fixtures/artifacts/empty-artifacts/',
+        },
+        audits: [
+          class ThrowyAudit extends Audit {
+            static get meta() {
+              return testAuditMeta;
+            }
+            static audit() {
+              throw new Error(errorMessage, {cause: ThrowyAudit.aFn()});
+            }
+            static aFn() {
+              return new Error();
+            }
+          },
+        ],
+      });
+
+      return runGatherAndAudit({}, {config}).then(results => {
+        const auditResult = results.lhr.audits['throwy-audit'];
+        assert.strictEqual(auditResult.score, null);
+        assert.strictEqual(auditResult.scoreDisplayMode, 'error');
+        assert.ok(auditResult.errorMessage.includes(errorMessage));
+        assert.ok(auditResult.errorStack.includes('at Function.aFn'));
       });
     });
   });

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -11,7 +11,7 @@
     "outDir": ".tmp/tsbuildinfo/",
     "rootDir": ".",
 
-    "target": "es2020",
+    "target": "es2022",
     "module": "es2022",
     "moduleResolution": "node",
     "esModuleInterop": true,

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -73,6 +73,8 @@ declare module Audit {
     explanation?: string | IcuMessage;
     /** Error message from any exception thrown while running this audit. */
     errorMessage?: string | IcuMessage;
+    /** Error stack from any exception thrown while running this audit. */
+    errorStack?: string;
     warnings?: Array<string | IcuMessage>;
     /** Overrides scoreDisplayMode with notApplicable if set to true */
     notApplicable?: boolean;

--- a/types/lhr/audit-result.d.ts
+++ b/types/lhr/audit-result.d.ts
@@ -31,6 +31,8 @@ export interface Result {
   explanation?: string;
   /** Error message from any exception thrown while running this audit. */
   errorMessage?: string;
+  /** Error stack from any exception thrown while running this audit. */
+  errorStack?: string;
   warnings?: string[];
   /** The scored value of the audit, provided in the range `0-1`, or null if `scoreDisplayMode` indicates not scored. */
   score: number|null;


### PR DESCRIPTION
This adds an optional `errorStack` to an error'd audit product.

Also included is some better handling for our `.evaluate` function for when there is a syntax error.

example:

```json
"hreflang": {
  "id": "hreflang",
  "title": "Document has a valid `hreflang`",
  "description": "hreflang links tell search engines what version of a page they should list in search results for a given language or region. [Learn more about `hreflang`](https://web.dev/hreflang/).",
  "score": null,
  "scoreDisplayMode": "error",
  "errorMessage": "Required LinkElements gatherer encountered an error: browserElementsHAHA is not defined",
  "errorStack": "ReferenceError: browserElementsHAHA is not defined\n    at getLinkElementsInDOM (_lighthouse-eval.js:286:22)\n    at _lighthouse-eval.js:308:3\n    at _lighthouse-eval.js:309:7"
}
```