### PR TITLE
misc: use cache in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,10 @@ jobs:
         GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-all

--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -32,9 +32,10 @@ jobs:
     - name: git clone
       uses: actions/checkout@v2
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
     - run: yarn --frozen-lockfile
 
     - run: yarn mocha --testMatch=third-party/chromium-synchronization/*-test.js

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -25,9 +25,12 @@ jobs:
         path: lighthouse
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
+        cache-dependency-path: |
+          ${{ github.workspace }}/yarn.lock
 
     - name: Generate cache hash
       run: bash $GITHUB_WORKSPACE/lighthouse/.github/scripts/generate-devtools-hash.sh > cdt-test-hash.txt
@@ -91,9 +94,12 @@ jobs:
         path: lighthouse
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
+        cache-dependency-path: |
+          ${{ github.workspace }}/yarn.lock
 
     - run: yarn --frozen-lockfile --network-timeout 1000000
       working-directory: ${{ github.workspace }}/lighthouse
@@ -136,9 +142,12 @@ jobs:
         path: lighthouse
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
+        cache-dependency-path: |
+          ${{ github.workspace }}/yarn.lock
 
     - name: Load build artifacts
       id: devtools-build-artifacts

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -17,9 +17,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
@@ -41,9 +42,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: yarn
           registry-url: https://registry.npmjs.org/
       - run: yarn --frozen-lockfile
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,9 +33,10 @@ jobs:
         fetch-depth: 2
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - name: Define ToT chrome path
       if: matrix.chrome-channel == 'ToT'
@@ -88,9 +89,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - name: Define ToT chrome path
       run: echo "CHROME_PATH=${env:GITHUB_WORKSPACE}\chrome-win\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
@@ -135,9 +137,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
@@ -183,9 +186,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report
@@ -231,9 +235,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,9 +26,10 @@ jobs:
         fetch-depth: 2
 
     - name: Use Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
+        cache: yarn
 
     - name: Set up protoc
       uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3
@@ -87,9 +88,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: yarn
 
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - run: yarn build-report


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Summary

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Node.js projects can run faster on GitHub Actions by enabling dependency caching on the [setup-node](https://github.com/actions/setup-node) action.

### AS-IS

```yaml
- name: Use Node.js 16.x
  uses: actions/setup-node@v1
  with:
    node-version: 16.x
```

### TO-BE

```yml
- name: Use Node.js 16.x
  uses: actions/setup-node@v3
  with:
    node-version: 16.x
    cache: yarn
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## Related Issues/PRs
#14624 


## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)