### PR TITLE
core(inspector-issues): ignore csp for scoring

### DIFF
--- a/core/audits/dobetterweb/inspector-issues.js
+++ b/core/audits/dobetterweb/inspector-issues.js
@@ -180,8 +180,12 @@ class IssuesPanelEntries extends Audit {
     if (cspIssues.length) {
       items.push(this.getContentSecurityPolicyRow(cspIssues));
     }
+    // The audit `csp-xss` is explicitly not scored for actionability reasons, so we shouldn't let
+    // a CSP issue fail this audit either.
+    const itemsRelevantToScoring =
+      items.filter(item => item.issueType !== 'Content security policy');
     return {
-      score: items.length > 0 ? 0 : 1,
+      score: itemsRelevantToScoring.length > 0 ? 0 : 1,
       details: Audit.makeTableDetails(headings, items),
     };
   }

--- a/core/test/audits/dobetterweb/inspector-issues-test.js
+++ b/core/test/audits/dobetterweb/inspector-issues-test.js
@@ -233,7 +233,7 @@ describe('Has inspector issues audit', () => {
     const auditResult = InspectorIssuesAudit.audit({
       InspectorIssues: issues,
     });
-    expect(auditResult.score).toBe(0);
+    expect(auditResult.score).toBe(1);
     expect(auditResult.details.items[0]).toMatchObject({
       issueType: 'Content security policy',
       subItems: {


### PR DESCRIPTION
We chose to not score `csp-xss` for reasons, yet `inspector-issues` will fail if a CSP issue is present. This PR makes LH more consistent by ignoring that issue for purposes of scoring.