### PR TITLE
core(dom-size): show total frames and max frame depth

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -464,6 +464,26 @@ const expectations = {
               },
               node: {snippet: '<div id="shadow-root-container">'},
             },
+            {
+              statistic: 'Total Frames',
+              value: {
+                type: 'numeric',
+                granularity: 1,
+                value: 1,
+              },
+            },
+            {
+              node: {
+                type: 'url',
+                value: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+              },
+              statistic: 'Maximum Frame Depth',
+              value: {
+                type: 'numeric',
+                granularity: 1,
+                value: 1,
+              },
+            },
           ],
         },
       },

--- a/core/audits/dobetterweb/dom-size.js
+++ b/core/audits/dobetterweb/dom-size.js
@@ -38,6 +38,10 @@ const UIStrings = {
   statisticDOMDepth: 'Maximum DOM Depth',
   /** Label for the numeric value of the maximum number of children any DOM element in the page has. The element described will have the most children in the page. */
   statisticDOMWidth: 'Maximum Child Elements',
+  /** Label for the total number of frame elements found in the page. */
+  statisticDOMTotalFrames: 'Total Frames',
+  /** Label for the numeric value of the maximum depth in the page's frame tree. */
+  statisticDOMFramesDepth: 'Maximum Frame Depth',
 };
 
 const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
@@ -68,7 +72,6 @@ class DOMSize extends Audit {
       median: 1400,
     };
   }
