### PR TITLE
core(full-page-screenshot): get screenshot, nodes concurrently

### DIFF
--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -222,9 +222,11 @@ class FullPageScreenshot extends FRGatherer {
         await this._resizeViewport(context, deviceMetrics);
       }
 
+      const [screenshot, nodes] =
+        await Promise.all([this._takeScreenshot(context), this._resolveNodes(context)]);
       return {
-        screenshot: await this._takeScreenshot(context),
-        nodes: await this._resolveNodes(context),
+        screenshot,
+        nodes,
       };
     } finally {
       if (!settings.usePassiveGathering) {

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -222,6 +222,8 @@ class FullPageScreenshot extends FRGatherer {
         await this._resizeViewport(context, deviceMetrics);
       }
 
+      // Issue both commands at once, to reduce the chance that the page changes between capturing
+      // a screenshot and resolving the nodes. https://github.com/GoogleChrome/lighthouse/pull/14763
       const [screenshot, nodes] =
         await Promise.all([this._takeScreenshot(context), this._resolveNodes(context)]);
       return {


### PR DESCRIPTION
This change seems to resolve an issue where _sometimes_ LH would produce element screenshots that did not line up (test w/ cnn.com). It was flaky behavior, so it's hard to know for sure if this is truly solved now. Please run a few times yourself. The `list` audit in a11y is what I was checking. If `user-sync` file is downloaded, trash the run and try again.

I ran this patch roughly 20 times with no incident, whereas before I could reproduce this problem at least twice every 5 runs.