### PR TITLE
report: reuse numberFormatters for ~50% performance gains

### DIFF
--- a/report/renderer/details-renderer.js
+++ b/report/renderer/details-renderer.js
@@ -53,7 +53,12 @@ export class DetailsRenderer {
         return this._renderList(details);
       case 'table':
       case 'opportunity':
-        return this._renderTable(details);
+      {
+        // Defer rendering of hidden tables, for a faster FCP
+        const tableElem = this._dom.createElement('table', 'lh-table');
+        setTimeout(() => this._renderTable(details, tableElem));
+        return tableElem;
+      }
       case 'criticalrequestchain':
         return CriticalRequestChainRenderer.render(this._dom, details, this);
 
@@ -377,12 +382,12 @@ export class DetailsRenderer {
 
   /**
    * @param {{headings: TableColumnHeading[], items: TableItem[]}} details
+   * @param {Element} tableElem
    * @return {Element}
    */
-  _renderTable(details) {
+  _renderTable(details, tableElem) {
     if (!details.items.length) return this._dom.createElement('span');
 
-    const tableElem = this._dom.createElement('table', 'lh-table');
     const theadElem = this._dom.createChildOf(tableElem, 'thead');
     const theadTrElem = this._dom.createChildOf(theadElem, 'tr');
 

--- a/report/renderer/details-renderer.js
+++ b/report/renderer/details-renderer.js
@@ -53,12 +53,7 @@ export class DetailsRenderer {
         return this._renderList(details);
       case 'table':
       case 'opportunity':
-      {
-        // Defer rendering of hidden tables, for a faster FCP
-        const tableElem = this._dom.createElement('table', 'lh-table');
-        setTimeout(() => this._renderTable(details, tableElem));
-        return tableElem;
-      }
+        return this._renderTable(details);
       case 'criticalrequestchain':
         return CriticalRequestChainRenderer.render(this._dom, details, this);
 
@@ -382,12 +377,12 @@ export class DetailsRenderer {
 
   /**
    * @param {{headings: TableColumnHeading[], items: TableItem[]}} details
-   * @param {Element} tableElem
    * @return {Element}
    */
-  _renderTable(details, tableElem) {
+  _renderTable(details) {
     if (!details.items.length) return this._dom.createElement('span');
 
+    const tableElem = this._dom.createElement('table', 'lh-table');
     const theadElem = this._dom.createChildOf(tableElem, 'thead');
     const theadTrElem = this._dom.createChildOf(theadElem, 'tr');
 

--- a/report/renderer/i18n.js
+++ b/report/renderer/i18n.js
@@ -23,6 +23,7 @@ export class I18n {
 
     this._locale = locale;
     this._strings = strings;
+    this._cachedNumberFormatters = new Map();
   }
 
   get strings() {
@@ -57,7 +58,16 @@ export class I18n {
       number = 0;
     }
 
-    return new Intl.NumberFormat(this._locale, opts).format(number).replace(' ', NBSP2);
+    let formatter;
+    // eslint-disable-next-line max-len
+    const cacheKey = `${opts.minimumFractionDigits}${opts.maximumFractionDigits}${opts.style}${opts.unit}${opts.unitDisplay}`;
+    formatter = this._cachedNumberFormatters.get(cacheKey);
+    if (!formatter) {
+      formatter = new Intl.NumberFormat(this._locale, opts);
+      this._cachedNumberFormatters.set(cacheKey, formatter);
+    }
+
+    return formatter.format(number).replace(' ', NBSP2);
   }
 
   /**

--- a/report/renderer/i18n.js
+++ b/report/renderer/i18n.js
@@ -60,7 +60,15 @@ export class I18n {
 
     let formatter;
     // eslint-disable-next-line max-len
-    const cacheKey = `${opts.minimumFractionDigits}${opts.maximumFractionDigits}${opts.style}${opts.unit}${opts.unitDisplay}`;
+    const cacheKey = [
+      opts.minimumFractionDigits,
+      opts.maximumFractionDigits,
+      opts.style,
+      opts.unit,
+      opts.unitDisplay,
+      this._locale,
+    ].join('');
+
     formatter = this._cachedNumberFormatters.get(cacheKey);
     if (!formatter) {
       formatter = new Intl.NumberFormat(this._locale, opts);


### PR DESCRIPTION
<details>
<summary> deferring table rendering stuff that we are _deferring_ to another PR </summary>


baseline perf of renderReport.. ~140ms JS plus rendering:
<img width="766" alt="image" src="https://user-images.githubusercontent.com/39191/199629436-0867bf7f-f208-4595-aec8-3956d5ac5de7.png">


after deferring `renderTable`'s impl.. just 70ms of JS before FCP:
<img width="759" alt="image" src="https://user-images.githubusercontent.com/39191/199629191-f63b1920-f218-47fa-b109-7f95565b4b0c.png">

</details>

and then 

reusing formatters brings 120ms of table rendering down to 50ms:
<img width="659" alt="image" src="https://user-images.githubusercontent.com/39191/199629393-069ad676-712c-4416-92d8-c11887d5ff7d.png">


that is renderReport being 50% faster!!!!!!!
