### PR TITLE
tests: render roundtrip proto lhr

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -58,6 +58,9 @@ jobs:
 
     - run: yarn test-proto # Run before unit-core because the roundtrip json is needed for proto tests.
 
+    - run: yarn build-viewer && yarn mocha --testMatch viewer/test/viewer-test-pptr.js -t 'proto roundtrip report'
+      name: 'Render roundtrip proto'
+
     - run: sudo apt-get install xvfb
 
     - name: yarn unit

--- a/core/lib/lighthouse-compatibility.js
+++ b/core/lib/lighthouse-compatibility.js
@@ -106,12 +106,22 @@ function upgradeLhrForCompatibility(lhr) {
 
   // Add some minimal stuff so older reports still work.
   if (!lhr.environment) {
-    // @ts-expect-error
-    lhr.environment = {benchmarkIndex: 0};
+    lhr.environment = {
+      benchmarkIndex: 0,
+      networkUserAgent: lhr.userAgent,
+      hostUserAgent: lhr.userAgent,
+    };
   }
   if (!lhr.configSettings.screenEmulation) {
-    // @ts-expect-error
-    lhr.configSettings.screenEmulation = {};
+    lhr.configSettings.screenEmulation = {
+      width: -1,
+      height: -1,
+      deviceScaleFactor: -1,
+      mobile: lhr.environment?.hostUserAgent ?
+        /mobile/i.test(lhr.environment.hostUserAgent) :
+        true,
+      disabled: false,
+    };
   }
   if (!lhr.i18n) {
     // @ts-expect-error

--- a/core/test/scripts/run-mocha-tests.js
+++ b/core/test/scripts/run-mocha-tests.js
@@ -203,6 +203,8 @@ function getTestFiles() {
     grep = new RegExp(titles.map(escapeRegex).join('|'));
 
     filteredTests = filteredTests.filter(file => failedTests.some(failed => failed.file === file));
+  } else if (argv.t) {
+    grep = argv.t;
   }
 
   if (filterFilePatterns.length) {
@@ -255,7 +257,7 @@ function exit({numberFailures, numberMochaInvocations}) {
 
 /**
  * @typedef OurMochaArgs
- * @property {RegExp | undefined} grep
+ * @property {RegExp | string | undefined} grep
  * @property {boolean} bail
  * @property {boolean} parallel
  * @property {string | undefined} require

--- a/viewer/test/viewer-test-pptr.js
+++ b/viewer/test/viewer-test-pptr.js
@@ -13,6 +13,9 @@ import {Server} from '../../cli/test/fixtures/static-server.js';
 import defaultConfig from '../../core/config/default-config.js';
 import {LH_ROOT} from '../../root.js';
 import {getCanonicalLocales} from '../../shared/localization/format.js';
+import {getProtoRoundTrip} from '../../core/test/test-utils.js';
+
+const {itIfProtoExists} = getProtoRoundTrip();
 
 const portNumber = 10200;
 const viewerUrl = `http://localhost:${portNumber}/dist/gh-pages/viewer/index.html`;
@@ -264,6 +267,20 @@ describe('Lighthouse Viewer', () => {
     });
   });
 
+  async function verifyLhrLoadsWithNoErrors(lhrFilePath) {
+    await viewerPage.goto(viewerUrl, {waitUntil: 'networkidle2', timeout: 30000});
+    const fileInput = await viewerPage.$('#hidden-file-input');
+    const waitForAck = viewerPage.evaluate(() =>
+      new Promise(resolve =>
+        document.addEventListener('lh-file-upload-test-ack', resolve, {once: true})));
+    await fileInput.uploadFile(lhrFilePath);
+    await Promise.race([
+      waitForAck,
+      new Promise((resolve, reject) => setTimeout(reject, 5_000)),
+    ]);
+    await ensureNoErrors();
+  }
+
   describe('Renders old reports', () => {
     [
       'lhr-3.0.0.json',
@@ -273,22 +290,16 @@ describe('Lighthouse Viewer', () => {
       'lhr-8.5.0.json',
     ].forEach((testFilename) => {
       it(`[${testFilename}] should load with no errors`, async () => {
-        await viewerPage.goto(viewerUrl, {waitUntil: 'networkidle2', timeout: 30000});
-        const fileInput = await viewerPage.$('#hidden-file-input');
-        const waitForAck = viewerPage.evaluate(() =>
-          new Promise(resolve =>
-            document.addEventListener('lh-file-upload-test-ack', resolve, {once: true})));
-        await fileInput.uploadFile(`${LH_ROOT}/report/test-assets/${testFilename}`);
-        await Promise.race([
-          waitForAck,
-          new Promise((resolve, reject) => setTimeout(reject, 5_000)),
-        ]);
-        await ensureNoErrors();
+        await verifyLhrLoadsWithNoErrors(`${LH_ROOT}/report/test-assets/${testFilename}`);
       });
     });
   });
 
   describe('PSI', () => {
+    itIfProtoExists('Renders proto roundtrip report', async () => {
+      await verifyLhrLoadsWithNoErrors(`${LH_ROOT}/.tmp/sample_v2_round_trip.json`);
+    });
+
     /** @type {Partial<puppeteer.ResponseForRequest>} */
     let interceptedRequest;
     /** @type {Partial<puppeteer.ResponseForRequest>} */

--- a/viewer/test/viewer-test-pptr.js
+++ b/viewer/test/viewer-test-pptr.js
@@ -14,6 +14,7 @@ import defaultConfig from '../../core/config/default-config.js';
 import {LH_ROOT} from '../../root.js';
 import {getCanonicalLocales} from '../../shared/localization/format.js';
 import {getProtoRoundTrip} from '../../core/test/test-utils.js';
+import { expect } from 'expect';
 
 const {itIfProtoExists} = getProtoRoundTrip();
 
@@ -279,6 +280,11 @@ describe('Lighthouse Viewer', () => {
       new Promise((resolve, reject) => setTimeout(reject, 5_000)),
     ]);
     await ensureNoErrors();
+
+    const content = await viewerPage.$eval('main', el => el.textContent);
+    for (const line of content.split('\n')) {
+      expect(line).not.toContain('undefined');
+    }
   }
 
   describe('Renders old reports', () => {


### PR DESCRIPTION
Includes the roundtrip proto LHR in the simple "fail if there is a runtime error" renderer test.

In addition to checks for `undefined` in the rendered output, this would have prevented the regression reported in #14808.