### PR TITLE
tests: fix node version in weekly cron

### DIFF
--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -31,10 +31,10 @@ jobs:
     steps:
     - name: git clone
       uses: actions/checkout@v2
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
     - run: yarn --frozen-lockfile
 
     - run: yarn mocha --testMatch=third-party/chromium-synchronization/*-test.js


### PR DESCRIPTION
This has been failing on `yarn install` lately :P 

also... looked into how we could get notifications on this cron failing and.... it's dumb: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs#:~:text=Notifications%20for%20scheduled%20workflows%20are%20sent%20to%20the%20user%20who%20initially%20created%20the%20workflow can only go to one person!