### PR TITLE
core(scoring): update expected perf score for flow fixtures

### DIFF
--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -9656,7 +9656,7 @@
               }
             ],
             "id": "performance",
-            "score": 0.92
+            "score": 0.9
           },
           "best-practices": {
             "title": "Best Practices",


### PR DESCRIPTION
~We don't know why #14667 passed green, but.. this is broken on main now.~

At the last commit of #14667, this number was 0.99.  In the meantime #14656 updated artifacts and this score went from 0.99 to 0.92.  (But with the new scoring (and new artifacts) the correct score is 0.90).

This snuck through cuz we don't have the 'enforce branch is up to date' setting on.

