### PR TITLE
tests(smoke): disable `lantern-idle-callback-short`

### DIFF
--- a/cli/test/smokehouse/config/exclusions.js
+++ b/cli/test/smokehouse/config/exclusions.js
@@ -28,4 +28,9 @@ const exclusions = {
   ],
 };
 
+// https://github.com/GoogleChrome/lighthouse/issues/14271
+for (const array of Object.values(exclusions)) {
+  array.push('lantern-idle-callback-short');
+}
+
 export default exclusions;


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/issues/14271

This is happening way too much.
