### PR TITLE
docs(proto): update protobuf installation guidance

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -1,24 +1,11 @@
 ## How to compile protos + use locally
 
-You'll need to have v3.7.1 of the protocol-buffer/protobuf compiler installed. (v3.7.1 is known to be compatible, and 3.11.x is known to be **not** compatible.).
+You'll need to have **`v3.20+`** of protobuf.
 
-1. Install the proto compiler by either
-    1. Brew installing - `brew install protobuf@3.7`
-    1. Manually installing from an [official release](https://github.com/protocolbuffers/protobuf/releases/tag/v3.7.1). There are [installation instructions](https://github.com/protocolbuffers/protobuf#protocol-compiler-installation), but these steps have worked well for us:
-        ```sh
-        mkdir protobuf-install && cd protobuf-install
-        curl -L -o protobuf-python-3.7.1.zip https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-python-3.7.1.zip
-        unzip protobuf-python-3.7.1.zip
-        cd protobuf-3.7.1
+Note that they [changed the versioning scheme](https://developers.google.com/protocol-buffers/docs/news/2022-05-06#versioning) and went from `3.20.1` to `4.21.0`. Making it more confusing, in `brew` and Github, `4.21.x` is shown as `v21.x`.
 
-        cd python
-        python setup.py build
-        python setup.py test
-        (cd .. && autogen.sh && configure && make)
-        (cd .. && sudo make install)
-        python setup.py build --cpp_implementation
-        sudo python setup.py install --cpp_implementation
-        ```
+
+1. Install the proto compiler with `brew install protobuf`, or something [like this](https://github.com/GoogleChrome/lighthouse/blob/9fd45c5e2b92e3b1f10b642ea631dd5a9598f5ee/.github/workflows/unit.yml#L32-L45).
 1. Run `yarn test-proto`
 
 ## Proto Resources
@@ -39,4 +26,3 @@ LHR round trip flow:
 ## Hacking Hints
 - Clean out compiled proto and json with `yarn clean`
 - Round trips might jumble the order of your JSON keys and lists!
-- Is your `six` installation troubling your `pip install protobuf`? Mine did.  Try `pip install --ignore-installed six`.


### PR DESCRIPTION
nice job with https://github.com/GoogleChrome/lighthouse/pull/14557 @adamraine 

this should sort out the docs. 

yay so glad for py3 compliance. makes all of this a bit less cranky.