### PR TITLE
report: filter `lcp-lazy-loaded` with LCP audits

### DIFF
--- a/core/config/metrics-to-audits.js
+++ b/core/config/metrics-to-audits.js
@@ -26,6 +26,7 @@ const lcpRelevantAudits = [
   'unused-javascript',
   'efficient-animated-content',
   'total-byte-weight',
+  'lcp-lazy-loaded',
 ];
 
 const tbtRelevantAudits = [

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -3331,7 +3331,8 @@
                   "preload-lcp-image",
                   "unused-javascript",
                   "efficient-animated-content",
-                  "total-byte-weight"
+                  "total-byte-weight",
+                  "lcp-lazy-loaded"
                 ]
               },
               {
@@ -19187,7 +19188,8 @@
                   "preload-lcp-image",
                   "unused-javascript",
                   "efficient-animated-content",
-                  "total-byte-weight"
+                  "total-byte-weight",
+                  "lcp-lazy-loaded"
                 ]
               },
               {

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -5552,7 +5552,8 @@
             "preload-lcp-image",
             "unused-javascript",
             "efficient-animated-content",
-            "total-byte-weight"
+            "total-byte-weight",
+            "lcp-lazy-loaded"
           ]
         },
         {


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/14722