### PR TITLE
misc(build): shim unneeded deps in lr report generator

### DIFF
--- a/build/build-lightrider-bundles.js
+++ b/build/build-lightrider-bundles.js
@@ -36,6 +36,9 @@ async function buildReportGenerator() {
       rollupPlugins.shim({
         [`${LH_ROOT}/report/generator/flow-report-assets.js`]: 'export const flowReportAssets = {}',
         'fs': 'export default {}',
+        'module': 'export function createRequire(){}',
+        'path': 'export default {}',
+        'url': 'export default {}',
       }),
     ],
   });


### PR DESCRIPTION
6c047772832f98b77718aa3cb9fefe877244e982 changed the report generator to es modules, which for _some reason_ results in rollup still including dependencies that had been DCE'd via `rollupPlugins.removeModuleDirCalls`. This PR explicitly shims the unneeded modules.

delta:

```
2,3c2,3
<   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('module'), require('url'), require('path')) :
<   typeof define === 'function' && define.amd ? define(['exports', 'module', 'url', 'path'], factory) :
---
>   typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
>   typeof define === 'function' && define.amd ? define(['exports'], factory) :
```

Edit: previously: #13416 #14031 #14098 #14258