### PR TITLE
core: expose default and desktop configs on `index.js`

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -184,6 +184,8 @@ export default lighthouse;
 export {Audit} from './audits/audit.js';
 export {default as Gatherer} from './gather/base-gatherer.js';
 export {NetworkRecords} from './computed/network-records.js';
+export {default as defaultConfig} from './config/default-config.js';
+export {default as desktopConfig} from './config/desktop-config.js';
 export {
   legacyNavigation,
   startFlow,


### PR DESCRIPTION
I think it would be useful to have these two at the top level api.

Ref https://github.com/GoogleChrome/lighthouse/issues/14048
