### PR TITLE
report: avoid really slow regexes for long urls

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -188,6 +188,8 @@ class Util {
 
     const MAX_LENGTH = 64;
     if (parsedUrl.protocol !== 'data:') {
+      // Even non-data uris can be 10k characters long.
+      name = name.slice(0, 200);
       // Always elide hexadecimal hash
       name = name.replace(/([a-f0-9]{7})[a-f0-9]{13}[a-f0-9]*/g, `$1${ELLIPSIS}`);
       // Also elide other hash-like mixed-case strings


### PR DESCRIPTION
I was looking at report perf and this regex stood out: 

<img width="970" alt="image" src="https://user-images.githubusercontent.com/39191/216202859-b2dc6d27-f9e4-4deb-a006-fcc809dc509f.png">

We already ran into this in #13785 (and fixed by https://github.com/GoogleChrome/lighthouse/pull/13791)

But.. theverge has a non-datauri URL that's 10kb long. and this nasty regex (my fault apparently) really doesn't enjoy working through such a big string.

