### PR TITLE
core(scoring): rebalance perf metric weightings for v10

### DIFF
--- a/core/config/default-config.js
+++ b/core/config/default-config.js
@@ -462,10 +462,10 @@ const defaultConfig = {
       supportedModes: ['navigation', 'timespan', 'snapshot'],
       auditRefs: [
         {id: 'first-contentful-paint', weight: 10, group: 'metrics', acronym: 'FCP', relevantAudits: metricsToAudits.fcpRelevantAudits},
-        {id: 'speed-index', weight: 10, group: 'metrics', acronym: 'SI'},
-        {id: 'total-blocking-time', weight: 30, group: 'metrics', acronym: 'TBT', relevantAudits: metricsToAudits.tbtRelevantAudits},
         {id: 'largest-contentful-paint', weight: 25, group: 'metrics', acronym: 'LCP', relevantAudits: metricsToAudits.lcpRelevantAudits},
+        {id: 'total-blocking-time', weight: 30, group: 'metrics', acronym: 'TBT', relevantAudits: metricsToAudits.tbtRelevantAudits},
         {id: 'cumulative-layout-shift', weight: 25, group: 'metrics', acronym: 'CLS', relevantAudits: metricsToAudits.clsRelevantAudits},
+        {id: 'speed-index', weight: 10, group: 'metrics', acronym: 'SI'},
         {id: 'experimental-interaction-to-next-paint', weight: 0, group: 'metrics', acronym: 'INP', relevantAudits: metricsToAudits.inpRelevantAudits},
 
         // These are our "invisible" metrics. Not displayed, but still in the LHR.

--- a/core/config/default-config.js
+++ b/core/config/default-config.js
@@ -462,14 +462,14 @@ const defaultConfig = {
       supportedModes: ['navigation', 'timespan', 'snapshot'],
       auditRefs: [
         {id: 'first-contentful-paint', weight: 10, group: 'metrics', acronym: 'FCP', relevantAudits: metricsToAudits.fcpRelevantAudits},
-        {id: 'interactive', weight: 10, group: 'metrics', acronym: 'TTI'},
         {id: 'speed-index', weight: 10, group: 'metrics', acronym: 'SI'},
         {id: 'total-blocking-time', weight: 30, group: 'metrics', acronym: 'TBT', relevantAudits: metricsToAudits.tbtRelevantAudits},
         {id: 'largest-contentful-paint', weight: 25, group: 'metrics', acronym: 'LCP', relevantAudits: metricsToAudits.lcpRelevantAudits},
-        {id: 'cumulative-layout-shift', weight: 15, group: 'metrics', acronym: 'CLS', relevantAudits: metricsToAudits.clsRelevantAudits},
+        {id: 'cumulative-layout-shift', weight: 25, group: 'metrics', acronym: 'CLS', relevantAudits: metricsToAudits.clsRelevantAudits},
         {id: 'experimental-interaction-to-next-paint', weight: 0, group: 'metrics', acronym: 'INP', relevantAudits: metricsToAudits.inpRelevantAudits},
 
         // These are our "invisible" metrics. Not displayed, but still in the LHR.
+        {id: 'interactive', weight: 0, group: 'hidden', acronym: 'TTI'},
         {id: 'max-potential-fid', weight: 0, group: 'hidden'},
         {id: 'first-meaningful-paint', weight: 0, acronym: 'FMP', group: 'hidden'},
 

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -3764,35 +3764,6 @@
                 ]
               },
               {
-                "id": "interactive",
-                "weight": 0,
-                "group": "metrics",
-                "acronym": "TTI"
-              },
-              {
-                "id": "speed-index",
-                "weight": 10,
-                "group": "metrics",
-                "acronym": "SI"
-              },
-              {
-                "id": "total-blocking-time",
-                "weight": 30,
-                "group": "metrics",
-                "acronym": "TBT",
-                "relevantAudits": [
-                  "long-tasks",
-                  "third-party-summary",
-                  "third-party-facades",
-                  "bootup-time",
-                  "mainthread-work-breakdown",
-                  "dom-size",
-                  "duplicated-javascript",
-                  "legacy-javascript",
-                  "viewport"
-                ]
-              },
-              {
                 "id": "largest-contentful-paint",
                 "weight": 25,
                 "group": "metrics",
@@ -3817,6 +3788,23 @@
                 ]
               },
               {
+                "id": "total-blocking-time",
+                "weight": 30,
+                "group": "metrics",
+                "acronym": "TBT",
+                "relevantAudits": [
+                  "long-tasks",
+                  "third-party-summary",
+                  "third-party-facades",
+                  "bootup-time",
+                  "mainthread-work-breakdown",
+                  "dom-size",
+                  "duplicated-javascript",
+                  "legacy-javascript",
+                  "viewport"
+                ]
+              },
+              {
                 "id": "cumulative-layout-shift",
                 "weight": 25,
                 "group": "metrics",
@@ -3826,6 +3814,18 @@
                   "non-composited-animations",
                   "unsized-images"
                 ]
+              },
+              {
+                "id": "speed-index",
+                "weight": 10,
+                "group": "metrics",
+                "acronym": "SI"
+              },
+              {
+                "id": "interactive",
+                "weight": 0,
+                "group": "hidden",
+                "acronym": "TTI"
               },
               {
                 "id": "max-potential-fid",
@@ -17920,35 +17920,6 @@
                 ]
               },
               {
-                "id": "interactive",
-                "weight": 0,
-                "group": "metrics",
-                "acronym": "TTI"
-              },
-              {
-                "id": "speed-index",
-                "weight": 10,
-                "group": "metrics",
-                "acronym": "SI"
-              },
-              {
-                "id": "total-blocking-time",
-                "weight": 30,
-                "group": "metrics",
-                "acronym": "TBT",
-                "relevantAudits": [
-                  "long-tasks",
-                  "third-party-summary",
-                  "third-party-facades",
-                  "bootup-time",
-                  "mainthread-work-breakdown",
-                  "dom-size",
-                  "duplicated-javascript",
-                  "legacy-javascript",
-                  "viewport"
-                ]
-              },
-              {
                 "id": "largest-contentful-paint",
                 "weight": 25,
                 "group": "metrics",
@@ -17973,6 +17944,23 @@
                 ]
               },
               {
+                "id": "total-blocking-time",
+                "weight": 30,
+                "group": "metrics",
+                "acronym": "TBT",
+                "relevantAudits": [
+                  "long-tasks",
+                  "third-party-summary",
+                  "third-party-facades",
+                  "bootup-time",
+                  "mainthread-work-breakdown",
+                  "dom-size",
+                  "duplicated-javascript",
+                  "legacy-javascript",
+                  "viewport"
+                ]
+              },
+              {
                 "id": "cumulative-layout-shift",
                 "weight": 25,
                 "group": "metrics",
@@ -17982,6 +17970,18 @@
                   "non-composited-animations",
                   "unsized-images"
                 ]
