### PR TITLE
misc(lint): enable no-conditional-assignment rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -78,6 +78,7 @@ module.exports = {
       argsIgnorePattern: '(^reject$|^_+$)',
       varsIgnorePattern: '(^_$|^LH$)',
     }],
+    'no-cond-assign': 2,
     'space-infix-ops': 2,
     'strict': [2, 'global'],
     'prefer-const': 2,

--- a/core/lib/page-functions.js
+++ b/core/lib/page-functions.js
@@ -59,7 +59,7 @@ function getElementsInDocument(selector) {
 
   /** @param {NodeListOf<Element>} nodes */
   const _findAllElements = nodes => {
-    for (let i = 0, el; el = nodes[i]; ++i) {
+    for (const el of nodes) {
       if (!selector || realMatchesFn.call(el, selector)) {
         /** @type {ParseSelector<T>} */
         // @ts-expect-error - el is verified as matching above, tsc just can't verify it through the .call().
@@ -265,7 +265,7 @@ function getNodePath(node) {
     }
     let index = 0;
     let prevNode;
-    while (prevNode = node.previousSibling) {
+    while (prevNode = node.previousSibling) { // eslint-disable-line no-cond-assign
       node = prevNode;
       // skip empty text nodes
       if (node.nodeType === Node.TEXT_NODE && (node.nodeValue || '').trim().length === 0) continue;


### PR DESCRIPTION
https://eslint.org/docs/latest/rules/no-cond-assign

I lost 30 minutes of debugging to this situation a few months back. (`=` instead of `===` in a conditional.) 
it now haunts me.

it's part of eslint:recommended, but `eslint-config-google` flips it back off: https://github.com/google/eslint-config-google/blob/master/index.js#L37

also.. the google config was archived last month! huh. bummer.