### PR TITLE
core(processed-navigation): computed directly from trace

### DIFF
--- a/core/audits/byte-efficiency/render-blocking-resources.js
+++ b/core/audits/byte-efficiency/render-blocking-resources.js
@@ -15,7 +15,6 @@ import {BaseNode} from '../../lib/dependency-graph/base-node.js';
 import {ByteEfficiencyAudit} from './byte-efficiency-audit.js';
 import {UnusedCSS} from '../../computed/unused-css.js';
 import {NetworkRequest} from '../../lib/network-request.js';
-import {ProcessedTrace} from '../../computed/processed-trace.js';
 import {ProcessedNavigation} from '../../computed/processed-navigation.js';
 import {LoadSimulator} from '../../computed/load-simulator.js';
 import {FirstContentfulPaint} from '../../computed/metrics/first-contentful-paint.js';
@@ -133,8 +132,7 @@ class RenderBlockingResources extends Audit {
     const trace = artifacts.traces[Audit.DEFAULT_PASS];
     const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
     const simulatorData = {devtoolsLog, settings: context.settings};
-    const processedTrace = await ProcessedTrace.request(trace, context);
-    const processedNavigation = await ProcessedNavigation.request(processedTrace, context);
+    const processedNavigation = await ProcessedNavigation.request(trace, context);
     const simulator = await LoadSimulator.request(simulatorData, context);
     const wastedCssBytes = await RenderBlockingResources.computeWastedCSSBytes(artifacts, context);
 

--- a/core/audits/uses-rel-preconnect.js
+++ b/core/audits/uses-rel-preconnect.js
@@ -11,7 +11,6 @@ import * as i18n from '../lib/i18n/i18n.js';
 import {NetworkRecords} from '../computed/network-records.js';
 import {MainResource} from '../computed/main-resource.js';
 import {LoadSimulator} from '../computed/load-simulator.js';
-import {ProcessedTrace} from '../computed/processed-trace.js';
 import {ProcessedNavigation} from '../computed/processed-navigation.js';
 import {PageDependencyGraph} from '../computed/page-dependency-graph.js';
 import {LanternLargestContentfulPaint} from '../computed/metrics/lantern-largest-contentful-paint.js';
@@ -113,14 +112,12 @@ class UsesRelPreconnectAudit extends Audit {
     /** @type {Array<LH.IcuMessage>} */
     const warnings = [];
 
-    const processedTrace = await ProcessedTrace.request(trace, context);
-
     const [networkRecords, mainResource, loadSimulator, processedNavigation, pageGraph] =
       await Promise.all([
         NetworkRecords.request(devtoolsLog, context),
         MainResource.request({devtoolsLog, URL: artifacts.URL}, context),
         LoadSimulator.request({devtoolsLog, settings}, context),
-        ProcessedNavigation.request(processedTrace, context),
+        ProcessedNavigation.request(trace, context),
         PageDependencyGraph.request({trace, devtoolsLog, URL: artifacts.URL}, context),
       ]);
 

--- a/core/computed/metrics/lantern-metric.js
+++ b/core/computed/metrics/lantern-metric.js
@@ -6,7 +6,6 @@
 
 import {BaseNode} from '../../lib/dependency-graph/base-node.js';
 import {NetworkRequest} from '../../lib/network-request.js';
-import {ProcessedTrace} from '../processed-trace.js';
 import {ProcessedNavigation} from '../processed-navigation.js';
 import {PageDependencyGraph} from '../page-dependency-graph.js';
 import {LoadSimulator} from '../load-simulator.js';
@@ -106,8 +105,7 @@ class LanternMetric {
 
     const metricName = this.name.replace('Lantern', '');
     const graph = await PageDependencyGraph.request(data, context);
-    const processedTrace = await ProcessedTrace.request(data.trace, context);
-    const processedNavigation = await ProcessedNavigation.request(processedTrace, context);
+    const processedNavigation = await ProcessedNavigation.request(data.trace, context);
     const simulator = data.simulator || (await LoadSimulator.request(data, context));
 
     const optimisticGraph = this.getOptimisticGraph(graph, processedNavigation);

--- a/core/computed/metrics/metric.js
+++ b/core/computed/metrics/metric.js
@@ -70,7 +70,7 @@ class Metric {
 
     const processedTrace = await ProcessedTrace.request(trace, context);
     const processedNavigation = gatherContext.gatherMode === 'timespan' ?
-      undefined : await ProcessedNavigation.request(processedTrace, context);
+      undefined : await ProcessedNavigation.request(trace, context);
 
     const augmentedData = Object.assign({
       networkRecords: await NetworkRecords.request(devtoolsLog, context),

--- a/core/computed/metrics/timing-summary.js
+++ b/core/computed/metrics/timing-summary.js
@@ -45,7 +45,7 @@ class TimingSummary {
     /* eslint-disable max-len */
 
     const processedTrace = await ProcessedTrace.request(trace, context);
-    const processedNavigation = await requestOrUndefined(ProcessedNavigation, processedTrace);
+    const processedNavigation = await requestOrUndefined(ProcessedNavigation, trace);
     const speedline = await Speedline.request(trace, context);
     const firstContentfulPaint = await requestOrUndefined(FirstContentfulPaint, metricComputationData);
     const firstContentfulPaintAllFrames = await requestOrUndefined(FirstContentfulPaintAllFrames, metricComputationData);

--- a/core/computed/processed-navigation.js
+++ b/core/computed/processed-navigation.js
@@ -5,14 +5,17 @@
  */
 
 import {makeComputedArtifact} from './computed-artifact.js';
+import {ProcessedTrace} from './processed-trace.js';
 import LHTraceProcessor from '../lib/lh-trace-processor.js';
 
 class ProcessedNavigation {
   /**
-     * @param {LH.Artifacts.ProcessedTrace} processedTrace
+     * @param {LH.Trace} trace
+     * @param {LH.Artifacts.ComputedContext} context
      * @return {Promise<LH.Artifacts.ProcessedNavigation>}
     */
-  static async compute_(processedTrace) {
+  static async compute_(trace, context) {
+    const processedTrace = await ProcessedTrace.request(trace, context);
     return LHTraceProcessor.processNavigation(processedTrace);
   }
 }

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -213,14 +213,14 @@ class TraceElements extends FRGatherer {
   }
 
   /**
-   * @param {LH.Artifacts.ProcessedTrace} processedTrace
+   * @param {LH.Trace} trace
    * @param {LH.Gatherer.FRTransitionalContext} context
    * @return {Promise<{nodeId: number, type: string} | undefined>}
    */
-  static async getLcpElement(processedTrace, context) {
+  static async getLcpElement(trace, context) {
     let processedNavigation;
     try {
-      processedNavigation = await ProcessedNavigation.request(processedTrace, context);
+      processedNavigation = await ProcessedNavigation.request(trace, context);
     } catch (err) {
       // If we were running in timespan mode and there was no paint, treat LCP as missing.
       if (context.gatherMode === 'timespan' && err.code === LighthouseError.errors.NO_FCP.code) {
@@ -270,7 +270,7 @@ class TraceElements extends FRGatherer {
     const processedTrace = await ProcessedTrace.request(trace, context);
     const {mainThreadEvents} = processedTrace;
 
-    const lcpNodeData = await TraceElements.getLcpElement(processedTrace, context);
+    const lcpNodeData = await TraceElements.getLcpElement(trace, context);
     const clsNodeData = TraceElements.getTopLayoutShiftElements(mainThreadEvents);
     const animatedElementData = await this.getAnimatedElements(mainThreadEvents);
     const responsivenessElementData = await TraceElements.getResponsivenessElement(trace, context);

--- a/core/test/computed/processed-navigation-test.js
+++ b/core/test/computed/processed-navigation-test.js
@@ -4,7 +4,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {ProcessedTrace} from '../../computed/processed-trace.js';
 import {ProcessedNavigation} from '../../computed/processed-navigation.js';
 import {readJson} from '../test-utils.js';
 
@@ -15,8 +14,7 @@ const noNavStartTrace = readJson('../fixtures/traces/no_navstart_event.json', im
 describe('ProcessedTrace', () => {
   it('computes the artifact', async () => {
     const context = {computedCache: new Map()};
-    const processedTrace = await ProcessedTrace.request(pwaTrace, context);
-    const processedNavigation = await ProcessedNavigation.request(processedTrace, context);
+    const processedNavigation = await ProcessedNavigation.request(pwaTrace, context);
 
     expect(processedNavigation).toEqual({
       domContentLoadedEvt: {
@@ -122,8 +120,7 @@ describe('ProcessedTrace', () => {
   it('fails with NO_NAVSTART', async () => {
     const context = {computedCache: new Map()};
     const compute = async () => {
-      const processedTrace = await ProcessedTrace.request(noNavStartTrace, context);
-      await ProcessedNavigation.request(processedTrace, context);
+      await ProcessedNavigation.request(noNavStartTrace, context);
     };
     await expect(compute()).rejects.toMatchObject({code: 'NO_NAVSTART'});
   });
@@ -132,8 +129,7 @@ describe('ProcessedTrace', () => {
     const context = {computedCache: new Map()};
 
     const compute = async () => {
-      const processedTrace = await ProcessedTrace.request(noFCPtrace, context);
-      await ProcessedNavigation.request(processedTrace, context);
+      await ProcessedNavigation.request(noFCPtrace, context);
     };
 
     await expect(compute()).rejects.toMatchObject({code: 'NO_FCP'});


### PR DESCRIPTION
(broken out from a larger change for easier review)

I'm generating some `ProcessedNavigation`s and it's really annoying to first make a `ProcessedTrace` every time, then pass that in to get a `ProcessedNavigation`. This change makes it so `ProcessedNavigation` generates its own dependency like a good computed artifact should.