### PR TITLE
misc(build): remove non-functional package.json shim

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -104,7 +104,6 @@ async function buildBundle(entryPath, distPath, opts = {minify: true}) {
   const shimsObj = {
     [require.resolve('../core/legacy/gather/connections/cri.js')]:
       'export const CriConnection = {}',
-    [require.resolve('../package.json')]: `export const version = '${pkg.version}';`,
   };
 
   const modulesToIgnore = [


### PR DESCRIPTION
This doesn't do anything anymore.

ref #14535