-
 
   /**
    * @param {LH.Artifacts} artifacts
@@ -116,6 +119,23 @@ class DOMSize extends Audit {
           type: 'numeric',
           granularity: 1,
           value: stats.width.max,
+        },
+      },
+      {
+        statistic: str_(UIStrings.statisticDOMTotalFrames),
+        value: {
+          type: 'numeric',
+          granularity: 1,
+          value: stats.totalFrames,
+        },
+      },
+      {
+        node: {type: 'url', value: stats.framesDepth.url},
+        statistic: str_(UIStrings.statisticDOMFramesDepth),
+        value: {
+          type: 'numeric',
+          granularity: 1,
+          value: stats.framesDepth.max,
         },
       },
     ];

--- a/core/gather/gatherers/dobetterweb/domstats.js
+++ b/core/gather/gatherers/dobetterweb/domstats.js
@@ -97,7 +97,7 @@ class DOMStats extends FRGatherer {
       // When Chrome comes across an iframe for a URL already framed above in the hierarchy,
       // it will load as an empty document and its URL in the frame tree will be just `:`.
       // Best to just ignore.
-      if (frameTree.frame.url === ':' || frameTree.frame.domainAndRegistry === '') {
+      if (frameTree.frame.url === ':') {
         return;
       }
 

--- a/core/test/audits/dobetterweb/dom-size-test.js
+++ b/core/test/audits/dobetterweb/dom-size-test.js
@@ -17,6 +17,8 @@ describe('DOMSize audit', () => {
       totalBodyElements: numElements,
       depth: {max: 1},
       width: {max: 2},
+      totalFrames: 3,
+      framesDepth: {max: 2, url: 'http://www.example.com'},
     },
   };
   const context = {options, settings: {locale: 'en'}};

--- a/core/test/fixtures/fraggle-rock/artifacts/step0/artifacts.json
+++ b/core/test/fixtures/fraggle-rock/artifacts/step0/artifacts.json
@@ -1378,14 +1378,14 @@
   "DOMStats": {
     "depth": {
       "max": 9,
-      "lhId": "1-12-path",
+      "lhId": "1-11-path",
       "devtoolsNodePath": "1,HTML,1,BODY,0,DIV,0,DIV,2,HEADER,0,DIV,2,DIV,0,DIV,0,svg,0,path",
       "selector": "div.flex > div.inline-block > svg.h-6 > path",
       "boundingRect": {
         "top": 20,
         "bottom": 44,
-        "left": 315,
-        "right": 336,
+        "left": 367,
+        "right": 388,
         "width": 21,
         "height": 24
       },
@@ -1394,21 +1394,26 @@
     },
     "width": {
       "max": 14,
-      "lhId": "1-13-BODY",
+      "lhId": "1-12-BODY",
       "devtoolsNodePath": "1,HTML,1,BODY",
       "selector": "body",
       "boundingRect": {
         "top": 0,
-        "bottom": 640,
+        "bottom": 823,
         "left": 0,
-        "right": 360,
-        "width": 360,
-        "height": 640
+        "right": 412,
+        "width": 412,
+        "height": 823
       },
       "snippet": "<body>",
       "nodeLabel": "body"
     },
-    "totalBodyElements": 70
+    "totalBodyElements": 70,
+    "totalFrames": 1,
+    "framesDepth": {
+      "max": 1,
+      "url": "https://www.mikescerealshack.co/"
+    }
   },
   "EmbeddedContent": [],
   "FontSize": {

--- a/core/test/fixtures/fraggle-rock/artifacts/step2/artifacts.json
+++ b/core/test/fixtures/fraggle-rock/artifacts/step2/artifacts.json
@@ -1950,7 +1950,7 @@
   "DOMStats": {
     "depth": {
       "max": 11,
-      "lhId": "1-52-SPAN",
+      "lhId": "1-54-SPAN",
       "devtoolsNodePath": "1,HTML,1,BODY,0,DIV,0,DIV,3,MAIN,2,A,0,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,SPAN",
       "selector": "div.hidden > div > div.text-sm > span.text-gray-400",
       "boundingRect": {
@@ -1966,21 +1966,26 @@
     },
     "width": {
       "max": 17,
-      "lhId": "1-53-BODY",
+      "lhId": "1-55-BODY",
       "devtoolsNodePath": "1,HTML,1,BODY",
       "selector": "body",
       "boundingRect": {
         "top": 0,
-        "bottom": 1668,
+        "bottom": 1664,
         "left": 0,
-        "right": 360,
-        "width": 360,
-        "height": 1668
+        "right": 397,
+        "width": 397,
+        "height": 1664
       },
       "snippet": "<body>",
       "nodeLabel": "body"
     },
-    "totalBodyElements": 361
+    "totalBodyElements": 361,
+    "totalFrames": 1,
+    "framesDepth": {
+      "max": 1,
+      "url": "https://www.mikescerealshack.co/search?q=call+of+duty"
+    }
   },
   "EmbeddedContent": [],
   "FontSize": {

--- a/core/test/fixtures/fraggle-rock/artifacts/step3/artifacts.json
+++ b/core/test/fixtures/fraggle-rock/artifacts/step3/artifacts.json
@@ -1303,14 +1303,14 @@
   "DOMStats": {
     "depth": {
       "max": 9,
-      "lhId": "1-13-path",
+      "lhId": "1-12-path",
       "devtoolsNodePath": "1,HTML,1,BODY,0,DIV,0,DIV,2,HEADER,0,DIV,2,DIV,0,DIV,0,svg,0,path",
       "selector": "div.flex > div.inline-block > svg.h-6 > path",
       "boundingRect": {
         "top": 20,
         "bottom": 44,
-        "left": 315,
-        "right": 336,
+        "left": 367,
+        "right": 388,
         "width": 21,
         "height": 24
       },
@@ -1318,22 +1318,27 @@
       "nodeLabel": "div.flex > div.inline-block > svg.h-6 > path"
     },
     "width": {
-      "max": 13,
-      "lhId": "1-14-BODY",
+      "max": 15,
+      "lhId": "1-13-BODY",
       "devtoolsNodePath": "1,HTML,1,BODY",
       "selector": "body",
       "boundingRect": {
         "top": 0,
         "bottom": 887,
         "left": 0,
-        "right": 360,
-        "width": 360,
+        "right": 412,
+        "width": 412,
         "height": 887
       },
       "snippet": "<body>",
       "nodeLabel": "body"
     },
-    "totalBodyElements": 81
+    "totalBodyElements": 83,
+    "totalFrames": 1,
+    "framesDepth": {
+      "max": 1,
+      "url": "https://www.mikescerealshack.co/corrections"
+    }
   },
   "EmbeddedContent": [],
   "FontSize": {

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -2882,14 +2882,14 @@
                 {
                   "node": {
                     "type": "node",
-                    "lhId": "1-12-path",
+                    "lhId": "1-11-path",
                     "path": "1,HTML,1,BODY,0,DIV,0,DIV,2,HEADER,0,DIV,2,DIV,0,DIV,0,svg,0,path",
                     "selector": "div.flex > div.inline-block > svg.h-6 > path",
                     "boundingRect": {
                       "top": 20,
                       "bottom": 44,
-                      "left": 315,
-                      "right": 336,
+                      "left": 367,
+                      "right": 388,
                       "width": 21,
                       "height": 24
                     },
@@ -2906,16 +2906,16 @@
                 {
                   "node": {
                     "type": "node",
-                    "lhId": "1-13-BODY",
+                    "lhId": "1-12-BODY",
                     "path": "1,HTML,1,BODY",
                     "selector": "body",
                     "boundingRect": {
                       "top": 0,
-                      "bottom": 640,
+                      "bottom": 823,
                       "left": 0,
-                      "right": 360,
-                      "width": 360,
-                      "height": 640
+                      "right": 412,
+                      "width": 412,
+                      "height": 823
                     },
                     "snippet": "<body>",
                     "nodeLabel": "body"
@@ -2925,6 +2925,26 @@
                     "type": "numeric",
                     "granularity": 1,
                     "value": 14
+                  }
+                },
+                {
+                  "statistic": "Total Frames",
+                  "value": {
+                    "type": "numeric",
+                    "granularity": 1,
+                    "value": 1
+                  }
+                },
+                {
+                  "node": {
+                    "type": "url",
+                    "value": "https://www.mikescerealshack.co/"
+                  },
+                  "statistic": "Maximum Frame Depth",
+                  "value": {
+                    "type": "numeric",
+                    "granularity": 1,
+                    "value": 1
                   }
                 }
               ]
@@ -7092,6 +7112,12 @@
             ],
             "core/audits/dobetterweb/dom-size.js | statisticDOMWidth": [
               "audits[dom-size].details.items[2].statistic"
+            ],
+            "core/audits/dobetterweb/dom-size.js | statisticDOMTotalFrames": [
+              "audits[dom-size].details.items[3].statistic"
+            ],
+            "core/audits/dobetterweb/dom-size.js | statisticDOMFramesDepth": [
+              "audits[dom-size].details.items[4].statistic"
             ],
             "core/audits/dobetterweb/geolocation-on-start.js | title": [
               "audits[geolocation-on-start].title"
@@ -13034,7 +13060,7 @@
                 {
                   "node": {
                     "type": "node",
-                    "lhId": "1-52-SPAN",
+                    "lhId": "1-54-SPAN",
                     "path": "1,HTML,1,BODY,0,DIV,0,DIV,3,MAIN,2,A,0,DIV,1,DIV,1,DIV,0,DIV,0,DIV,0,SPAN",
                     "selector": "div.hidden > div > div.text-sm > span.text-gray-400",
                     "boundingRect": {
@@ -13058,16 +13084,16 @@
                 {
                   "node": {
                     "type": "node",
-                    "lhId": "1-53-BODY",
+                    "lhId": "1-55-BODY",
                     "path": "1,HTML,1,BODY",
                     "selector": "body",
                     "boundingRect": {
                       "top": 0,
-                      "bottom": 1668,
+                      "bottom": 1664,
                       "left": 0,
-                      "right": 360,
-                      "width": 360,
-                      "height": 1668
+                      "right": 397,
+                      "width": 397,
+                      "height": 1664
                     },
                     "snippet": "<body>",
                     "nodeLabel": "body"
@@ -13077,6 +13103,26 @@
                     "type": "numeric",
                     "granularity": 1,
                     "value": 17
+                  }
+                },
+                {
+                  "statistic": "Total Frames",
+                  "value": {
+                    "type": "numeric",
+                    "granularity": 1,
+                    "value": 1
+                  }
+                },
+                {
+                  "node": {
+                    "type": "url",
+                    "value": "https://www.mikescerealshack.co/search?q=call+of+duty"
+                  },
+                  "statistic": "Maximum Frame Depth",
+                  "value": {
+                    "type": "numeric",
+                    "granularity": 1,
+                    "value": 1
                   }
                 }
               ]
@@ -15498,6 +15544,12 @@
             ],
             "core/audits/dobetterweb/dom-size.js | statisticDOMWidth": [
               "audits[dom-size].details.items[2].statistic"
+            ],
+            "core/audits/dobetterweb/dom-size.js | statisticDOMTotalFrames": [
+              "audits[dom-size].details.items[3].statistic"
+            ],
+            "core/audits/dobetterweb/dom-size.js | statisticDOMFramesDepth": [
+              "audits[dom-size].details.items[4].statistic"
             ],
             "core/audits/dobetterweb/js-libraries.js | title": [
               "audits[js-libraries].title"
@@ -18607,9 +18659,9 @@
             "description": "A large DOM will increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn how to avoid an excessive DOM size](https://developer.chrome.com/docs/lighthouse/performance/dom-size/).",
             "score": 1,
             "scoreDisplayMode": "numeric",
-            "numericValue": 81,
+            "numericValue": 83,
             "numericUnit": "element",
-            "displayValue": "81 elements",
+            "displayValue": "83 elements",
             "details": {
               "type": "table",
               "headings": [
@@ -18635,20 +18687,20 @@
                   "value": {
                     "type": "numeric",
                     "granularity": 1,
-                    "value": 81
+                    "value": 83
                   }
                 },
                 {
                   "node": {
                     "type": "node",
-                    "lhId": "1-13-path",
+                    "lhId": "1-12-path",
                     "path": "1,HTML,1,BODY,0,DIV,0,DIV,2,HEADER,0,DIV,2,DIV,0,DIV,0,svg,0,path",
                     "selector": "div.flex > div.inline-block > svg.h-6 > path",
                     "boundingRect": {
                       "top": 20,
                       "bottom": 44,
-                      "left": 315,
-                      "right": 336,
+                      "left": 367,
+                      "right": 388,
                       "width": 21,
                       "height": 24
                     },
@@ -18665,15 +18717,15 @@
                 {
                   "node": {
                     "type": "node",
-                    "lhId": "1-14-BODY",
+                    "lhId": "1-13-BODY",
                     "path": "1,HTML,1,BODY",
                     "selector": "body",
                     "boundingRect": {
                       "top": 0,
                       "bottom": 887,
                       "left": 0,
-                      "right": 360,
-                      "width": 360,
+                      "right": 412,
+                      "width": 412,
                       "height": 887
                     },
                     "snippet": "<body>",
@@ -18683,7 +18735,27 @@
                   "value": {
                     "type": "numeric",
                     "granularity": 1,
-                    "value": 13
+                    "value": 15
+                  }
+                },
+                {
+                  "statistic": "Total Frames",
+                  "value": {
+                    "type": "numeric",
+                    "granularity": 1,
+                    "value": 1
+                  }
+                },
+                {
+                  "node": {
+                    "type": "url",
+                    "value": "https://www.mikescerealshack.co/corrections"
+                  },
+                  "statistic": "Maximum Frame Depth",
+                  "value": {
+                    "type": "numeric",
+                    "granularity": 1,
+                    "value": 1
                   }
                 }
               ]
@@ -22870,7 +22942,7 @@
             "core/audits/dobetterweb/dom-size.js | displayValue": [
               {
                 "values": {
-                  "itemCount": 81
+                  "itemCount": 83
                 },
                 "path": "audits[dom-size].displayValue"
               }
@@ -22889,6 +22961,12 @@
             ],
             "core/audits/dobetterweb/dom-size.js | statisticDOMWidth": [
               "audits[dom-size].details.items[2].statistic"
+            ],
+            "core/audits/dobetterweb/dom-size.js | statisticDOMTotalFrames": [
+              "audits[dom-size].details.items[3].statistic"
+            ],
+            "core/audits/dobetterweb/dom-size.js | statisticDOMFramesDepth": [
+              "audits[dom-size].details.items[4].statistic"
             ],
             "core/audits/dobetterweb/geolocation-on-start.js | title": [
               "audits[geolocation-on-start].title"

--- a/core/test/results/artifacts/artifacts.json
+++ b/core/test/results/artifacts/artifacts.json
@@ -10591,8 +10591,8 @@
   "DOMStats": {
     "depth": {
       "max": 4,
-      "lhId": "5-44-title",
-      "devtoolsNodePath": "3,HTML,1,BODY,9,DIV,3,svg,0,title",
+      "lhId": "1-25-title",
+      "devtoolsNodePath": "2,HTML,1,BODY,9,DIV,5,svg,0,title",
       "selector": "body > div > svg.social-facebook > title#social-facebook-5",
       "boundingRect": {
         "top": 0,
@@ -10607,21 +10607,26 @@
     },
     "width": {
       "max": 100,
-      "lhId": "5-45-DIV",
-      "devtoolsNodePath": "3,HTML,1,BODY,6,DIV",
+      "lhId": "1-26-DIV",
+      "devtoolsNodePath": "2,HTML,1,BODY,6,DIV",
       "selector": "body > div#shadow-root-container",
       "boundingRect": {
         "top": 316,
         "bottom": 316,
         "left": 8,
-        "right": 352,
-        "width": 344,
+        "right": 404,
+        "width": 396,
         "height": 0
       },
       "snippet": "<div id=\"shadow-root-container\">",
       "nodeLabel": "body > div#shadow-root-container"
     },
-    "totalBodyElements": 153
+    "totalBodyElements": 153,
+    "totalFrames": 0,
+    "framesDepth": {
+      "max": 0,
+      "url": ""
+    }
   },
   "OptimizedImages": [
     {

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -4530,8 +4530,8 @@
           {
             "node": {
               "type": "node",
-              "lhId": "5-44-title",
-              "path": "3,HTML,1,BODY,9,DIV,3,svg,0,title",
+              "lhId": "1-25-title",
+              "path": "2,HTML,1,BODY,9,DIV,5,svg,0,title",
               "selector": "body > div > svg.social-facebook > title#social-facebook-5",
               "boundingRect": {
                 "top": 0,
@@ -4554,15 +4554,15 @@
           {
             "node": {
               "type": "node",
-              "lhId": "5-45-DIV",
-              "path": "3,HTML,1,BODY,6,DIV",
+              "lhId": "1-26-DIV",
+              "path": "2,HTML,1,BODY,6,DIV",
               "selector": "body > div#shadow-root-container",
               "boundingRect": {
                 "top": 316,
                 "bottom": 316,
                 "left": 8,
-                "right": 352,
-                "width": 344,
+                "right": 404,
+                "width": 396,
                 "height": 0
               },
               "snippet": "<div id=\"shadow-root-container\">",
@@ -4573,6 +4573,26 @@
               "type": "numeric",
               "granularity": 1,
               "value": 100
+            }
+          },
+          {
+            "statistic": "Total Frames",
+            "value": {
+              "type": "numeric",
+              "granularity": 1,
+              "value": 0
+            }
+          },
+          {
+            "node": {
+              "type": "url",
+              "value": ""
+            },
+            "statistic": "Maximum Frame Depth",
+            "value": {
+              "type": "numeric",
+              "granularity": 1,
+              "value": 0
             }
           }
         ]
@@ -9512,6 +9532,12 @@
       ],
       "core/audits/dobetterweb/dom-size.js | statisticDOMWidth": [
         "audits[dom-size].details.items[2].statistic"
+      ],
+      "core/audits/dobetterweb/dom-size.js | statisticDOMTotalFrames": [
+        "audits[dom-size].details.items[3].statistic"
+      ],
+      "core/audits/dobetterweb/dom-size.js | statisticDOMFramesDepth": [
+        "audits[dom-size].details.items[4].statistic"
       ],
       "core/audits/dobetterweb/geolocation-on-start.js | failureTitle": [
         "audits[geolocation-on-start].title"

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -704,6 +704,12 @@
   "core/audits/dobetterweb/dom-size.js | statisticDOMElements": {
     "message": "Total DOM Elements"
   },
+  "core/audits/dobetterweb/dom-size.js | statisticDOMFramesDepth": {
+    "message": "Maximum Frame Depth"
+  },
+  "core/audits/dobetterweb/dom-size.js | statisticDOMTotalFrames": {
+    "message": "Total Frames"
+  },
   "core/audits/dobetterweb/dom-size.js | statisticDOMWidth": {
     "message": "Maximum Child Elements"
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -704,6 +704,12 @@
   "core/audits/dobetterweb/dom-size.js | statisticDOMElements": {
     "message": "T̂ót̂ál̂ D́ÔḾ Êĺêḿêńt̂ś"
   },
+  "core/audits/dobetterweb/dom-size.js | statisticDOMFramesDepth": {
+    "message": "M̂áx̂ím̂úm̂ F́r̂ám̂é D̂ép̂t́ĥ"
+  },
+  "core/audits/dobetterweb/dom-size.js | statisticDOMTotalFrames": {
+    "message": "T̂ót̂ál̂ F́r̂ám̂éŝ"
+  },
   "core/audits/dobetterweb/dom-size.js | statisticDOMWidth": {
     "message": "M̂áx̂ím̂úm̂ Ćĥíl̂d́ Êĺêḿêńt̂ś"
   },

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -259,6 +259,9 @@ declare module Artifacts {
     totalBodyElements: number;
     width: NodeDetails & {max: number;};
     depth: NodeDetails & {max: number;};
+
+    totalFrames: number;
+    framesDepth: {max: number; url: string};
   }
 
   interface EmbeddedContentInfo {


### PR DESCRIPTION
While inspecting [this site](https://www.objetivo.br/), I noticed it had hella iframes. This page goes a few iframes deep and eventually tries to iframe a page a second time, which Chrome dutifully steps in to prevent a never-ending recursion.

The first layer of these iframes is for a "logout" page in the header. Odd, since 1) I'm not logged in and 2) no pixels are even visible (it's display none'd). I'm thinking that any sufficiently deep frame hierarchy is a sign that something is amiss, so it seems good to add this information to the `dom-size` audit.