### PR TITLE
tests: rewrite fake timer usage to reduce isolation

### DIFF
--- a/core/test/gather/driver/execution-context-test.js
+++ b/core/test/gather/driver/execution-context-test.js
@@ -13,8 +13,6 @@ import {
   timers,
 } from '../../test-utils.js';
 
-timers.useFakeTimers();
-
 // This can be removed when FR becomes the default.
 const createMockSendCommandFn =
   mockCommands.createMockSendCommandFn.bind(null, {useSessionId: false});
@@ -89,6 +87,9 @@ describe('ExecutionContext', () => {
 });
 
 describe('.evaluateAsync', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   /** @type {LH.Gatherer.FRProtocolSession} */
   let sessionMock;
   /** @type {ExecutionContext} */

--- a/core/test/gather/driver/navigation-test.js
+++ b/core/test/gather/driver/navigation-test.js
@@ -18,9 +18,10 @@ const {createMockOnceFn} = mockCommands;
 // https://github.com/GoogleChrome/lighthouse/blob/main/docs/hacking-tips.md#mocking-modules-with-testdouble
 const {gotoURL, getNavigationWarnings} = await import('../../../gather/driver/navigation.js');
 
-timers.useFakeTimers();
-
 describe('.gotoURL', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   /** @type {LH.Gatherer.FRTransitionalDriver} */
   let driver;
   /** @type {ReturnType<typeof createMockDriver>} */

--- a/core/test/gather/driver/prepare-test.js
+++ b/core/test/gather/driver/prepare-test.js
@@ -36,11 +36,9 @@ beforeEach(() => {
   storageMock.getImportantStorageWarning.mockReset();
 });
 
-afterEach(() => {
-  timers.useRealTimers();
-});
-
 describe('.prepareThrottlingAndNetwork()', () => {
+  after(() => timers.dispose());
+
   it('sets throttling appropriately', async () => {
     await prepare.prepareThrottlingAndNetwork(
       sessionMock.asSession(),
@@ -153,6 +151,8 @@ describe('.prepareThrottlingAndNetwork()', () => {
 });
 
 describe('.prepareTargetForIndividualNavigation()', () => {
+  after(() => timers.dispose());
+
   it('clears storage when not disabled', async () => {
     await prepare.prepareTargetForIndividualNavigation(
       sessionMock.asSession(),
@@ -210,6 +210,8 @@ describe('.prepareTargetForIndividualNavigation()', () => {
 });
 
 describe('.prepareTargetForNavigationMode()', () => {
+  after(() => timers.dispose());
+
   let driverMock = createMockDriver();
 
   beforeEach(() => {
@@ -263,6 +265,7 @@ describe('.prepareTargetForNavigationMode()', () => {
 
   it('enables async stacks on every main frame navigation', async () => {
     timers.useFakeTimers();
+    after(() => timers.dispose());
 
     sessionMock.sendCommand
       .mockResponse('Debugger.enable')
@@ -329,6 +332,7 @@ describe('.prepareTargetForNavigationMode()', () => {
 
   it('handle javascript dialogs automatically', async () => {
     timers.useFakeTimers();
+    after(() => timers.dispose());
 
     sessionMock.sendCommand.mockResponse('Page.handleJavaScriptDialog');
     sessionMock.on.mockEvent('Page.javascriptDialogOpening', {type: 'confirm'});

--- a/core/test/gather/driver/prepare-test.js
+++ b/core/test/gather/driver/prepare-test.js
@@ -37,8 +37,6 @@ beforeEach(() => {
 });
 
 describe('.prepareThrottlingAndNetwork()', () => {
-  after(() => timers.dispose());
-
   it('sets throttling appropriately', async () => {
     await prepare.prepareThrottlingAndNetwork(
       sessionMock.asSession(),
@@ -151,8 +149,6 @@ describe('.prepareThrottlingAndNetwork()', () => {
 });
 
 describe('.prepareTargetForIndividualNavigation()', () => {
-  after(() => timers.dispose());
-
   it('clears storage when not disabled', async () => {
     await prepare.prepareTargetForIndividualNavigation(
       sessionMock.asSession(),
@@ -210,8 +206,6 @@ describe('.prepareTargetForIndividualNavigation()', () => {
 });
 
 describe('.prepareTargetForNavigationMode()', () => {
-  after(() => timers.dispose());
-
   let driverMock = createMockDriver();
 
   beforeEach(() => {

--- a/core/test/gather/driver/wait-for-condition-test.js
+++ b/core/test/gather/driver/wait-for-condition-test.js
@@ -16,7 +16,6 @@ import {
 
 const {createMockOnceFn} = mockCommands;
 
-timers.useFakeTimers();
 
 function createMockWaitForFn() {
   const {promise, resolve, reject} = createDecomposedPromise();
@@ -54,6 +53,9 @@ function createMockMultipleInvocationWaitForFn() {
 }
 
 describe('waitForFullyLoaded()', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   let session;
   let networkMonitor;
   /** @type {import('../../../gather/driver/wait-for-condition.js').WaitOptions} */
@@ -223,6 +225,9 @@ describe('waitForFullyLoaded()', () => {
 });
 
 describe('waitForFcp()', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   let session;
 
   beforeEach(() => {

--- a/core/test/gather/gatherers/css-usage-test.js
+++ b/core/test/gather/gatherers/css-usage-test.js
@@ -9,9 +9,10 @@ import {defaultSettings} from '../../../config/constants.js';
 import {createMockDriver, createMockBaseArtifacts} from '../mock-driver.js';
 import {flushAllTimersAndMicrotasks, timers} from '../../test-utils.js';
 
-timers.useFakeTimers();
-
 describe('.getArtifact', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   it('gets CSS usage', async () => {
     const driver = createMockDriver();
     driver.defaultSession.on

--- a/core/test/gather/gatherers/image-elements-test.js
+++ b/core/test/gather/gatherers/image-elements-test.js
@@ -16,8 +16,6 @@ const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', 
 
 const networkRecords = NetworkRecorder.recordsFromLogs(devtoolsLog);
 
-timers.useFakeTimers();
-
 /**
  * @param {Partial<LH.Artifacts.ImageElement>=} partial
  * @return {LH.Artifacts.ImageElement}
@@ -70,6 +68,9 @@ function makeImageElements() {
 }
 
 describe('.fetchElementsWithSizingInformation', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   let gatherer = makeImageElements();
   let driver = createMockDriver();
   beforeEach(() => {
@@ -128,6 +129,9 @@ describe('.fetchElementsWithSizingInformation', () => {
 });
 
 describe('.fetchSourceRules', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   let gatherer = makeImageElements();
   let session = createMockSession();
 
@@ -229,6 +233,9 @@ describe('.fetchSourceRules', () => {
 });
 
 describe('.collectExtraDetails', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   let gatherer = makeImageElements();
   let driver = createMockDriver().asDriver();
 
@@ -291,7 +298,7 @@ describe('.collectExtraDetails', () => {
   });
 });
 
-describe('FR compat', () => {
+describe('FR compat (image-elements)', () => {
   it('uses loadData in legacy mode', async () => {
     const gatherer = new ImageElements();
     const mockContext = createMockContext();

--- a/core/test/gather/gatherers/inspector-issues-test.js
+++ b/core/test/gather/gatherers/inspector-issues-test.js
@@ -10,8 +10,6 @@ import {createMockContext} from '../mock-driver.js';
 import {flushAllTimersAndMicrotasks, timers} from '../../test-utils.js';
 import {networkRecordsToDevtoolsLog} from '../../network-records-to-devtools-log.js';
 
-timers.useFakeTimers();
-
 /**
  * @param {Partial<LH.Artifacts.NetworkRequest>=} partial
  * @return {LH.Artifacts.NetworkRequest}
@@ -149,6 +147,9 @@ function mockDeprecation(type) {
 }
 
 describe('instrumentation', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   it('collects inspector issues', async () => {
     const mockContext = createMockContext();
     const mockMixedContentIssue = mockMixedContent({resourceType: 'Audio'});
@@ -304,7 +305,10 @@ describe('_getArtifact', () => {
   });
 });
 
-describe('FR compat', () => {
+describe('FR compat (inspector-issues)', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   let mockContext = createMockContext();
   /** @type {InspectorIssues} */
   let gatherer;

--- a/core/test/gather/gatherers/js-usage-test.js
+++ b/core/test/gather/gatherers/js-usage-test.js
@@ -11,9 +11,10 @@ import {createMockSendCommandFn, createMockOnFn} from '../mock-commands.js';
 import {createMockContext} from '../../gather/mock-driver.js';
 import {flushAllTimersAndMicrotasks, timers} from '../../test-utils.js';
 
-timers.useFakeTimers();
-
 describe('JsUsage gatherer', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   /**
    * `scriptParsedEvents` mocks the `Debugger.scriptParsed` events.
    * `coverage` mocks the result of `Profiler.takePreciseCoverage`.

--- a/core/test/gather/gatherers/main-document-content-test.js
+++ b/core/test/gather/gatherers/main-document-content-test.js
@@ -13,7 +13,7 @@ const devtoolsLog = readJson('../../fixtures/traces/lcp-m78.devtools.log.json', 
 
 const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 
-describe('FR compat', () => {
+describe('FR compat (main-document-content)', () => {
   it('uses loadData in legacy mode', async () => {
     const gatherer = new MainDocumentContent();
     const networkRecords = NetworkRecorder.recordsFromLogs(devtoolsLog);

--- a/core/test/gather/gatherers/source-maps-test.js
+++ b/core/test/gather/gatherers/source-maps-test.js
@@ -10,8 +10,6 @@ import SourceMaps from '../../../gather/gatherers/source-maps.js';
 import {createMockSendCommandFn, createMockOnFn} from '../mock-commands.js';
 import {flushAllTimersAndMicrotasks, fnAny, timers} from '../../test-utils.js';
 
-timers.useFakeTimers();
-
 const mapJson = JSON.stringify({
   version: 3,
   file: 'out.js',
@@ -22,6 +20,9 @@ const mapJson = JSON.stringify({
 });
 
 describe('SourceMaps gatherer', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   /**
    * `scriptParsedEvent` mocks the `sourceMapURL` and `url` seen from the protocol.
    * `map` mocks the (JSON) of the source maps that `Runtime.evaluate` returns.

--- a/core/test/gather/gatherers/trace-elements-test.js
+++ b/core/test/gather/gatherers/trace-elements-test.js
@@ -13,8 +13,6 @@ import {flushAllTimersAndMicrotasks, fnAny, readJson, timers} from '../../test-u
 
 const animationTrace = readJson('../../fixtures/traces/animation.json', import.meta);
 
-timers.useFakeTimers();
-
 function makeLayoutShiftTraceEvent(score, impactedNodes, had_recent_input = false) { // eslint-disable-line camelcase
   return {
     name: 'LayoutShift',
@@ -735,6 +733,9 @@ describe('Trace Elements gatherer - Animated Elements', () => {
 });
 
 describe('instrumentation', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   it('resolves animation name', async () => {
     const connectionStub = new Connection();
     connectionStub.on = createMockOnFn()
@@ -779,7 +780,7 @@ describe('instrumentation', () => {
   });
 });
 
-describe('FR compat', () => {
+describe('FR compat (trace-elements)', () => {
   it('uses loadData in legacy mode', async () => {
     const trace = ['1', '2'];
     const gatherer = new TraceElementsGatherer();

--- a/core/test/gather/gatherers/trace-test.js
+++ b/core/test/gather/gatherers/trace-test.js
@@ -8,9 +8,10 @@ import {makePromiseInspectable, flushAllTimersAndMicrotasks, timers} from '../..
 import {createMockContext} from '../mock-driver.js';
 import TraceGatherer from '../../../gather/gatherers/trace.js';
 
-timers.useFakeTimers();
-
 describe('TraceGatherer', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   let gatherer = new TraceGatherer();
   let context = createMockContext();
 

--- a/core/test/gather/session-test.js
+++ b/core/test/gather/session-test.js
@@ -17,9 +17,10 @@ import {
   timers,
 } from '../test-utils.js';
 
-timers.useFakeTimers();
-
 describe('ProtocolSession', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   const DEFAULT_TIMEOUT = 30_000;
 
   /** @type {LH.Puppeteer.CDPSession} */

--- a/core/test/legacy/gather/driver-test.js
+++ b/core/test/legacy/gather/driver-test.js
@@ -17,8 +17,6 @@ import {
 
 const {createMockSendCommandFn} = mockCommands;
 
-timers.useFakeTimers();
-
 /**
  * @typedef DriverMockMethods
  * @property {Driver['evaluate']} evaluate redefined to remove "private" designation
@@ -44,6 +42,9 @@ beforeEach(() => {
 });
 
 describe('.getRequestContent', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   it('throws if getRequestContent takes too long', async () => {
     const mockTimeout = 5000;
     const driverTimeout = 1000;
@@ -68,6 +69,9 @@ describe('.getRequestContent', () => {
 });
 
 describe('.evaluateAsync', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   // The logic here is tested by core/test/gather/driver/execution-context-test.js
   // Just exercise a bit of the plumbing here to ensure we delegate correctly for plugin backcompat.
   it('evaluates an expression', async () => {
@@ -94,6 +98,9 @@ describe('.evaluateAsync', () => {
 });
 
 describe('.sendCommand', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   it('.sendCommand timesout when commands take too long', async () => {
     const mockTimeout = 5000;
     // @ts-expect-error
@@ -117,6 +124,9 @@ describe('.sendCommand', () => {
 });
 
 describe('.beginTrace', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   beforeEach(() => {
     connectionStub.sendCommand = createMockSendCommandFn()
       .mockResponse('Browser.getVersion', fakeDriver.protocolGetVersionResponse)
@@ -145,6 +155,9 @@ describe('.beginTrace', () => {
 });
 
 describe('Domain.enable/disable State', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   it('dedupes (simple)', async () => {
     connectionStub.sendCommand = createMockSendCommandFn()
       .mockResponse('Network.enable')
@@ -201,6 +214,9 @@ describe('Domain.enable/disable State', () => {
 });
 
 describe('Multi-target management', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   it('enables the Network domain for iframes', async () => {
     connectionStub.sendCommand = createMockSendCommandFn()
       .mockResponseToSession('Network.enable', '123')

--- a/core/test/scripts/run-mocha-tests.js
+++ b/core/test/scripts/run-mocha-tests.js
@@ -50,8 +50,6 @@ function getFailedTests() {
 // all test files (everything if --no-parallel, else each worker will load a subset of the files
 // all at once). This results in unexpected mocks contaminating other test files.
 //
-// Tests do other undesired things in the global scope too, such as enabling fake timers.
-//
 // For now, we isolate a number of tests until they can be refactored.
 //
 // To run tests without isolation, and all in one process:
@@ -63,21 +61,6 @@ function getFailedTests() {
 //    yarn mocha --no-parallel
 // (also, just comment out the `testsToRunIsolated` below, as they won't impact this verification)
 const testsToIsolate = new Set([
-  // grep -lRE '^timers\.useFakeTimers' --include='*-test.*' --exclude-dir=node_modules
-  'flow-report/test/common-test.tsx',
-  'core/test/gather/session-test.js',
-  'core/test/legacy/gather/driver-test.js',
-  'core/test/gather/driver/execution-context-test.js',
-  'core/test/gather/driver/navigation-test.js',
-  'core/test/gather/driver/wait-for-condition-test.js',
-  'core/test/gather/gatherers/css-usage-test.js',
-  'core/test/gather/gatherers/image-elements-test.js',
-  'core/test/gather/gatherers/inspector-issues-test.js',
-  'core/test/gather/gatherers/js-usage-test.js',
-  'core/test/gather/gatherers/source-maps-test.js',
-  'core/test/gather/gatherers/trace-elements-test.js',
-  'core/test/gather/gatherers/trace-test.js',
-
   // grep -lRE '^await td\.replace' --include='*-test.*' --exclude-dir=node_modules
   'core/test/gather/snapshot-runner-test.js',
   'core/test/gather/timespan-runner-test.js',

--- a/core/test/test-env/mocha-setup.js
+++ b/core/test/test-env/mocha-setup.js
@@ -162,6 +162,7 @@ const rootHooks = {
       });
     }
   },
+  // This runs _once_, after all of the tests in the root suite.
   async afterAll() {
     timers.dispose();
     td.reset();

--- a/flow-report/test/common-test.tsx
+++ b/flow-report/test/common-test.tsx
@@ -12,9 +12,10 @@ import {FlowStepThumbnail} from '../src/common';
 
 let lhr: LH.Result;
 
-timers.useFakeTimers();
-
 describe('FlowStepThumbnail', () => {
+  before(() => timers.useFakeTimers());
+  after(() => timers.dispose());
+
   beforeEach(() => {
     global.console.warn = jestMock.fn();
 


### PR DESCRIPTION
Moved all the invocations of `timers` into a scoped context (`describe`, typically).