### PR TITLE
core(lantern): add comment to about node times being in microseconds

### DIFF
--- a/core/lib/dependency-graph/base-node.js
+++ b/core/lib/dependency-graph/base-node.js
@@ -50,6 +50,7 @@ class BaseNode {
   }
 
   /**
+   * In microseconds
    * @return {number}
    */
   get startTime() {
@@ -57,6 +58,7 @@ class BaseNode {
   }
 
   /**
+   * In microseconds
    * @return {number}
    */
   get endTime() {

--- a/core/lib/dependency-graph/network-node.js
+++ b/core/lib/dependency-graph/network-node.js
@@ -22,8 +22,6 @@ class NetworkNode extends BaseNode {
   }
 
   /**
-   * In seconds.
-   * TODO: make ms.
    * @return {number}
    */
   get startTime() {
@@ -31,8 +29,6 @@ class NetworkNode extends BaseNode {
   }
 
   /**
-   * In seconds.
-   * TODO: make ms.
    * @return {number}
    */
   get endTime() {


### PR DESCRIPTION
we got confused here https://github.com/GoogleChrome/lighthouse/pull/14567#discussion_r1034228708

lantern cpu nodes just use the trace event's `ts` value, which is microseconds. network node is multiplied to match