### PR TITLE
tests(devtools): use correct build folder for e2e tests

### DIFF
--- a/core/test/devtools-tests/run-e2e-tests.sh
+++ b/core/test/devtools-tests/run-e2e-tests.sh
@@ -9,9 +9,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD_FOLDER="${BUILD_FOLDER:-LighthouseIntegration}"
 export LH_ROOT="$SCRIPT_DIR/../../.."
 
 cd "$DEVTOOLS_PATH"
 
 TEST_PATTERN="${1:-lighthouse/*}"
-npm run e2etest -- "$TEST_PATTERN"
+npm run e2etest -- "$TEST_PATTERN" --target=$BUILD_FOLDER

--- a/third-party/devtools-tests/e2e/lighthouse/snapshot_test.ts
+++ b/third-party/devtools-tests/e2e/lighthouse/snapshot_test.ts
@@ -77,7 +77,7 @@ describe('Snapshot', async function() {
     });
 
     const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr);
-    assert.strictEqual(auditResults.length, 73);
+    assert.strictEqual(auditResults.length, 72);
     assert.strictEqual(erroredAudits.length, 0);
     assert.deepStrictEqual(failedAudits.map(audit => audit.id), [
       'document-title',

--- a/third-party/devtools-tests/e2e/lighthouse/timespan_test.ts
+++ b/third-party/devtools-tests/e2e/lighthouse/timespan_test.ts
@@ -84,7 +84,7 @@ describe('Timespan', async function() {
     assert.strictEqual(devicePixelRatio, 1);
 
     const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr);
-    assert.strictEqual(auditResults.length, 47);
+    assert.strictEqual(auditResults.length, 46);
     assert.strictEqual(erroredAudits.length, 0);
     assert.deepStrictEqual(failedAudits.map(audit => audit.id), []);
 


### PR DESCRIPTION
Ever since https://github.com/GoogleChrome/lighthouse/pull/14492 our devtools e2e tests have been using the incorrect build folder. So we build DT with our changes but then test whatever DT ships in chrome.