### PR TITLE
docs(readme): add AwesomeTechStack to the "Lighthouse Integrations"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -321,6 +321,8 @@ Some of our docs have tests that run only in CI by default. To modify our docume
 
 This section details services that have integrated Lighthouse data. If you're working on a cool project integrating Lighthouse and would like to be featured here, file an issue to this repo or tweet at us [@_____lighthouse](https://twitter.com/____lighthouse)!
 
+* **[AwesomeTechStack](https://awesometechstack.com)** — Unlock the secrets of top-performing websites with AwesomeTechStack's comprehensive technology analysis. From security to modernity and performance, we'll provide you with the information you need to level up your tech stack's awesomeness.
+
 * **[Web Page Test](https://www.webpagetest.org)** — An [open source](https://github.com/WPO-Foundation/webpagetest) tool for measuring and analyzing the performance of web pages on real devices. Users can choose to produce a Lighthouse report alongside the analysis of WebPageTest results.
 
 * **[HTTPArchive](http://httparchive.org/)** - HTTPArchive tracks how the web is built by crawling 500k pages with Web Page Test, including Lighthouse results, and stores the information in BigQuery where it is [publicly available](https://discuss.httparchive.org/t/quickstart-guide-to-exploring-the-http-archive/682).


### PR DESCRIPTION
We collaborated with Lighthouse 2 Years back: https://github.com/GoogleChrome/lighthouse/pull/10475
Now we saw that we were removed here: https://github.com/GoogleChrome/lighthouse/commit/3ccdb7ac55c0a41d87a1d611546e034260107167

as you can see on this site: https://awesometechstack.com/documentation/
![1 (2)](https://user-images.githubusercontent.com/55059012/218052470-fc0606b5-50f7-4ff6-a17b-28f153c54cb1.PNG)

and also having description and a backlink on every of our over 80 thousand website analysis:
https://awesometechstack.com/analysis/website/awesometechstack.com/
![2](https://user-images.githubusercontent.com/55059012/218052536-7e3f9e64-fed4-4da2-8708-1d76ce38ee19.PNG)

and here:
https://awesometechstack.com/analysis/website/reports/lighthouse/?url=awesometechstack.com
![3](https://user-images.githubusercontent.com/55059012/218133530-123b13da-da4c-4388-99af-2f5045133694.PNG)

We would more than proud to be part of the listing again 👍 