### PR TITLE
misc: change default build folder for devtools gn

### DIFF
--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -47,7 +47,7 @@ async function setup() {
  */
 async function runLighthouse(url, configJson, testRunnerOptions = {}) {
   const chromeFlags = [
-    `--custom-devtools-frontend=file://${devtoolsDir}/out/Default/gen/front_end`,
+    `--custom-devtools-frontend=file://${devtoolsDir}/out/LighthouseIntegration/gen/front_end`,
   ];
   const {lhr, artifacts, logs} = await testUrlFromDevtools(url, {
     config: configJson,

--- a/core/scripts/build-devtools.sh
+++ b/core/scripts/build-devtools.sh
@@ -14,12 +14,14 @@ set -euo pipefail
 # 
 # Run `bash core/test/devtools-tests/setup.sh` first to update the temporary devtools checkout.
 # Specify `$DEVTOOLS_PATH` to use a different devtools repo.
+# Specify `$BUILD_FOLDER` to use a build other than 'LighthouseIntegration' (ex: Default).
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../.."
 TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
 DEFAULT_DEVTOOLS_PATH="$TEST_DIR/devtools/devtools-frontend"
 DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$DEFAULT_DEVTOOLS_PATH"}
+BUILD_FOLDER="${BUILD_FOLDER:-LighthouseIntegration}"
 
 echo "DEVTOOLS_PATH: $DEVTOOLS_PATH"
 
@@ -41,6 +43,10 @@ fi
 yarn devtools "$DEVTOOLS_PATH"
 
 cd "$DEVTOOLS_PATH"
-gn gen out/Default --args='devtools_dcheck_always_on=true is_debug=false'
+if git config user.email | grep -q '@google.com'; then
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false use_goma=true'
+else
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+fi
 gclient sync
-autoninja -C out/Default
+autoninja -C "out/$BUILD_FOLDER"

--- a/core/scripts/open-devtools.sh
+++ b/core/scripts/open-devtools.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # 2) Opens $CHROME_PATH using new devtools frontend build, passing any additional args to Chrome.
 #
 # Specify `$DEVTOOLS_PATH` to use a different devtools repo.
+# Specify `$BUILD_FOLDER` to use a build other than 'LighthouseIntegration' (ex: Default to use out/Default).
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../.."
@@ -28,6 +29,7 @@ fi
 
 echo "CHROME_PATH: $CHROME_PATH"
 
+export BUILD_FOLDER="${BUILD_FOLDER:-LighthouseIntegration}"
 bash "$LH_ROOT/core/scripts/build-devtools.sh"
 
-"$CHROME_PATH" --custom-devtools-frontend=file://"$DEVTOOLS_PATH"/out/Default/gen/front_end $*
+"$CHROME_PATH" --custom-devtools-frontend=file://"$DEVTOOLS_PATH"/out/"$BUILD_FOLDER"/gen/front_end $*

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -10,12 +10,12 @@
  * May work on older versions of Chrome.
  *
  * To use with locally built DevTools and Lighthouse, run (assuming devtools at ~/src/devtools/devtools-frontend):
- *    yarn devtools
- *    yarn run-devtools --chrome-flags=--custom-devtools-frontend=file://$HOME/src/devtools/devtools-frontend/out/Default/gen/front_end
+ *    DEVTOOLS_PATH=~/src/devtools/devtools-frontend sh core/scripts/build-devtools.sh
+ *    yarn run-devtools --chrome-flags=--custom-devtools-frontend=file://$HOME/src/devtools/devtools-frontend/out/LighthouseIntegration/gen/front_end
  *
  * Or with the DevTools in .tmp:
  *   bash core/test/devtools-tests/setup.sh
- *   yarn run-devtools --chrome-flags=--custom-devtools-frontend=file://$PWD/.tmp/chromium-web-tests/devtools/devtools-frontend/out/Default/gen/front_end
+ *   yarn run-devtools --chrome-flags=--custom-devtools-frontend=file://$PWD/.tmp/chromium-web-tests/devtools/devtools-frontend/out/LighthouseIntegration/gen/front_end
  *
  * URL list file: yarn run-devtools < path/to/urls.txt
  * Single URL: yarn run-devtools "https://example.com"

--- a/core/test/devtools-tests/download-devtools.sh
+++ b/core/test/devtools-tests/download-devtools.sh
@@ -32,4 +32,8 @@ cd `dirname $DEVTOOLS_PATH`
 fetch --nohooks --no-history devtools-frontend
 cd devtools-frontend
 gclient sync
-gn gen out/Default --args='devtools_dcheck_always_on=true is_debug=false'
+if git config user.email | grep -q '@google.com'; then
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false use_goma=true'
+else
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+fi

--- a/core/test/devtools-tests/roll-devtools.sh
+++ b/core/test/devtools-tests/roll-devtools.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../../.."
+BUILD_FOLDER="${BUILD_FOLDER:-LighthouseIntegration}"
 
 roll_devtools() {
   # Roll devtools. Besides giving DevTools the latest lighthouse source files,
@@ -28,6 +29,12 @@ roll_devtools
 # `yarn devtools` deleted.
 gclient sync --delete_unversioned_trees --reset
 
-# Build devtools. This creates `out/Default/gen/front_end`.
-autoninja -C out/Default
+if git config user.email | grep -q '@google.com'; then
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false use_goma=true'
+else
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+fi
+
+# Build devtools. By default, this creates `out/LighthouseIntegration/gen/front_end`.
+autoninja -C "out/$BUILD_FOLDER"
 cd -

--- a/core/test/devtools-tests/setup.sh
+++ b/core/test/devtools-tests/setup.sh
@@ -8,6 +8,7 @@
 
 # Setup dependencies for devtools e2e tests.
 # Set SKIP_DOWNLOADS to skip all the downloading and just export variables.
+# Set BUILD_FOLDER to use a folder other than 'LighthouseIntegration' (ex: Default to use out/Default).
 
 set -euo pipefail
 
@@ -17,6 +18,7 @@ TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
 
 export DEPOT_TOOLS_PATH="$TEST_DIR/depot-tools"
 export DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$TEST_DIR/devtools/devtools-frontend"}
+export BUILD_FOLDER="${BUILD_FOLDER:-LighthouseIntegration}"
 
 if [ -z ${SKIP_DOWNLOADS+x} ]
 then


### PR DESCRIPTION
When pointing our build/run scripts to my local devtools checkout, I was surprised/annoyed how it blew out my existing Default build args. So let's use a specifically named build folder for our hacking here. Also made said folder configurable.

drive by: set use_goma if googler