### PR TITLE
core(fps): limit height at max webp size

### DIFF
--- a/cli/test/fixtures/max-texture-size.html
+++ b/cli/test/fixtures/max-texture-size.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    .filler {
+      height: 20000px;
+      display: flex;
+      align-items: flex-end;
+      background-color: yellow;
+    }
+  </style>
+</head>
+<body>
+  <h1>There is some content far below me vvvvvv</h1>
+  <h2 class="filler">I am farther than the maximum texture size</h2>
+</body>
+</html>

--- a/cli/test/smokehouse/core-tests.js
+++ b/cli/test/smokehouse/core-tests.js
@@ -63,6 +63,7 @@ import seoTapTargets from './test-definitions/seo-tap-targets.js';
 import sourceMaps from './test-definitions/source-maps.js';
 import timing from './test-definitions/timing.js';
 import fpsScaled from './test-definitions/fps-scaled.js';
+import fpsMax from './test-definitions/fps-max.js';
 
 /** @type {ReadonlyArray<Smokehouse.TestDfn>} */
 const smokeTests = [
@@ -125,6 +126,7 @@ const smokeTests = [
   sourceMaps,
   timing,
   fpsScaled,
+  fpsMax,
 ];
 
 export default smokeTests;

--- a/cli/test/smokehouse/test-definitions/fps-max.js
+++ b/cli/test/smokehouse/test-definitions/fps-max.js
@@ -1,0 +1,51 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/** @type {LH.Config.Json} */
+const config = {
+  extends: 'lighthouse:default',
+  settings: {
+    onlyCategories: ['performance'],
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const expectations = {
+  artifacts: {
+    ViewportDimensions: {
+      innerWidth: 360,
+      innerHeight: 640,
+      outerWidth: 360,
+      outerHeight: 640,
+      // In DevTools this value will be exactly 3.
+      devicePixelRatio: '2.625 +/- 1',
+    },
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/max-texture-size.html',
+    finalDisplayedUrl: 'http://localhost:10200/max-texture-size.html',
+    audits: {
+      'full-page-screenshot': {
+        details: {
+          screenshot: {
+            data: /^data:image\/webp;base64,.{50}/,
+            height: 16383,
+            width: 360,
+          },
+        },
+      },
+    },
+  },
+};
+
+export default {
+  id: 'fps-max',
+  expectations,
+  config,
+};
+

--- a/cli/test/smokehouse/test-definitions/fps-max.js
+++ b/cli/test/smokehouse/test-definitions/fps-max.js
@@ -4,8 +4,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-const MAX_TEXTURE_SIZE = process.platform === 'linux' ? 8191 : 16383;
-
 /** @type {LH.Config.Json} */
 const config = {
   extends: 'lighthouse:default',
@@ -36,7 +34,7 @@ const expectations = {
         details: {
           screenshot: {
             data: /^data:image\/webp;base64,.{50}/,
-            height: MAX_TEXTURE_SIZE,
+            height: 16383,
             width: 360,
           },
         },

--- a/cli/test/smokehouse/test-definitions/fps-max.js
+++ b/cli/test/smokehouse/test-definitions/fps-max.js
@@ -4,6 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+const MAX_TEXTURE_SIZE = process.platform === 'linux' ? 8191 : 16383;
+
 /** @type {LH.Config.Json} */
 const config = {
   extends: 'lighthouse:default',
@@ -34,7 +36,7 @@ const expectations = {
         details: {
           screenshot: {
             data: /^data:image\/webp;base64,.{50}/,
-            height: 16383,
+            height: MAX_TEXTURE_SIZE,
             width: 360,
           },
         },

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -87,12 +87,12 @@ class FullPageScreenshot extends FRGatherer {
 
     // Height should be as tall as the content.
     // Scale the emulated height to reach the content height.
-    const fullHeight = Math.round(
+    const desiredLayoutViewportHeight = Math.min(metrics.cssContentSize.height, maxTextureSize);
+    const newDeviceHeight = Math.round(
       deviceMetrics.height *
-      metrics.contentSize.height /
-      metrics.layoutViewport.clientHeight
+      desiredLayoutViewportHeight /
+      metrics.cssLayoutViewport.clientHeight
     );
-    const height = Math.min(fullHeight, maxTextureSize);
 
     // Setup network monitor before we change the viewport.
     const networkMonitor = new NetworkMonitor(context.driver.targetManager);
@@ -108,7 +108,7 @@ class FullPageScreenshot extends FRGatherer {
     await session.sendCommand('Emulation.setDeviceMetricsOverride', {
       mobile: deviceMetrics.mobile,
       deviceScaleFactor: 1,
-      height,
+      height: newDeviceHeight,
       width: 0, // Leave width unchanged
     });
 

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -93,8 +93,8 @@ class FullPageScreenshot extends FRGatherer {
     // Scale the emulated height to reach the content height.
     const fullHeight = Math.round(
       deviceMetrics.height *
-      metrics.cssContentSize.height /
-      metrics.cssLayoutViewport.clientHeight
+      metrics.contentSize.height /
+      metrics.layoutViewport.clientHeight
     );
     const height = Math.min(fullHeight, maxTextureSize);
 
@@ -112,7 +112,7 @@ class FullPageScreenshot extends FRGatherer {
     await session.sendCommand('Emulation.setDeviceMetricsOverride', {
       mobile: deviceMetrics.mobile,
       deviceScaleFactor: 1,
-      height: height,
+      height,
       width: 0, // Leave width unchanged
     });
 

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -41,6 +41,10 @@ function getObservedDeviceMetrics() {
   };
 }
 
+/**
+ * The screenshot dimensions are sized to `window.outerHeight` / `window.innerWidth`,
+ * however the bounding boxes of the elements are relative to `window.innerHeight` / `window.innerWidth`.
+ */
 function getScreenshotAreaSize() {
   return {
     width: window.innerWidth,
@@ -87,12 +91,12 @@ class FullPageScreenshot extends FRGatherer {
 
     // Height should be as tall as the content.
     // Scale the emulated height to reach the content height.
-    const desiredLayoutViewportHeight = Math.min(metrics.cssContentSize.height, maxTextureSize);
-    const newDeviceHeight = Math.round(
+    const fullHeight = Math.round(
       deviceMetrics.height *
-      desiredLayoutViewportHeight /
+      metrics.cssContentSize.height /
       metrics.cssLayoutViewport.clientHeight
     );
+    const height = Math.min(fullHeight, maxTextureSize);
 
     // Setup network monitor before we change the viewport.
     const networkMonitor = new NetworkMonitor(context.driver.targetManager);
@@ -108,7 +112,7 @@ class FullPageScreenshot extends FRGatherer {
     await session.sendCommand('Emulation.setDeviceMetricsOverride', {
       mobile: deviceMetrics.mobile,
       deviceScaleFactor: 1,
-      height: newDeviceHeight,
+      height: height,
       width: 0, // Leave width unchanged
     });
 

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -17,6 +17,9 @@ import {waitForNetworkIdle} from '../driver/wait-for-condition.js';
 // Note: this analysis was done for JPEG, but now we use WEBP.
 const FULL_PAGE_SCREENSHOT_QUALITY = 30;
 
+// https://developers.google.com/speed/webp/faq#what_is_the_maximum_size_a_webp_image_can_be
+const MAX_WEBP_SIZE = 16383;
+
 /**
  * @template {string} S
  * @param {S} str
@@ -68,25 +71,11 @@ class FullPageScreenshot extends FRGatherer {
 
   /**
    * @param {LH.Gatherer.FRTransitionalContext} context
-   * @return {Promise<number>}
-   * @see https://bugs.chromium.org/p/chromium/issues/detail?id=770769
-   */
-  async getMaxTextureSize(context) {
-    return await context.driver.executionContext.evaluate(pageFunctions.getMaxTextureSize, {
-      args: [],
-      useIsolation: true,
-      deps: [],
-    });
-  }
-
-  /**
-   * @param {LH.Gatherer.FRTransitionalContext} context
    * @param {{height: number, width: number, mobile: boolean}} deviceMetrics
    * @return {Promise<LH.Artifacts.FullPageScreenshot['screenshot']>}
    */
   async _takeScreenshot(context, deviceMetrics) {
     const session = context.driver.defaultSession;
-    const maxTextureSize = await this.getMaxTextureSize(context);
     const metrics = await session.sendCommand('Page.getLayoutMetrics');
 
     // Height should be as tall as the content.
@@ -96,7 +85,7 @@ class FullPageScreenshot extends FRGatherer {
       metrics.cssContentSize.height /
       metrics.cssLayoutViewport.clientHeight
     );
-    const height = Math.min(fullHeight, maxTextureSize);
+    const height = Math.min(fullHeight, MAX_WEBP_SIZE);
 
     // Setup network monitor before we change the viewport.
     const networkMonitor = new NetworkMonitor(context.driver.targetManager);

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -93,8 +93,8 @@ class FullPageScreenshot extends FRGatherer {
     // Scale the emulated height to reach the content height.
     const fullHeight = Math.round(
       deviceMetrics.height *
-      metrics.contentSize.height /
-      metrics.layoutViewport.clientHeight
+      metrics.cssContentSize.height /
+      metrics.cssLayoutViewport.clientHeight
     );
     const height = Math.min(fullHeight, maxTextureSize);
 

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -164,27 +164,6 @@ function getOuterHTMLSnippet(element, ignoreAttrs = [], snippetCharacterLimit = 
 }
 
 /**
- * Get the maximum size of a texture the GPU can handle
- * @see https://bugs.chromium.org/p/chromium/issues/detail?id=770769#c13
- * @return {number}
- */
-function getMaxTextureSize() {
-  try {
-    const canvas = document.createElement('canvas');
-    const gl = canvas.getContext('webgl');
-    if (!gl) throw new Error('no webgl');
-    const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-    return maxTextureSize;
-  } catch (e) {
-    // If the above fails for any reason we need a fallback number;
-    // 4096 is the max texture size on a Pixel 2 XL, so to be conservative we'll use a low value like it.
-    // But we'll subtract 1 just to identify this case later on.
-    const MAX_TEXTURE_SIZE_FALLBACK = 4095;
-    return MAX_TEXTURE_SIZE_FALLBACK;
-  }
-}
-
-/**
  * Computes a memory/CPU performance benchmark index to determine rough device class.
  * @see https://github.com/GoogleChrome/lighthouse/issues/9085
  * @see https://docs.google.com/spreadsheets/d/1E0gZwKsxegudkjJl8Fki_sOwHKpqgXwt8aBAfuUaB8A/edit?usp=sharing
@@ -555,7 +534,6 @@ export const pageFunctions = {
   getElementsInDocument,
   getOuterHTMLSnippet,
   computeBenchmarkIndex,
-  getMaxTextureSize,
   getNodeDetails,
   getNodePath,
   getNodeSelector,

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -174,7 +174,7 @@ function getMaxTextureSize() {
     const gl = canvas.getContext('webgl');
     if (!gl) throw new Error('no webgl');
     const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-    return maxTextureSize;
+    return maxTextureSize - 1;
   } catch (e) {
     // If the above fails for any reason we need a fallback number;
     // 4096 is the max texture size on a Pixel 2 XL, so to be conservative we'll use a low value like it.

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -174,7 +174,7 @@ function getMaxTextureSize() {
     const gl = canvas.getContext('webgl');
     if (!gl) throw new Error('no webgl');
     const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-    return maxTextureSize - 1;
+    return maxTextureSize;
   } catch (e) {
     // If the above fails for any reason we need a fallback number;
     // 4096 is the max texture size on a Pixel 2 XL, so to be conservative we'll use a low value like it.

--- a/core/test/gather/gatherers/full-page-screenshot-test.js
+++ b/core/test/gather/gatherers/full-page-screenshot-test.js
@@ -29,9 +29,9 @@ beforeEach(() => {
   mockContext.driver.defaultSession.sendCommand.mockImplementation((method) => {
     if (method === 'Page.getLayoutMetrics') {
       return {
-        contentSize,
+        cssContentSize: contentSize,
         // See comment within _takeScreenshot() implementation
-        layoutViewport: {clientWidth: screenSize.width, clientHeight: screenSize.height},
+        cssLayoutViewport: {clientWidth: screenSize.width, clientHeight: screenSize.height},
       };
     }
     if (method === 'Page.captureScreenshot') {

--- a/core/test/gather/gatherers/full-page-screenshot-test.js
+++ b/core/test/gather/gatherers/full-page-screenshot-test.js
@@ -7,9 +7,6 @@
 import {createMockContext} from '../../gather/mock-driver.js';
 import FullPageScreenshotGatherer from '../../../gather/gatherers/full-page-screenshot.js';
 
-// Headless's default value is (1024 * 16), but this varies by device
-const maxTextureSizeMock = 1024 * 8;
-
 /** @type {{width: number, height: number}} */
 let contentSize;
 /** @type {{width?: number, height?: number, dpr: number}} */
@@ -43,8 +40,6 @@ beforeEach(() => {
   mockContext.driver._executionContext.evaluate.mockImplementation(fn => {
     if (fn.name === 'resolveNodes') {
       return {};
-    } if (fn.name === 'getMaxTextureSize') {
-      return maxTextureSizeMock;
     } else if (fn.name === 'getObservedDeviceMetrics') {
       return {
         width: screenSize.width,
@@ -203,7 +198,7 @@ describe('FullPageScreenshot gatherer', () => {
         mobile: true,
         deviceScaleFactor: 1,
         width: 0,
-        height: maxTextureSizeMock,
+        height: 16383,
       }
     );
   });


### PR DESCRIPTION
The screenshot was returning an empty string for the data on https://theverge.com

We are not limited by the max texture size (16384 on my macbook; but this is unrelated to Page.captureScreenshot) but we are limited by the [max web size of 16383](https://developers.google.com/speed/webp/faq#:~:text=the%20container%20specification.-,What%20is%20the%20maximum%20size%20a%20WebP%20image%20can%20be,image%20is%2016383%20x%2016383)