### PR TITLE
core(lr): disable bf-cache

### DIFF
--- a/core/config/lr-desktop-config.js
+++ b/core/config/lr-desktop-config.js
@@ -16,8 +16,12 @@ const config = {
     throttling: constants.throttling.desktopDense4G,
     screenEmulation: constants.screenEmulationMetrics.desktop,
     emulatedUserAgent: constants.userAgents.desktop,
-    // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
-    skipAudits: ['uses-http2'],
+    skipAudits: [
+      // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
+      'uses-http2',
+      // There are always bf-cache failures when testing in headless. Reenable when headless can give us realistic bf-cache insights.
+      'bf-cache',
+    ],
   },
 };
 

--- a/core/config/lr-mobile-config.js
+++ b/core/config/lr-mobile-config.js
@@ -10,9 +10,12 @@ const config = {
   settings: {
     maxWaitForFcp: 15 * 1000,
     maxWaitForLoad: 35 * 1000,
-    // lighthouse:default is mobile by default
-    // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
-    skipAudits: ['uses-http2'],
+    skipAudits: [
+      // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
+      'uses-http2',
+      // There are always bf-cache failures when testing in headless. Reenable when headless can give us realistic bf-cache insights.
+      'bf-cache',
+    ],
   },
   audits: [
     'metrics/first-contentful-paint-3g',


### PR DESCRIPTION
There are always failure reasons when testing bf-cache in headless mode. I can repro with Puppeteer so this is not specific to Lighthouse.
