### PR TITLE
deps: switch third-party-web dataset to entities-nostats subset

### DIFF
--- a/core/lib/third-party-web.js
+++ b/core/lib/third-party-web.js
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import thirdPartyWeb from 'third-party-web/httparchive-nostats-subset.js';
+import thirdPartyWeb from 'third-party-web/nostats-subset.js';
 
 /** @typedef {import("third-party-web").IEntity} ThirdPartyEntity */
 /** @typedef {import("third-party-web").IProduct} ThirdPartyProduct */


### PR DESCRIPTION
I was tracking down why a [recent upgrade of the library](https://github.com/GoogleChrome/lighthouse/pull/14546) was losing one of the recognized entities, and in the process realized we aren't getting several entities that are in `entities.json`.

```javascript
const getEntityMerged = require('third-party-web').getEntity;
const getEntityHTTPArchive = require('third-party-web/httparchive-nostats-subset.js').getEntity;
console.log('result from merged entities: ',
  getEntityMerged('https://mnl4bjjsnz-dsn.algolia.net/1/indexes/dev_OFFICE_SCENES/query'))
console.log('result in httparchive entities:',
  getEntityHTTPArchive('https://mnl4bjjsnz-dsn.algolia.net/1/indexes/dev_OFFICE_SCENES/query'))
```
With 0.20.2, it outputs:
```shell
result from merged entities:  {
  company: 'Algolia',
  categories: [ 'utility' ],
  name: 'Algolia',
  homepage: 'https://www.algolia.com/',
  category: 'utility',
  domains: [ '*.algolianet.com', '*.algolia.net', '*.algolia.io' ],
  products: [],
  totalExecutionTime: 0,
  totalOccurrences: 0,
  averageExecutionTime: NaN
}
result in httparchive entities: undefined
```
The entity moved out of the HTTPArchive dataset (as expected since it went below the threshold requirements to make it to that dataset). 

Digging further:

```shell
jsonlint entities-nostats.json | grep \"name\" | wc -l
2135

jsonlint entities-httparchive-nostats.json | grep \"name\" | wc -l
1095

diff <(jsonlint entities-nostats.json | grep \"name\" | sort) \
  <(jsonlint entities-httparchive-nostats.json | grep \"name\" | sort) | grep \< | wc -l
1040
```