### PR TITLE
core: use main-frame LCP trace element

### DIFF
--- a/cli/test/smokehouse/test-definitions/perf-frame-metrics.js
+++ b/cli/test/smokehouse/test-definitions/perf-frame-metrics.js
@@ -86,6 +86,20 @@ const expectations = {
           ],
         },
       },
+      'largest-contentful-paint': {
+        // Non-all-frames value.
+        numericValue: '>5000',
+      },
+      'largest-contentful-paint-element': {
+        details: {
+          items: [{
+            node: {
+              // Element should be from main frame while metric is not LCPAllFrames.
+              nodeLabel: 'This is the main frame LCP and FCP.',
+            },
+          }],
+        },
+      },
     },
   },
 };

--- a/core/audits/preload-lcp-image.js
+++ b/core/audits/preload-lcp-image.js
@@ -119,7 +119,8 @@ class PreloadLCPImageAudit extends Audit {
    * @return {string | undefined}
    */
   static getLcpUrl(trace, processedNavigation) {
-    const lcpEvent = processedNavigation.largestContentfulPaintAllFramesEvt;
+    // Use main-frame-only LCP to match the metric value.
+    const lcpEvent = processedNavigation.largestContentfulPaintEvt;
     if (!lcpEvent) return;
 
     const lcpImagePaintEvent = trace.traceEvents.filter(e => {

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -230,8 +230,9 @@ class TraceElements extends FRGatherer {
       throw err;
     }
 
+    // Use main-frame-only LCP to match the metric value.
+    const lcpData = processedNavigation.largestContentfulPaintEvt?.args?.data;
     // These should exist, but trace types are loose.
-    const lcpData = processedNavigation.largestContentfulPaintAllFramesEvt?.args?.data;
     if (lcpData?.nodeId === undefined || !lcpData.type) return;
 
     return {


### PR DESCRIPTION
Reverts the `s/processedNavigation.largestContentfulPaintEvt/processedNavigation.largestContentfulPaintAllFramesEvt` from #14695 and goes back to getting the LCP element from the main frame. Was not a bug, since that's where the LCP value comes from too.

Also added some comments and assertions to the frames smoke test for the next time I look at these lines and wonder, "wait, why aren't we looking at the all-frames LCP?". 