### PR TITLE
core: track frame id in network monitor and execution context

### DIFF
--- a/core/gather/driver/execution-context.js
+++ b/core/gather/driver/execution-context.js
@@ -27,7 +27,9 @@ class ExecutionContext {
     // and other page actions. Cleanup our relevant bookkeeping as we see those events.
     // Domains are enabled when a dedicated execution context is requested.
     session.on('Page.frameNavigated', event => {
-      this._mainFrameId = event.frame.id;
+      if (!event.frame.parentId) {
+        this._mainFrameId = event.frame.id;
+      }
       this.clearContextId();
     });
     session.on('Runtime.executionContextDestroyed', event => {

--- a/core/gather/driver/network-monitor.js
+++ b/core/gather/driver/network-monitor.js
@@ -46,7 +46,9 @@ class NetworkMonitor extends NetworkMonitorEventEmitter {
     /** @param {LH.Crdp.Page.FrameNavigatedEvent} event */
     this._onFrameNavigated = event => {
       this._frameNavigations.push(event.frame);
-      this._mainFrameId = event.frame.id;
+      if (!event.frame.parentId) {
+        this._mainFrameId = event.frame.id;
+      }
     };
 
     /** @param {LH.Protocol.RawEventMessage} event */


### PR DESCRIPTION
Second attempt at fixing https://github.com/GoogleChrome/lighthouse/issues/14662. https://github.com/GoogleChrome/lighthouse/pull/14663 was the first attempt

Still using `Page.getFrameTree` for reduced protocol traffic.

