### PR TITLE
docs(readme): move lighthouse logo and description to top

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,11 @@
+
+<p align="center">
+  <img src="./assets/lighthouse-logo_512px.png" alt="Lighthouse logo" height="150">
+  <br>
+  <b>Lighthouse</b>, ˈlītˌhous (n): a <s>tower or other structure</s> tool containing a beacon light
+  to warn or guide <s>ships at sea</s> developers.
+</p>
+
 # Lighthouse  [![GitHub Actions Status Badge](https://github.com/GoogleChrome/lighthouse/workflows/CI/badge.svg)](https://github.com/GoogleChrome/lighthouse/actions/workflows/ci.yml) [![GitHub Actions Status Badge](https://github.com/GoogleChrome/lighthouse/workflows/unit/badge.svg)](https://github.com/GoogleChrome/lighthouse/actions/workflows/unit.yml) [![GitHub Actions Status Badge](https://github.com/GoogleChrome/lighthouse/workflows/smoke/badge.svg)](https://github.com/GoogleChrome/lighthouse/actions/workflows/smoke.yml) [![Coverage Status](https://codecov.io/gh/GoogleChrome/lighthouse/branch/main/graph/badge.svg)](https://codecov.io/gh/GoogleChrome/lighthouse) [![Build tracker for Lighthouse](https://img.shields.io/badge/buildtracker-ok-blue)](https://lh-build-tracker.herokuapp.com/) [![NPM lighthouse package](https://img.shields.io/npm/v/lighthouse.svg)](https://npmjs.org/package/lighthouse)
 
 > Lighthouse analyzes web apps and web pages, collecting modern performance metrics and insights on developer best practices.
@@ -458,11 +466,3 @@ If you're interested in running your own custom audits, check out our
 
 We'd love help writing audits, fixing bugs, and making the tool more useful!
 See [Contributing](./CONTRIBUTING.md) to get started.
-
----
-<p align="center">
-  <img src="./assets/lighthouse-logo_512px.png" alt="Lighthouse logo" height="150">
-  <br>
-  <b>Lighthouse</b>, ˈlītˌhous (n): a <s>tower or other structure</s> tool containing a beacon light
-  to warn or guide <s>ships at sea</s> developers.
-</p>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
Changes: Move lighthouse logo and description to top.

Inspiration: I think it's a waste to put it in the bottom as most people won't reach that part of the docs anyway. The lighthouse logo and the creative description deserves more spotlight in this doc.

**Related Issues/PRs**

None
