### PR TITLE
core(bf-cache-failures): pause on the temporary page

### DIFF
--- a/core/gather/gatherers/bf-cache-failures.js
+++ b/core/gather/gatherers/bf-cache-failures.js
@@ -9,6 +9,7 @@ import {waitForFrameNavigated, waitForLoadEvent} from '../driver/wait-for-condit
 import DevtoolsLog from './devtools-log.js';
 
 const FAILURE_EVENT_TIMEOUT = 100;
+const TEMP_PAGE_PAUSE_TIMEOUT = 100;
 
 class BFCacheFailures extends FRGatherer {
   /** @type {LH.Gatherer.GathererMeta<'DevtoolsLog'>} */
@@ -111,6 +112,8 @@ class BFCacheFailures extends FRGatherer {
       session.sendCommand('Page.navigate', {url: 'chrome://terms'}),
       waitForLoadEvent(session, 0).promise,
     ]);
+
+    await new Promise(resolve => setTimeout(resolve, TEMP_PAGE_PAUSE_TIMEOUT));
 
     const [, frameNavigatedEvent] = await Promise.all([
       session.sendCommand('Page.navigateToHistoryEntry', {entryId: entry.id}),


### PR DESCRIPTION
Unfortunately, this is the best solution I could get to while investigating the recent e2e test failures. I haven't seen it fail with this timeout yet but obviously not a guarantee. IMO this should at least reduce the flakiness.

I experimented with `waitForCPUIdle` instead but `Runtime.evaluate` will throw an error similar to `Page.navigateToHistoryEntry`.
