### PR TITLE
core(lantern): add network timings to debug traces

### DIFF
--- a/core/lib/dependency-graph/simulator/simulator-timing-map.js
+++ b/core/lib/dependency-graph/simulator/simulator-timing-map.js
@@ -39,9 +39,17 @@ import {BaseNode} from '../base-node.js';
 /** @typedef {NetworkNodeTimingStarted & Pick<NodeTimingComplete, 'estimatedTimeElapsed'>} NetworkNodeTimingInProgress */
 
 /** @typedef {CpuNodeTimingInProgress & Pick<NodeTimingComplete, 'endTime'>} CpuNodeTimingComplete */
-/** @typedef {NetworkNodeTimingInProgress & Pick<NodeTimingComplete, 'endTime'>} NetworkNodeTimingComplete */
+/** @typedef {NetworkNodeTimingInProgress & Pick<NodeTimingComplete, 'endTime'> & {connectionTiming: ConnectionTiming}} NetworkNodeTimingComplete */
 
 /** @typedef {NodeTimingQueued | CpuNodeTimingStarted | NetworkNodeTimingStarted | CpuNodeTimingInProgress | NetworkNodeTimingInProgress | CpuNodeTimingComplete | NetworkNodeTimingComplete} NodeTimingData */
+
+/**
+ * @typedef ConnectionTiming A breakdown of network connection timings.
+ * @property {number} [dnsResolutionTime]
+ * @property {number} [connectionTime]
+ * @property {number} [sslTime]
+ * @property {number} timeToFirstByte
+ */
 
 class SimulatorTimingMap {
   constructor() {
@@ -83,12 +91,13 @@ class SimulatorTimingMap {
 
   /**
    * @param {Node} node
-   * @param {{endTime: number}} values
+   * @param {{endTime: number, connectionTiming?: ConnectionTiming}} values
    */
   setCompleted(node, values) {
     const nodeTiming = {
       ...this.getInProgress(node),
       endTime: values.endTime,
+      connectionTiming: values.connectionTiming,
     };
 
     this._nodeTimings.set(node, nodeTiming);

--- a/core/lib/lantern-trace-saver.js
+++ b/core/lib/lantern-trace-saver.js
@@ -4,8 +4,11 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+/** @typedef {import('./dependency-graph/base-node.js').Node} Node */
+/** @typedef {import('./dependency-graph/simulator/simulator.js').CompleteNodeTiming} CompleteNodeTiming */
+
 /**
- * @param {LH.Gatherer.Simulation.Result['nodeTimings']} nodeTimings
+ * @param {Map<Node, CompleteNodeTiming>} nodeTimings
  * @return {LH.Trace}
  */
 function convertNodeTimingsToTrace(nodeTimings) {
@@ -123,7 +126,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
   /**
    * @param {number} requestId
    * @param {LH.Artifacts.NetworkRequest} record
-   * @param {LH.Gatherer.Simulation.NodeTiming} timing
+   * @param {CompleteNodeTiming} timing
    * @return {LH.TraceEvent}
    */
   function createWillSendRequestEvent(requestId, record, timing) {
@@ -142,7 +145,7 @@ function convertNodeTimingsToTrace(nodeTimings) {
   /**
    * @param {number} requestId
    * @param {LH.Artifacts.NetworkRequest} record
-   * @param {LH.Gatherer.Simulation.NodeTiming} timing
+   * @param {CompleteNodeTiming} timing
    * @return {LH.TraceEvent[]}
    */
   function createFakeNetworkEvents(requestId, record, timing) {

--- a/core/test/lib/dependency-graph/simulator/tcp-connection-test.js
+++ b/core/test/lib/dependency-graph/simulator/tcp-connection-test.js
@@ -46,6 +46,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
         congestionWindow: 40,
         roundTrips: 5,
         timeElapsed: 500,
+        connectionTiming: {
+          connectionTime: 250,
+          dnsResolutionTime: 0,
+          sslTime: 100,
+          timeToFirstByte: 300,
+        },
       });
       connection.setCongestionWindow(40); // will download all in one round trip
       assert.deepEqual(connection.simulateDownloadUntil(50000), {
@@ -54,6 +60,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
         congestionWindow: 40,
         roundTrips: 3,
         timeElapsed: 300,
+        connectionTiming: {
+          connectionTime: 250,
+          dnsResolutionTime: 0,
+          sslTime: 100,
+          timeToFirstByte: 300,
+        },
       });
     });
   });
@@ -90,6 +102,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
           congestionWindow: 10,
           roundTrips: 2,
           timeElapsed: 200,
+          connectionTiming: {
+            connectionTime: 150,
+            dnsResolutionTime: 0,
+            sslTime: undefined, // non-SSL
+            timeToFirstByte: 200,
+          },
         });
       });
 
