### PR TITLE
core(full-page-screenshot): disable `fromSurface`

### DIFF
--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -121,6 +121,7 @@ class FullPageScreenshot extends FRGatherer {
 
     const result = await session.sendCommand('Page.captureScreenshot', {
       format: 'webp',
+      fromSurface: false,
       quality: FULL_PAGE_SCREENSHOT_QUALITY,
     });
     const data = 'data:image/webp;base64,' + result.data;


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/pull/14656#discussion_r1065200023

I was seeing screenshot size reduction of ~5-10KB.
