### PR TITLE
core(fr): preserve scroll position in gatherers

### DIFF
--- a/core/gather/gatherers/accessibility.js
+++ b/core/gather/gatherers/accessibility.js
@@ -15,76 +15,80 @@ import {pageFunctions} from '../../lib/page-functions.js';
  */
 /* c8 ignore start */
 async function runA11yChecks() {
+  /** @type {import('axe-core/axe')} */
+  // @ts-expect-error - axe defined by axeLibSource
+  const axe = window.axe;
+  const application = `lighthouse-${Math.random()}`;
+  axe.configure({
+    branding: {
+      application,
+    },
+    noHtml: true,
+  });
+  const axeResults = await axe.run(document, {
+    elementRef: true,
+    runOnly: {
+      type: 'tag',
+      values: [
+        'wcag2a',
+        'wcag2aa',
+      ],
+    },
+    // resultTypes doesn't limit the output of the axeResults object. Instead, if it's defined,
+    // some expensive element identification is done only for the respective types. https://github.com/dequelabs/axe-core/blob/f62f0cf18f7b69b247b0b6362cf1ae71ffbf3a1b/lib/core/reporters/helpers/process-aggregate.js#L61-L97
+    resultTypes: ['violations', 'inapplicable'],
+    rules: {
+      // Consider http://go/prcpg for expert review of the aXe rules.
+      'tabindex': {enabled: true},
+      'accesskeys': {enabled: true},
+      'heading-order': {enabled: true},
+      'meta-viewport': {enabled: true},
+      'duplicate-id': {enabled: false},
+      'table-fake-caption': {enabled: false},
+      'td-has-header': {enabled: false},
+      'marquee': {enabled: false},
+      'area-alt': {enabled: false},
+      'html-xml-lang-mismatch': {enabled: false},
+      'blink': {enabled: false},
+      'server-side-image-map': {enabled: false},
+      'identical-links-same-purpose': {enabled: false},
+      'no-autoplay-audio': {enabled: false},
+      'svg-img-alt': {enabled: false},
+      'audio-caption': {enabled: false},
+      'aria-treeitem-name': {enabled: true},
+      // https://github.com/dequelabs/axe-core/issues/2958
+      'nested-interactive': {enabled: false},
+      'frame-focusable-content': {enabled: false},
+      'aria-roledescription': {enabled: false},
+      'scrollable-region-focusable': {enabled: false},
+      // TODO(paulirish): create audits and enable these 3.
+      'input-button-name': {enabled: false},
+      'role-img-alt': {enabled: false},
+      'select-name': {enabled: false},
+    },
+  });
+
+  // axe just scrolled the page, scroll back to the top of the page so that element positions
+  // are relative to the top of the page
+  document.documentElement.scrollTop = 0;
+
+  return {
+    violations: axeResults.violations.map(createAxeRuleResultArtifact),
+    incomplete: axeResults.incomplete.map(createAxeRuleResultArtifact),
+    notApplicable: axeResults.inapplicable.map(result => ({id: result.id})), // FYI: inapplicable => notApplicable!
+    passes: axeResults.passes.map(result => ({id: result.id})),
+    version: axeResults.testEngine.version,
+  };
+}
+
+function runA11yChecksAndResetScroll() {
   const originalScrollPosition = {
     x: window.scrollX,
     y: window.scrollY,
   };
 
   try {
-    /** @type {import('axe-core/axe')} */
-    // @ts-expect-error - axe defined by axeLibSource
-    const axe = window.axe;
-    const application = `lighthouse-${Math.random()}`;
-    axe.configure({
-      branding: {
-        application,
-      },
-      noHtml: true,
-    });
-    const axeResults = await axe.run(document, {
-      elementRef: true,
-      runOnly: {
-        type: 'tag',
-        values: [
-          'wcag2a',
-          'wcag2aa',
-        ],
-      },
-      // resultTypes doesn't limit the output of the axeResults object. Instead, if it's defined,
-      // some expensive element identification is done only for the respective types. https://github.com/dequelabs/axe-core/blob/f62f0cf18f7b69b247b0b6362cf1ae71ffbf3a1b/lib/core/reporters/helpers/process-aggregate.js#L61-L97
-      resultTypes: ['violations', 'inapplicable'],
-      rules: {
-        // Consider http://go/prcpg for expert review of the aXe rules.
-        'tabindex': {enabled: true},
-        'accesskeys': {enabled: true},
-        'heading-order': {enabled: true},
-        'meta-viewport': {enabled: true},
-        'duplicate-id': {enabled: false},
-        'table-fake-caption': {enabled: false},
-        'td-has-header': {enabled: false},
-        'marquee': {enabled: false},
-        'area-alt': {enabled: false},
-        'html-xml-lang-mismatch': {enabled: false},
-        'blink': {enabled: false},
-        'server-side-image-map': {enabled: false},
-        'identical-links-same-purpose': {enabled: false},
-        'no-autoplay-audio': {enabled: false},
-        'svg-img-alt': {enabled: false},
-        'audio-caption': {enabled: false},
-        'aria-treeitem-name': {enabled: true},
-        // https://github.com/dequelabs/axe-core/issues/2958
-        'nested-interactive': {enabled: false},
-        'frame-focusable-content': {enabled: false},
-        'aria-roledescription': {enabled: false},
-        'scrollable-region-focusable': {enabled: false},
-        // TODO(paulirish): create audits and enable these 3.
-        'input-button-name': {enabled: false},
-        'role-img-alt': {enabled: false},
-        'select-name': {enabled: false},
-      },
-    });
-
-    // axe just scrolled the page, scroll back to the top of the page so that element positions
-    // are relative to the top of the page
-    document.documentElement.scrollTop = 0;
-
-    return {
-      violations: axeResults.violations.map(createAxeRuleResultArtifact),
-      incomplete: axeResults.incomplete.map(createAxeRuleResultArtifact),
-      notApplicable: axeResults.inapplicable.map(result => ({id: result.id})), // FYI: inapplicable => notApplicable!
-      passes: axeResults.passes.map(result => ({id: result.id})),
-      version: axeResults.testEngine.version,
-    };
+    return runA11yChecks();
   } finally {
     window.scrollTo(originalScrollPosition.x, originalScrollPosition.y);
   }
@@ -177,13 +181,14 @@ class Accessibility extends FRGatherer {
   getArtifact(passContext) {
     const driver = passContext.driver;
 
-    return driver.executionContext.evaluate(runA11yChecks, {
+    return driver.executionContext.evaluate(runA11yChecksAndResetScroll, {
       args: [],
       useIsolation: true,
       deps: [
         axeSource,
         pageFunctions.getNodeDetails,
         createAxeRuleResultArtifact,
+        runA11yChecks,
       ],
     });
   }

--- a/core/gather/gatherers/accessibility.js
+++ b/core/gather/gatherers/accessibility.js
@@ -20,74 +20,74 @@ async function runA11yChecks() {
     y: window.scrollY,
   };
 
-  /** @type {import('axe-core/axe')} */
-  // @ts-expect-error - axe defined by axeLibSource
-  const axe = window.axe;
-  const application = `lighthouse-${Math.random()}`;
-  axe.configure({
-    branding: {
-      application,
-    },
-    noHtml: true,
-  });
-  const axeResults = await axe.run(document, {
-    elementRef: true,
-    runOnly: {
-      type: 'tag',
-      values: [
-        'wcag2a',
-        'wcag2aa',
-      ],
-    },
-    // resultTypes doesn't limit the output of the axeResults object. Instead, if it's defined,
-    // some expensive element identification is done only for the respective types. https://github.com/dequelabs/axe-core/blob/f62f0cf18f7b69b247b0b6362cf1ae71ffbf3a1b/lib/core/reporters/helpers/process-aggregate.js#L61-L97
-    resultTypes: ['violations', 'inapplicable'],
-    rules: {
-      // Consider http://go/prcpg for expert review of the aXe rules.
-      'tabindex': {enabled: true},
-      'accesskeys': {enabled: true},
-      'heading-order': {enabled: true},
-      'meta-viewport': {enabled: true},
-      'duplicate-id': {enabled: false},
-      'table-fake-caption': {enabled: false},
-      'td-has-header': {enabled: false},
-      'marquee': {enabled: false},
-      'area-alt': {enabled: false},
-      'html-xml-lang-mismatch': {enabled: false},
-      'blink': {enabled: false},
-      'server-side-image-map': {enabled: false},
-      'identical-links-same-purpose': {enabled: false},
-      'no-autoplay-audio': {enabled: false},
-      'svg-img-alt': {enabled: false},
-      'audio-caption': {enabled: false},
-      'aria-treeitem-name': {enabled: true},
-      // https://github.com/dequelabs/axe-core/issues/2958
-      'nested-interactive': {enabled: false},
-      'frame-focusable-content': {enabled: false},
-      'aria-roledescription': {enabled: false},
-      'scrollable-region-focusable': {enabled: false},
-      // TODO(paulirish): create audits and enable these 3.
-      'input-button-name': {enabled: false},
-      'role-img-alt': {enabled: false},
-      'select-name': {enabled: false},
-    },
-  });
+  try {
+    /** @type {import('axe-core/axe')} */
+    // @ts-expect-error - axe defined by axeLibSource
+    const axe = window.axe;
+    const application = `lighthouse-${Math.random()}`;
+    axe.configure({
+      branding: {
+        application,
+      },
+      noHtml: true,
+    });
+    const axeResults = await axe.run(document, {
+      elementRef: true,
+      runOnly: {
+        type: 'tag',
+        values: [
+          'wcag2a',
+          'wcag2aa',
+        ],
+      },
+      // resultTypes doesn't limit the output of the axeResults object. Instead, if it's defined,
+      // some expensive element identification is done only for the respective types. https://github.com/dequelabs/axe-core/blob/f62f0cf18f7b69b247b0b6362cf1ae71ffbf3a1b/lib/core/reporters/helpers/process-aggregate.js#L61-L97
+      resultTypes: ['violations', 'inapplicable'],
+      rules: {
+        // Consider http://go/prcpg for expert review of the aXe rules.
+        'tabindex': {enabled: true},
+        'accesskeys': {enabled: true},
+        'heading-order': {enabled: true},
+        'meta-viewport': {enabled: true},
+        'duplicate-id': {enabled: false},
+        'table-fake-caption': {enabled: false},
+        'td-has-header': {enabled: false},
+        'marquee': {enabled: false},
+        'area-alt': {enabled: false},
+        'html-xml-lang-mismatch': {enabled: false},
+        'blink': {enabled: false},
+        'server-side-image-map': {enabled: false},
+        'identical-links-same-purpose': {enabled: false},
+        'no-autoplay-audio': {enabled: false},
+        'svg-img-alt': {enabled: false},
+        'audio-caption': {enabled: false},
+        'aria-treeitem-name': {enabled: true},
+        // https://github.com/dequelabs/axe-core/issues/2958
+        'nested-interactive': {enabled: false},
+        'frame-focusable-content': {enabled: false},
+        'aria-roledescription': {enabled: false},
+        'scrollable-region-focusable': {enabled: false},
+        // TODO(paulirish): create audits and enable these 3.
+        'input-button-name': {enabled: false},
+        'role-img-alt': {enabled: false},
+        'select-name': {enabled: false},
+      },
+    });
 
-  // axe just scrolled the page, scroll back to the top of the page so that element positions
-  // are relative to the top of the page
-  document.documentElement.scrollTop = 0;
+    // axe just scrolled the page, scroll back to the top of the page so that element positions
+    // are relative to the top of the page
+    document.documentElement.scrollTop = 0;
 
-  const result = {
-    violations: axeResults.violations.map(createAxeRuleResultArtifact),
-    incomplete: axeResults.incomplete.map(createAxeRuleResultArtifact),
-    notApplicable: axeResults.inapplicable.map(result => ({id: result.id})), // FYI: inapplicable => notApplicable!
-    passes: axeResults.passes.map(result => ({id: result.id})),
-    version: axeResults.testEngine.version,
-  };
-
-  window.scrollTo(originalScrollPosition.x, originalScrollPosition.y);
-
-  return result;
+    return {
+      violations: axeResults.violations.map(createAxeRuleResultArtifact),
+      incomplete: axeResults.incomplete.map(createAxeRuleResultArtifact),
+      notApplicable: axeResults.inapplicable.map(result => ({id: result.id})), // FYI: inapplicable => notApplicable!
+      passes: axeResults.passes.map(result => ({id: result.id})),
+      version: axeResults.testEngine.version,
+    };
+  } finally {
+    window.scrollTo(originalScrollPosition.x, originalScrollPosition.y);
+  }
 }
 
 /**

--- a/core/gather/gatherers/accessibility.js
+++ b/core/gather/gatherers/accessibility.js
@@ -15,6 +15,11 @@ import {pageFunctions} from '../../lib/page-functions.js';
  */
 /* c8 ignore start */
 async function runA11yChecks() {
+  const originalScrollPosition = {
+    x: window.scrollX,
+    y: window.scrollY,
+  };
+
   /** @type {import('axe-core/axe')} */
   // @ts-expect-error - axe defined by axeLibSource
   const axe = window.axe;
@@ -72,13 +77,17 @@ async function runA11yChecks() {
   // are relative to the top of the page
   document.documentElement.scrollTop = 0;
 
-  return {
+  const result = {
     violations: axeResults.violations.map(createAxeRuleResultArtifact),
     incomplete: axeResults.incomplete.map(createAxeRuleResultArtifact),
     notApplicable: axeResults.inapplicable.map(result => ({id: result.id})), // FYI: inapplicable => notApplicable!
     passes: axeResults.passes.map(result => ({id: result.id})),
     version: axeResults.testEngine.version,
   };
+
+  window.scrollTo(originalScrollPosition.x, originalScrollPosition.y);
+
+  return result;
 }
 
 /**

--- a/core/gather/gatherers/accessibility.js
+++ b/core/gather/gatherers/accessibility.js
@@ -81,14 +81,14 @@ async function runA11yChecks() {
   };
 }
 
-function runA11yChecksAndResetScroll() {
+async function runA11yChecksAndResetScroll() {
   const originalScrollPosition = {
     x: window.scrollX,
     y: window.scrollY,
   };
 
   try {
-    return runA11yChecks();
+    return await runA11yChecks();
   } finally {
     window.scrollTo(originalScrollPosition.x, originalScrollPosition.y);
   }

--- a/core/gather/gatherers/seo/tap-targets.js
+++ b/core/gather/gatherers/seo/tap-targets.js
@@ -203,9 +203,9 @@ function gatherTapTargets(tapTargetsSelector, className) {
   const tapTargetElements = getElementsInDocument(tapTargetsSelector);
 
   /** @type {{
-      tapTargetElement: Element,
-      clientRects: LH.Artifacts.Rect[]
-    }[]} */
+    tapTargetElement: Element,
+    clientRects: LH.Artifacts.Rect[]
+  }[]} */
   const tapTargetsWithClientRects = [];
   tapTargetElements.forEach(tapTargetElement => {
     // Filter out tap targets that are likely to cause false failures:
@@ -233,12 +233,12 @@ function gatherTapTargets(tapTargetsSelector, className) {
   // detected as non-tappable (they are tappable, just not while the viewport
   // is at the current scroll position)
   const reenableFixedAndStickyElementPointerEvents =
-      disableFixedAndStickyElementPointerEvents(className);
+    disableFixedAndStickyElementPointerEvents(className);
 
   /** @type {{
-      tapTargetElement: Element,
-      visibleClientRects: LH.Artifacts.Rect[]
-    }[]} */
+    tapTargetElement: Element,
+    visibleClientRects: LH.Artifacts.Rect[]
+  }[]} */
   const tapTargetsWithVisibleClientRects = [];
   // We use separate loop here to get visible client rects because that involves
   // scrolling around the page for elementCenterIsAtZAxisTop, which would affect the

--- a/core/gather/gatherers/seo/tap-targets.js
+++ b/core/gather/gatherers/seo/tap-targets.js
@@ -195,6 +195,11 @@ function gatherTapTargets(tapTargetsSelector, className) {
   /** @type {LH.Artifacts.TapTarget[]} */
   const targets = [];
 
+  const originalScrollPosition = {
+    x: window.scrollX,
+    y: window.scrollY,
+  };
+
   // Capture element positions relative to the top of the page
   window.scrollTo(0, 0);
 
@@ -278,6 +283,8 @@ function gatherTapTargets(tapTargetsSelector, className) {
   }
 
   reenableFixedAndStickyElementPointerEvents();
+
+  window.scrollTo(originalScrollPosition.x, originalScrollPosition.y);
 
   return targets;
 }

--- a/core/gather/gatherers/seo/tap-targets.js
+++ b/core/gather/gatherers/seo/tap-targets.js
@@ -192,100 +192,109 @@ function disableFixedAndStickyElementPointerEvents(className) {
  */
 /* c8 ignore start */
 function gatherTapTargets(tapTargetsSelector, className) {
+  /** @type {LH.Artifacts.TapTarget[]} */
+  const targets = [];
+
+  // Capture element positions relative to the top of the page
+  window.scrollTo(0, 0);
+
+  /** @type {HTMLElement[]} */
+  // @ts-expect-error - getElementsInDocument put into scope via stringification
+  const tapTargetElements = getElementsInDocument(tapTargetsSelector);
+
+  /** @type {{
+      tapTargetElement: Element,
+      clientRects: LH.Artifacts.Rect[]
+    }[]} */
+  const tapTargetsWithClientRects = [];
+  tapTargetElements.forEach(tapTargetElement => {
+    // Filter out tap targets that are likely to cause false failures:
+    if (elementHasAncestorTapTarget(tapTargetElement, tapTargetsSelector)) {
+      // This is usually intentional, either the tap targets trigger the same action
+      // or there's a child with a related action (like a delete button for an item)
+      return;
+    }
+    if (elementIsInTextBlock(tapTargetElement)) {
+      // Links inside text blocks cause a lot of failures, and there's also an exception for them
+      // in the Web Content Accessibility Guidelines https://www.w3.org/TR/WCAG21/#target-size
+      return;
+    }
+    if (!elementIsVisible(tapTargetElement)) {
+      return;
+    }
+
+    tapTargetsWithClientRects.push({
+      tapTargetElement,
+      clientRects: getClientRects(tapTargetElement),
+    });
+  });
+
+  // Disable pointer events so that tap targets below them don't get
+  // detected as non-tappable (they are tappable, just not while the viewport
+  // is at the current scroll position)
+  const reenableFixedAndStickyElementPointerEvents =
+      disableFixedAndStickyElementPointerEvents(className);
+
+  /** @type {{
+      tapTargetElement: Element,
+      visibleClientRects: LH.Artifacts.Rect[]
+    }[]} */
+  const tapTargetsWithVisibleClientRects = [];
+  // We use separate loop here to get visible client rects because that involves
+  // scrolling around the page for elementCenterIsAtZAxisTop, which would affect the
+  // client rect positions.
+  tapTargetsWithClientRects.forEach(({tapTargetElement, clientRects}) => {
+    // Filter out empty client rects
+    let visibleClientRects = clientRects.filter(cr => cr.width !== 0 && cr.height !== 0);
+
+    // Filter out client rects that are invisible, e.g because they are in a position absolute element
+    // with a lower z-index than the main content.
+    // This will also filter out all position fixed or sticky tap targets elements because we disable pointer
+    // events on them before running this. That's the correct behavior because whether a position fixed/stick
+    // element overlaps with another tap target depends on the scroll position.
+    visibleClientRects = visibleClientRects.filter(rect => {
+      // Just checking the center can cause false failures for large partially hidden tap targets,
+      // but that should be a rare edge case
+      // @ts-expect-error - put into scope via stringification
+      const rectCenterPoint = getRectCenterPoint(rect);
+      return elementCenterIsAtZAxisTop(tapTargetElement, rectCenterPoint);
+    });
+
+    if (visibleClientRects.length > 0) {
+      tapTargetsWithVisibleClientRects.push({
+        tapTargetElement,
+        visibleClientRects,
+      });
+    }
+  });
+
+  for (const {tapTargetElement, visibleClientRects} of tapTargetsWithVisibleClientRects) {
+    targets.push({
+      clientRects: visibleClientRects,
+      href: /** @type {HTMLAnchorElement} */(tapTargetElement)['href'] || '',
+      // @ts-expect-error - getNodeDetails put into scope via stringification
+      node: getNodeDetails(tapTargetElement),
+    });
+  }
+
+  reenableFixedAndStickyElementPointerEvents();
+
+  return targets;
+}
+
+/**
+ * @param {string} tapTargetsSelector
+ * @param {string} className
+ * @return {LH.Artifacts.TapTarget[]}
+ */
+function gatherTapTargetsAndResetScroll(tapTargetsSelector, className) {
   const originalScrollPosition = {
     x: window.scrollX,
     y: window.scrollY,
   };
 
   try {
-    /** @type {LH.Artifacts.TapTarget[]} */
-    const targets = [];
-
-    // Capture element positions relative to the top of the page
-    window.scrollTo(0, 0);
-
-    /** @type {HTMLElement[]} */
-    // @ts-expect-error - getElementsInDocument put into scope via stringification
-    const tapTargetElements = getElementsInDocument(tapTargetsSelector);
-
-    /** @type {{
-      tapTargetElement: Element,
-      clientRects: LH.Artifacts.Rect[]
-    }[]} */
-    const tapTargetsWithClientRects = [];
-    tapTargetElements.forEach(tapTargetElement => {
-      // Filter out tap targets that are likely to cause false failures:
-      if (elementHasAncestorTapTarget(tapTargetElement, tapTargetsSelector)) {
-        // This is usually intentional, either the tap targets trigger the same action
-        // or there's a child with a related action (like a delete button for an item)
-        return;
-      }
-      if (elementIsInTextBlock(tapTargetElement)) {
-        // Links inside text blocks cause a lot of failures, and there's also an exception for them
-        // in the Web Content Accessibility Guidelines https://www.w3.org/TR/WCAG21/#target-size
-        return;
-      }
-      if (!elementIsVisible(tapTargetElement)) {
-        return;
-      }
-
-      tapTargetsWithClientRects.push({
-        tapTargetElement,
-        clientRects: getClientRects(tapTargetElement),
-      });
-    });
-
-    // Disable pointer events so that tap targets below them don't get
-    // detected as non-tappable (they are tappable, just not while the viewport
-    // is at the current scroll position)
-    const reenableFixedAndStickyElementPointerEvents =
-      disableFixedAndStickyElementPointerEvents(className);
-
-    /** @type {{
-      tapTargetElement: Element,
-      visibleClientRects: LH.Artifacts.Rect[]
-    }[]} */
-    const tapTargetsWithVisibleClientRects = [];
-    // We use separate loop here to get visible client rects because that involves
-    // scrolling around the page for elementCenterIsAtZAxisTop, which would affect the
-    // client rect positions.
-    tapTargetsWithClientRects.forEach(({tapTargetElement, clientRects}) => {
-      // Filter out empty client rects
-      let visibleClientRects = clientRects.filter(cr => cr.width !== 0 && cr.height !== 0);
-
-      // Filter out client rects that are invisible, e.g because they are in a position absolute element
-      // with a lower z-index than the main content.
-      // This will also filter out all position fixed or sticky tap targets elements because we disable pointer
-      // events on them before running this. That's the correct behavior because whether a position fixed/stick
-      // element overlaps with another tap target depends on the scroll position.
-      visibleClientRects = visibleClientRects.filter(rect => {
-        // Just checking the center can cause false failures for large partially hidden tap targets,
-        // but that should be a rare edge case
-        // @ts-expect-error - put into scope via stringification
-        const rectCenterPoint = getRectCenterPoint(rect);
-        return elementCenterIsAtZAxisTop(tapTargetElement, rectCenterPoint);
-      });
-
-      if (visibleClientRects.length > 0) {
-        tapTargetsWithVisibleClientRects.push({
-          tapTargetElement,
-          visibleClientRects,
-        });
-      }
-    });
-
-    for (const {tapTargetElement, visibleClientRects} of tapTargetsWithVisibleClientRects) {
-      targets.push({
-        clientRects: visibleClientRects,
-        href: /** @type {HTMLAnchorElement} */(tapTargetElement)['href'] || '',
-        // @ts-expect-error - getNodeDetails put into scope via stringification
-        node: getNodeDetails(tapTargetElement),
-      });
-    }
-
-    reenableFixedAndStickyElementPointerEvents();
-
-    return targets;
+    return gatherTapTargets(tapTargetsSelector, className);
   } finally {
     window.scrollTo(originalScrollPosition.x, originalScrollPosition.y);
   }
@@ -346,25 +355,27 @@ class TapTargets extends FRGatherer {
     const className = 'lighthouse-disable-pointer-events';
     const styleSheetId = await this.addStyleRule(session, className);
 
-    const tapTargets = await passContext.driver.executionContext.evaluate(gatherTapTargets, {
-      args: [tapTargetsSelector, className],
-      useIsolation: true,
-      deps: [
-        pageFunctions.getNodeDetails,
-        pageFunctions.getElementsInDocument,
-        disableFixedAndStickyElementPointerEvents,
-        elementIsVisible,
-        elementHasAncestorTapTarget,
-        elementCenterIsAtZAxisTop,
-        getClientRects,
-        hasTextNodeSiblingsFormingTextBlock,
-        elementIsInTextBlock,
-        RectHelpers.getRectCenterPoint,
-        pageFunctions.getNodePath,
-        pageFunctions.getNodeSelector,
-        pageFunctions.getNodeLabel,
-      ],
-    });
+    const tapTargets =
+      await passContext.driver.executionContext.evaluate(gatherTapTargetsAndResetScroll, {
+        args: [tapTargetsSelector, className],
+        useIsolation: true,
+        deps: [
+          pageFunctions.getNodeDetails,
+          pageFunctions.getElementsInDocument,
+          disableFixedAndStickyElementPointerEvents,
+          elementIsVisible,
+          elementHasAncestorTapTarget,
+          elementCenterIsAtZAxisTop,
+          getClientRects,
+          hasTextNodeSiblingsFormingTextBlock,
+          elementIsInTextBlock,
+          RectHelpers.getRectCenterPoint,
+          pageFunctions.getNodePath,
+          pageFunctions.getNodeSelector,
+          pageFunctions.getNodeLabel,
+          gatherTapTargets,
+        ],
+      });
 
     await this.removeStyleRule(session, styleSheetId);
 

--- a/core/legacy/gather/driver.js
+++ b/core/legacy/gather/driver.js
@@ -406,23 +406,6 @@ class Driver {
   }
 
   /**
-   * @param {{x: number, y: number}} position
-   * @return {Promise<void>}
-   */
-  scrollTo(position) {
-    const scrollExpression = `window.scrollTo(${position.x}, ${position.y})`;
-    return this.executionContext.evaluateAsync(scrollExpression, {useIsolation: true});
-  }
-
-  /**
-   * @return {Promise<{x: number, y: number}>}
-   */
-  getScrollPosition() {
-    return this.executionContext.evaluateAsync(`({x: window.scrollX, y: window.scrollY})`,
-      {useIsolation: true});
-  }
-
-  /**
    * @param {{additionalTraceCategories?: string|null}=} settings
    * @return {Promise<void>}
    */

--- a/core/legacy/gather/gather-runner.js
+++ b/core/legacy/gather/gather-runner.js
@@ -313,16 +313,11 @@ class GatherRunner {
    * @return {Promise<void>}
    */
   static async afterPass(passContext, loadData, gathererResults) {
-    const driver = passContext.driver;
     const config = passContext.passConfig;
     const gatherers = config.gatherers;
 
     const apStatus = {msg: `Running afterPass methods`, id: `lh:gather:afterPass`};
     log.time(apStatus, 'verbose');
-
-    // Some gatherers scroll the page which can cause unexpected results for other gatherers.
-    // We reset the scroll position in between each gatherer.
-    const scrollPosition = await driver.getScrollPosition();
 
     for (const gathererDefn of gatherers) {
       const gatherer = gathererDefn.instance;
@@ -339,7 +334,6 @@ class GatherRunner {
       gathererResult.push(artifactPromise);
       gathererResults[gatherer.name] = gathererResult;
       await artifactPromise.catch(() => {});
-      await driver.scrollTo(scrollPosition);
       log.timeEnd(status);
     }
     log.timeEnd(apStatus);

--- a/core/test/legacy/gather/fake-driver.js
+++ b/core/test/legacy/gather/fake-driver.js
@@ -10,8 +10,6 @@ import {fnAny, readJson} from '../../test-utils.js';
  * @param {{protocolGetVersionResponse: LH.CrdpCommands['Browser.getVersion']['returnType']}} param0
  */
 function makeFakeDriver({protocolGetVersionResponse}) {
-  let scrollPosition = {x: 0, y: 0};
-
   return {
     get fetcher() {
       return {};
@@ -55,14 +53,6 @@ function makeFakeDriver({protocolGetVersionResponse}) {
       cacheNativesOnNewDocument() {
         return Promise.resolve();
       },
-    },
-    /** @param {{x: number, y: number}} position */
-    scrollTo(position) {
-      scrollPosition = position;
-      return Promise.resolve();
-    },
-    getScrollPosition() {
-      return Promise.resolve(scrollPosition);
     },
     beginTrace() {
       return Promise.resolve();

--- a/core/test/legacy/gather/gather-runner-test.js
+++ b/core/test/legacy/gather/gather-runner-test.js
@@ -687,40 +687,6 @@ describe('GatherRunner', function() {
     });
   });
 
-  it('resets scroll position between every gatherer', async () => {
-    class ScrollMcScrollyGatherer extends TestGatherer {
-      /** @param {{driver: Driver}} context */
-      afterPass(context) {
-        context.driver.scrollTo({x: 1000, y: 1000});
-      }
-    }
-
-    const url = 'https://example.com';
-    const driver = Object.assign({}, fakeDriver);
-    const scrollToSpy = jestMock.spyOn(driver, 'scrollTo');
-
-    const passConfig = {
-      recordTrace: true,
-      gatherers: [
-        {instance: new ScrollMcScrollyGatherer()},
-        {instance: new TestGatherer()},
-      ],
-    };
-
-    /** @type {any} Using Test-only gatherer. */
-    const gathererResults = {
-      TestGatherer: [],
-    };
-    const passContext = {url, driver, passConfig, computedCache: new Map()};
-    await GatherRunner.afterPass(passContext, {}, gathererResults);
-    // One time for the afterPass of ScrollMcScrolly, two times for the resets of the two gatherers.
-    expect(scrollToSpy.mock.calls).toEqual([
-      [{x: 1000, y: 1000}],
-      [{x: 0, y: 0}],
-      [{x: 0, y: 0}],
-    ]);
-  });
-
   it('does as many passes as are required', async () => {
     const t1 = new TestGatherer();
     const t2 = new TestGatherer();


### PR DESCRIPTION
This functionality was never brought from legacy navs into FR so we should be consistent. Also, preserving the scroll position will at least be *less* destructive during flows (#14336).

Additionally, we don't need to restore the scroll position after *every* gatherer, only tap targets and a11y. [I've noticed some issues when we try to restore the scroll position immediately after the bfcache gatherer in legacy mode](https://github.com/GoogleChrome/lighthouse/actions/runs/3887332794/jobs/6633815689).

Moving the scroll position restoration inside the tap targets and a11y gatherers achieves both of these goals.