@@ -101,6 +119,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
           congestionWindow: 10,
           roundTrips: 3,
           timeElapsed: 300,
+          connectionTiming: {
+            connectionTime: 250,
+            dnsResolutionTime: 0,
+            sslTime: 100,
+            timeToFirstByte: 300,
+          },
         });
       });
 
@@ -112,6 +136,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
           congestionWindow: 10,
           roundTrips: 3,
           timeElapsed: 300,
+          connectionTiming: {
+            connectionTime: 250,
+            dnsResolutionTime: 0,
+            sslTime: 100,
+            timeToFirstByte: 300,
+          },
         });
       });
 
@@ -124,6 +154,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
           congestionWindow: 10,
           roundTrips: 3,
           timeElapsed: 300 + responseTime,
+          connectionTiming: {
+            connectionTime: 250,
+            dnsResolutionTime: 0,
+            sslTime: 100,
+            timeToFirstByte: 378,
+          },
         });
       });
 
@@ -136,6 +172,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
           congestionWindow: 68,
           roundTrips: 105,
           timeElapsed: 10500,
+          connectionTiming: {
+            connectionTime: 250,
+            dnsResolutionTime: 0,
+            sslTime: 100,
+            timeToFirstByte: 300,
+          },
         });
       });
 
@@ -147,6 +189,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
           congestionWindow: 10,
           roundTrips: 3,
           timeElapsed: 50,
+          connectionTiming: {
+            connectionTime: 250,
+            dnsResolutionTime: 0,
+            sslTime: 100,
+            timeToFirstByte: 300,
+          },
         });
       });
 
@@ -160,6 +208,9 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
           congestionWindow: 10,
           roundTrips: 0,
           timeElapsed: 0,
+          connectionTiming: {
+            timeToFirstByte: 0,
+          },
         });
       });
 
@@ -175,6 +226,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
             congestionWindow: 68,
             roundTrips: 51, // 5 mb / (1460 * 68)
             timeElapsed: 5100,
+            connectionTiming: {
+              connectionTime: 250,
+              dnsResolutionTime: 0,
+              sslTime: 100,
+              timeToFirstByte: 300,
+            },
           }
         );
       });
@@ -191,6 +248,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
             congestionWindow: 10,
             roundTrips: 2,
             timeElapsed: 200,
+            connectionTiming: {
+              connectionTime: 150,
+              dnsResolutionTime: 0,
+              sslTime: undefined, // non-SSL
+              timeToFirstByte: 200,
+            },
           }
         );
       });
@@ -205,6 +268,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
             congestionWindow: 10,
             roundTrips: 2,
             timeElapsed: 200,
+            connectionTiming: {
+              connectionTime: 150,
+              dnsResolutionTime: 0,
+              sslTime: undefined, // non-SSL
+              timeToFirstByte: 200,
+            },
           }
         );
       });
@@ -222,6 +291,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
             congestionWindow: 10,
             roundTrips: 2,
             timeElapsed: 125,
+            connectionTiming: {
+              connectionTime: 150,
+              dnsResolutionTime: 0,
+              sslTime: undefined, // non-SSL
+              timeToFirstByte: 200,
+            },
           }
         );
       });
@@ -240,6 +315,12 @@ describe('DependencyGraph/Simulator/TcpConnection', () => {
             congestionWindow: 68,
             roundTrips: 8,
             timeElapsed: 800, // skips the handshake because time already elapsed
+            connectionTiming: {
+              connectionTime: 250,
+              dnsResolutionTime: 0,
+              sslTime: 100,
+              timeToFirstByte: 300,
+            },
           }
         );
       });


### PR DESCRIPTION
Adds network request timing breakdowns to lantern debug traces. When debugging simulator results (e.g. for debugging #14166), it can be really helpful to see time for DNS, connection, to get the first byte back, etc.

Because the changes are kind of thread through four different files, it might be helpful to look at individual commits (some general trace fixes, getting full node timings to the trace saver, and adding new timings to network nodes).

Changes have no effect on simulator functionality or results. Timings available to audits are unchanged, it's only the trace generator that has access to the full node timings.

---
### Example

Trace from main:
<img width="960" alt="A Chrome DevTools performance trace, showing simulated network requests blocks in a timeline" src="https://user-images.githubusercontent.com/316891/204876742-baeca4cb-8f22-41ae-9141-709b7905acf3.png">


Trace from this branch:
<img width="960" alt="The same performance trace, where network requests now have additional timing annotations" src="https://user-images.githubusercontent.com/316891/204876772-c0e3d25d-c552-449d-bfb6-9fdfc50b6617.png">

For reference, the "real" (devtools-throttled) trace:

<img width="960" alt="A real devtools trace showing similar timing annotations" src="https://user-images.githubusercontent.com/316891/204877666-1d624f17-aa43-4fbb-b442-c2750d8578a9.png">