+              },
+              {
+                "id": "speed-index",
+                "weight": 10,
+                "group": "metrics",
+                "acronym": "SI"
+              },
+              {
+                "id": "interactive",
+                "weight": 0,
+                "group": "hidden",
+                "acronym": "TTI"
               },
               {
                 "id": "max-potential-fid",

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -3765,7 +3765,7 @@
               },
               {
                 "id": "interactive",
-                "weight": 10,
+                "weight": 0,
                 "group": "metrics",
                 "acronym": "TTI"
               },
@@ -3818,7 +3818,7 @@
               },
               {
                 "id": "cumulative-layout-shift",
-                "weight": 15,
+                "weight": 25,
                 "group": "metrics",
                 "acronym": "CLS",
                 "relevantAudits": [
@@ -9184,7 +9184,7 @@
               },
               {
                 "id": "cumulative-layout-shift",
-                "weight": 15,
+                "weight": 25,
                 "group": "metrics",
                 "acronym": "CLS",
                 "relevantAudits": [
@@ -17921,7 +17921,7 @@
               },
               {
                 "id": "interactive",
-                "weight": 10,
+                "weight": 0,
                 "group": "metrics",
                 "acronym": "TTI"
               },
@@ -17974,7 +17974,7 @@
               },
               {
                 "id": "cumulative-layout-shift",
-                "weight": 15,
+                "weight": 25,
                 "group": "metrics",
                 "acronym": "CLS",
                 "relevantAudits": [

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -6006,35 +6006,6 @@
           ]
         },
         {
-          "id": "interactive",
-          "weight": 0,
-          "group": "metrics",
-          "acronym": "TTI"
-        },
-        {
-          "id": "speed-index",
-          "weight": 10,
-          "group": "metrics",
-          "acronym": "SI"
-        },
-        {
-          "id": "total-blocking-time",
-          "weight": 30,
-          "group": "metrics",
-          "acronym": "TBT",
-          "relevantAudits": [
-            "long-tasks",
-            "third-party-summary",
-            "third-party-facades",
-            "bootup-time",
-            "mainthread-work-breakdown",
-            "dom-size",
-            "duplicated-javascript",
-            "legacy-javascript",
-            "viewport"
-          ]
-        },
-        {
           "id": "largest-contentful-paint",
           "weight": 25,
           "group": "metrics",
@@ -6059,6 +6030,23 @@
           ]
         },
         {
+          "id": "total-blocking-time",
+          "weight": 30,
+          "group": "metrics",
+          "acronym": "TBT",
+          "relevantAudits": [
+            "long-tasks",
+            "third-party-summary",
+            "third-party-facades",
+            "bootup-time",
+            "mainthread-work-breakdown",
+            "dom-size",
+            "duplicated-javascript",
+            "legacy-javascript",
+            "viewport"
+          ]
+        },
+        {
           "id": "cumulative-layout-shift",
           "weight": 25,
           "group": "metrics",
@@ -6068,6 +6056,18 @@
             "non-composited-animations",
             "unsized-images"
           ]
