### PR TITLE
rename entityClassification to entities in LHR.

### DIFF
--- a/core/runner.js
+++ b/core/runner.js
@@ -112,7 +112,7 @@ class Runner {
         categories,
         categoryGroups: resolvedConfig.groups || undefined,
         stackPacks: stackPacks.getStackPacks(artifacts.Stacks),
-        entityClassification: await Runner.getEntityClassification(artifacts,
+        entities: await Runner.getEntityClassification(artifacts,
           {options: {}, computedCache, settings}),
         fullPageScreenshot: resolvedConfig.settings.disableFullPageScreenshot ?
           undefined : artifacts.FullPageScreenshot,
@@ -153,7 +153,7 @@ class Runner {
     const classifiedEntities = await EntityClassification.request(
       {URL: artifacts.URL, devtoolsLog}, context);
 
-    /** @type {Array<LH.Result.Entity>} */
+    /** @type {Array<LH.Result.LhrEntity>} */
     const entities = [];
     /** @type {Record<string, number>} */
     const entityIndexByOrigin = {};
@@ -161,7 +161,7 @@ class Runner {
     const entityIndexByName = {};
 
     for (const [entity, entityUrls] of classifiedEntities.urlsByEntity) {
-      /** @type {LH.Result.Entity} */
+      /** @type {LH.Result.LhrEntity} */
       const shortEntity = {
         name: entity.name,
         homepage: entity.homepage,
@@ -181,7 +181,7 @@ class Runner {
     }
 
     return {
-      entities,
+      list: entities,
       firstParty: classifiedEntities.firstParty?.name,
       entityIndexByOrigin,
       entityIndexByName,

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -4206,8 +4206,8 @@
             }
           }
         ],
-        "entityClassification": {
-          "entities": [
+        "entities": {
+          "list": [
             {
               "name": "mikescerealshack.co",
               "isFirstParty": true,
@@ -9815,8 +9815,8 @@
           }
         },
         "stackPacks": [],
-        "entityClassification": {
-          "entities": [
+        "entities": {
+          "list": [
             {
               "name": "mikescerealshack.co",
               "isFirstParty": true,
@@ -20023,8 +20023,8 @@
             }
           }
         ],
-        "entityClassification": {
-          "entities": [
+        "entities": {
+          "list": [
             {
               "name": "mikescerealshack.co",
               "isFirstParty": true,

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -6330,8 +6330,8 @@
       }
     }
   ],
-  "entityClassification": {
-    "entities": [
+  "entities": {
+    "list": [
       {
         "name": "localhost",
         "isFirstParty": true,

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -617,7 +617,7 @@ message StackPack {
 // Message containing Entity Classification.
 message Entities {
   // List of entities.
-  repeated Entity list = 1;
+  repeated LhrEntity list = 1;
   
   // Name of the first-party entity.
   string firstParty = 2;
@@ -630,7 +630,7 @@ message Entities {
 }
 
 // Message containing an Entity.
-message Entity {
+message LhrEntity {
   // Name of the entity.
   string name = 1;
   

--- a/proto/lighthouse-result.proto
+++ b/proto/lighthouse-result.proto
@@ -234,7 +234,7 @@ message LighthouseResult {
   google.protobuf.Value full_page_screenshot = 19;
 
   // Entity classification data.
-  EntityClassification entityClassification = 20;
+  Entities entities = 20;
 }
 
 // Message containing a category
@@ -615,9 +615,9 @@ message StackPack {
 }
 
 // Message containing Entity Classification.
-message EntityClassification {
+message Entities {
   // List of entities.
-  repeated Entity entities = 1;
+  repeated Entity list = 1;
   
   // Name of the first-party entity.
   string firstParty = 2;

--- a/types/lhr/lhr.d.ts
+++ b/types/lhr/lhr.d.ts
@@ -155,7 +155,7 @@ declare module Result {
 
   /**
    * Entity classification for the run, for resolving URLs/items to entities in report.
-   * The two lookup tables (LUT) below provide space-optimized, O(1) index lookup into entities.
+   * The two lookup tables (LUT) below provide space-optimized, O(1) index lookup into entities.list.
    */
   interface Entities {
     /** All entities (1st and 3rd party) discovered during the run */

--- a/types/lhr/lhr.d.ts
+++ b/types/lhr/lhr.d.ts
@@ -57,7 +57,7 @@ interface Result {
   /** An array containing the result of all stack packs. */
   stackPacks?: Result.StackPack[];
   /** All the origins encountered during this Lighthouse run, and information about what web property (aka "entity") they belong to. Won't be present for snapshot mode. */
-  entityClassification?: Result.EntityClassification;
+  entities?: Result.Entities;
   /** Screenshot taken of the full page, with node rects referencing audit results. If there was an error with collection, this is null. If disabled via the disableFullPageScreenshot setting, this is undefined. */
   fullPageScreenshot?: Result.FullPageScreenshot | null;
 }
@@ -157,9 +157,9 @@ declare module Result {
    * Entity classification for the run, for resolving URLs/items to entities in report.
    * The two lookup tables (LUT) below provide space-optimized, O(1) index lookup into entities.
    */
-  interface EntityClassification {
+  interface Entities {
     /** All entities (1st and 3rd party) discovered during the run */
-    entities: Array<Entity>;
+    list: Array<LhrEntity>;
     /** Name of the first-party entity */
     firstParty?: string;
     /** Entity-name to entity index lookup table  */
@@ -171,7 +171,7 @@ declare module Result {
   /**
    * An entity that's either recognized by third-party-web or made up by Lighthouse.
    */
-  interface Entity {
+  interface LhrEntity {
     /** Name of the entity. Maps to third-party-web unique name for recognized entities and a root domain name for the unrecognized. */
     name: string;
     /** Homepage URL for a recognized entity, if available in third-party-web. */


### PR DESCRIPTION
I did the rename in a branch off #14622; will merge back into branch once we are happy with the name changes.

- [x] rename `lhr.entityClassification` to `lhr.entities` (associated type becomes `Result.Entities`)
  - [x] type of an individual entity is renamed to `Result.LhrEntity` to disambiguate from `Artifact.Entity`
- [x] rename what was previously `lhr.entityClassification.entities` to `lhr.entities.list`. 

If the rename looks good, I'll merge back to the branch. Compare with [changes including 14622 here](https://github.com/GoogleChrome/lighthouse/compare/entity-based-3p-reportonly-rename?expand=1).