### PR TITLE
tests(devtools): support dbw smoke

### DIFF
--- a/cli/test/smokehouse/config/exclusions.js
+++ b/cli/test/smokehouse/config/exclusions.js
@@ -14,7 +14,7 @@ const exclusions = {
   'devtools': [
     // Disabled because normal Chrome usage makes DevTools not function on
     // these poorly constructed pages
-    'errors-expired-ssl', 'errors-infinite-loop', 'dbw' /* dialog prompt */,
+    'errors-expired-ssl', 'errors-infinite-loop',
     // Disabled because Chrome will follow the redirect first, and Lighthouse will
     // only ever see/run the final URL.
     'redirects-client-paint-server', 'redirects-multiple-server',

--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -36,15 +36,6 @@ const imgB = {
  * Expected Lighthouse audit values for Do Better Web tests.
  */
 const expectations = {
-  networkRequests: {
-    // Number of network requests differs between Fraggle Rock and legacy modes because
-    // FR has fewer passes, preserve this check moving forward.
-    _fraggleRockOnly: true,
-
-    // 22 requests made for a single navigation.
-    // 6 extra requests made because stylesheets are evicted from the cache by the time DT opens.
-    length: 28,
-  },
   artifacts: {
     BenchmarkIndex: '<10000',
     HostFormFactor: 'desktop',
@@ -243,6 +234,8 @@ const expectations = {
               sourceLocation: {url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000'},
             },
             4: {
+              // In the DT runner, the initial page load before staring Lighthouse will prevent this error.
+              _excludeRunner: 'devtools',
               source: 'network',
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
               sourceLocation: {url: 'http://localhost:10200/favicon.ico'},

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -288,6 +288,13 @@ async function installConsoleListener(inspectorSession, logs) {
 }
 
 /**
+ * @param {puppeteer.Dialog} dialog
+ */
+function dismissDialog(dialog) {
+  dialog.dismiss();
+}
+
+/**
  * @param {string} url
  * @param {{config?: LH.Config.Json, chromeFlags?: string[], useLegacyNavigation?: boolean}} [options]
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, logs: string[]}>}
@@ -315,9 +322,13 @@ async function testUrlFromDevtools(url, options = {}) {
     const logs = [];
     await installConsoleListener(inspectorSession, logs);
 
+    page.on('dialog', dismissDialog);
+
     await page.goto(url, {waitUntil: ['domcontentloaded']});
 
     await waitForFunction(inspectorSession, waitForLighthouseReady);
+
+    page.off('dialog', dismissDialog);
 
     if (!useLegacyNavigation) {
       await evaluateInSession(inspectorSession, disableLegacyNavigation);


### PR DESCRIPTION
Would be nice to have DT smoke coverage of https://github.com/GoogleChrome/lighthouse/pull/14465. Turns out it was pretty easy to get dbw working in the DT smoke runner.