+        },
+        {
+          "id": "speed-index",
+          "weight": 10,
+          "group": "metrics",
+          "acronym": "SI"
+        },
+        {
+          "id": "interactive",
+          "weight": 0,
+          "group": "hidden",
+          "acronym": "TTI"
         },
         {
           "id": "max-potential-fid",

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -6007,7 +6007,7 @@
         },
         {
           "id": "interactive",
-          "weight": 10,
+          "weight": 0,
           "group": "metrics",
           "acronym": "TTI"
         },
@@ -6060,7 +6060,7 @@
         },
         {
           "id": "cumulative-layout-shift",
-          "weight": 15,
+          "weight": 25,
           "group": "metrics",
           "acronym": "CLS",
           "relevantAudits": [
@@ -6297,7 +6297,7 @@
         }
       ],
       "id": "performance",
-      "score": 0.26
+      "score": 0.3
     },
     "accessibility": {
       "title": "Accessibility",

--- a/report/renderer/performance-category-renderer.js
+++ b/report/renderer/performance-category-renderer.js
@@ -116,8 +116,10 @@ export class PerformanceCategoryRenderer extends CategoryRenderer {
   _getScoringCalculatorHref(auditRefs) {
     // TODO: filter by !!acronym when dropping renderer support of v7 LHRs.
     const metrics = auditRefs.filter(audit => audit.group === 'metrics');
+    const tti = auditRefs.find(audit => audit.id === 'interactive');
     const fci = auditRefs.find(audit => audit.id === 'first-cpu-idle');
     const fmp = auditRefs.find(audit => audit.id === 'first-meaningful-paint');
+    if (tti) metrics.push(tti);
     if (fci) metrics.push(fci);
     if (fmp) metrics.push(fmp);
 

--- a/report/test/generator/report-generator-test.js
+++ b/report/test/generator/report-generator-test.js
@@ -106,7 +106,7 @@ describe('ReportGenerator', () => {
 \\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"http://localhost:10200/dobetterweb/dbw_tester.html\\",\\"2021-09-07T20:11:11.853Z\\",\\"navigation\\"
 
 category,score
-\\"performance\\",\\"0.26\\"
+\\"performance\\",\\"0.3\\"
 \\"accessibility\\",\\"0.77\\"
 \\"best-practices\\",\\"0.27\\"
 \\"seo\\",\\"0.67\\"
@@ -114,9 +114,9 @@ category,score
 
 category,audit,score,displayValue,description
 \\"performance\\",\\"first-contentful-paint\\",\\"0.01\\",\\"6.8 s\\",\\"First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).\\"
-\\"performance\\",\\"interactive\\",\\"0.41\\",\\"8.2 s\\",\\"Time to Interactive is the amount of time it takes for the page to become fully interactive. [Learn more about the Time to Interactive metric](https://developer.chrome.com/docs/lighthouse/performance/interactive/).\\"
-\\"performance\\",\\"speed-index\\",\\"0.21\\",\\"8.1 s\\",\\"Speed Index shows how quickly the contents of a page are visibly populated. [Learn more about the Speed Index metric](https://developer.chrome.com/docs/lighthouse/performance/speed-index/).\\"
+\\"performance\\",\\"largest-contentful-paint\\",\\"0.07\\",\\"6.8 s\\",\\"Largest Contentful Paint marks the time at which the largest text or image is painted. [Learn more about the Largest Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-largest-contentful-paint/)\\"
 \\"performance\\",\\"total-blocking-time\\",\\"0.2\\",\\"1,220 ms\\",\\"Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds. [Learn more about the Total Blocking Time metric](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time/).\\"
+\\"performance\\",\\"cumulative-layout-shift\\",\\"0.8\\",\\"0.136\\",\\"Cumulative Layout Shift measures the movement of visible elements within the viewport. [Learn more about the Cumulative Layout Shift metric](https://web.dev/cls/).\\"
 "
 `);
 

--- a/report/test/renderer/performance-category-renderer-test.js
+++ b/report/test/renderer/performance-category-renderer-test.js
@@ -69,11 +69,10 @@ describe('PerfCategoryRenderer', () => {
       Array.from(timelineElements).map(el => el.id),
       [
         'first-contentful-paint',
-        'interactive',
-        'speed-index',
-        'total-blocking-time',
         'largest-contentful-paint',
+        'total-blocking-time',
         'cumulative-layout-shift',
+        'speed-index',
       ]
     );
   });
@@ -322,11 +321,11 @@ describe('PerfCategoryRenderer', () => {
       expect(url.hash.split('&')).toMatchInlineSnapshot(`
 Array [
   "#FCP=6844",
-  "TTI=8191",
-  "SI=8114",
-  "TBT=1221",
   "LCP=6844",
+  "TBT=1221",
   "CLS=0",
+  "SI=8114",
+  "TTI=8191",
   "FMP=6844",
 ]
 `);
@@ -343,11 +342,11 @@ Array [
         expect(url.hash.split('&')).toMatchInlineSnapshot(`
 Array [
   "#FCP=6844",
-  "TTI=8191",
-  "SI=8114",
-  "TBT=1221",
   "LCP=6844",
+  "TBT=1221",
   "CLS=0.14",
+  "SI=8114",
+  "TTI=8191",
   "FMP=6844",
   "device=mobile",
   "version=6.0.0",


### PR DESCRIPTION
ref #14565

#14586 updated with relevant things to update

Readable summary and FAQ coming.

-----------

<!--
drop TTI, add 10 points to CLS, add 5 to TBT

edit: 


In June 2021, https://github.com/GoogleChrome/lighthouse/blob/main/docs/v8-perf-faq.md#whats-the-story-with-tti captured this plan for TTI:

> That said, we expect to continue to reduce the weight of TTI and will likely remove it in a future major Lighthouse release.

-->

![Screen Shot 2023-01-12 at 1 11 49 PM](https://user-images.githubusercontent.com/6752989/212182260-9ec336f0-af56-4a88-8b3e-6aea1c9f7c57.png)
