### PR TITLE
core(redirects): use requestId instead of URL to find requests

### DIFF
--- a/cli/test/smokehouse/test-definitions/redirects-client-paint-server.js
+++ b/cli/test/smokehouse/test-definitions/redirects-client-paint-server.js
@@ -44,9 +44,12 @@ const expectations = {
         score: '<1',
         numericValue: '>=8000',
         details: {
-          items: {
-            length: 3,
-          },
+          items: [
+            // Conservative wastedMs to avoid flakes.
+            {url: /js-redirect\.html/, wastedMs: '>6000'},
+            {url: /online-only\.html/, wastedMs: '>500'},
+            {url: /redirects-final\.html/, wastedMs: 0},
+          ],
         },
       },
     },

--- a/cli/test/smokehouse/test-definitions/redirects-history-push-state.js
+++ b/cli/test/smokehouse/test-definitions/redirects-history-push-state.js
@@ -30,6 +30,18 @@ const expectations = {
     requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fonline-only.html%3Fdelay%3D1000%26redirect%3D%2Fredirects-final.html%253FpushState`,
     finalDisplayedUrl: 'http://localhost:10200/push-state',
     audits: {
+      redirects: {
+        score: '<1',
+        numericValue: '>=8000',
+        details: {
+          items: [
+            // Conservative wastedMs to avoid flakes.
+            {url: /js-redirect\.html/, wastedMs: '>6000'},
+            {url: /online-only\.html/, wastedMs: '>500'},
+            {url: /redirects-final\.html\?pushState/, wastedMs: 0},
+          ],
+        },
+      },
     },
     runWarnings: [
       /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html\?pushState. Try testing the second URL directly./,

--- a/cli/test/smokehouse/test-definitions/redirects-multiple-server.js
+++ b/cli/test/smokehouse/test-definitions/redirects-multiple-server.js
@@ -40,9 +40,13 @@ const expectations = {
       'redirects': {
         score: '<1',
         details: {
-          items: {
-            length: 4,
-          },
+          items: [
+            // Conservative wastedMs to avoid flakes.
+            {url: /online-only\.html/, wastedMs: '>500'},
+            {url: /online-only\.html/, wastedMs: '>500'},
+            {url: /online-only\.html/, wastedMs: '>500'},
+            {url: /redirects-final\.html/, wastedMs: 0},
+          ],
         },
       },
     },

--- a/cli/test/smokehouse/test-definitions/redirects-scripts.js
+++ b/cli/test/smokehouse/test-definitions/redirects-scripts.js
@@ -11,6 +11,7 @@ const config = {
     onlyAudits: [
       'legacy-javascript',
       'unused-javascript',
+      'redirects',
     ],
   },
 };
@@ -51,6 +52,16 @@ const expectations = {
                 ],
               },
             },
+          ],
+        },
+      },
+      'redirects': {
+        numericValue: '>0',
+        details: {
+          items: [
+            // Conservative wastedMs to avoid flakes.
+            {url: /online-only\.html/, wastedMs: '>0'},
+            {url: /redirects-scripts\.html/, wastedMs: 0},
           ],
         },
       },

--- a/cli/test/smokehouse/test-definitions/redirects-single-client.js
+++ b/cli/test/smokehouse/test-definitions/redirects-single-client.js
@@ -29,6 +29,16 @@ const expectations = {
     requestedUrl: `http://localhost:10200/js-redirect.html?delay=2000&jsDelay=5000&jsRedirect=%2Fredirects-final.html#hash`,
     finalDisplayedUrl: 'http://localhost:10200/redirects-final.html',
     audits: {
+      redirects: {
+        numericValue: '>=6000',
+        details: {
+          items: [
+            // Conservative wastedMs to avoid flakes.
+            {url: /js-redirect\.html/, wastedMs: '>6000'},
+            {url: /redirects-final\.html/, wastedMs: 0},
+          ],
+        },
+      },
     },
     runWarnings: [
       /The page may not be loading as expected because your test URL \(.*js-redirect.html.*\) was redirected to .*redirects-final.html. Try testing the second URL directly./,

--- a/cli/test/smokehouse/test-definitions/redirects-single-server.js
+++ b/cli/test/smokehouse/test-definitions/redirects-single-server.js
@@ -48,9 +48,11 @@ const expectations = {
         score: 1,
         numericValue: '>=2000',
         details: {
-          items: {
-            length: 2,
-          },
+          items: [
+            // Conservative wastedMs to avoid flakes.
+            {url: /online-only\.html/, wastedMs: '>1000'},
+            {url: /redirects-final\.html$/, wastedMs: 0},
+          ],
         },
       },
     },

--- a/core/audits/redirects.js
+++ b/core/audits/redirects.js
@@ -9,7 +9,6 @@ import {ByteEfficiencyAudit} from './byte-efficiency/byte-efficiency-audit.js';
 import * as i18n from '../lib/i18n/i18n.js';
 import {ProcessedTrace} from '../computed/processed-trace.js';
 import {NetworkRecords} from '../computed/network-records.js';
-import {MainResource} from '../computed/main-resource.js';
 import {LanternInteractive} from '../computed/metrics/lantern-interactive.js';
 
 const UIStrings = {
@@ -48,12 +47,11 @@ class Redirects extends Audit {
    *
    * Returns network records [/requestedUrl, /firstRedirect, /secondRedirect, /thirdRedirect, /mainDocumentUrl]
    *
-   * @param {LH.Artifacts.NetworkRequest} mainResource
    * @param {Array<LH.Artifacts.NetworkRequest>} networkRecords
    * @param {LH.Artifacts.ProcessedTrace} processedTrace
    * @return {Array<LH.Artifacts.NetworkRequest>}
    */
-  static getDocumentRequestChain(mainResource, networkRecords, processedTrace) {
+  static getDocumentRequestChain(networkRecords, processedTrace) {
     /** @type {Array<LH.Artifacts.NetworkRequest>} */
     const documentRequests = [];
 
@@ -92,7 +90,6 @@ class Redirects extends Audit {
 
     const processedTrace = await ProcessedTrace.request(trace, context);
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
-    const mainResource = await MainResource.request({URL: artifacts.URL, devtoolsLog}, context);
 
     const metricComputationData = {trace, devtoolsLog, gatherContext, settings, URL: artifacts.URL};
     const metricResult = await LanternInteractive.request(metricComputationData, context);
@@ -105,8 +102,7 @@ class Redirects extends Audit {
       }
     }
 
-    const documentRequests = Redirects.getDocumentRequestChain(
-      mainResource, networkRecords, processedTrace);
+    const documentRequests = Redirects.getDocumentRequestChain(networkRecords, processedTrace);
 
     let totalWastedMs = 0;
     const tableRows = [];

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -709,7 +709,7 @@ declare module Artifacts {
     timestamps: TraceTimes;
     /** The relative times from timeOrigin to key events, in milliseconds. */
     timings: TraceTimes;
-    /** The subset of trace events from the page's process, sorted by timestamp. */
+    /** The subset of trace events from the main frame's process, sorted by timestamp. Due to cross-origin navigations, the main frame may have multiple processes, so events may be from more than one process.  */
     processEvents: Array<TraceEvent>;
     /** The subset of trace events from the page's main thread, sorted by timestamp. */
     mainThreadEvents: Array<TraceEvent>;
@@ -977,6 +977,7 @@ export interface TraceEvent {
       processId?: number;
       isLoadingMainFrame?: boolean;
       documentLoaderURL?: string;
+      navigationId?: string;
       frames?: {
         frame: string;
         url: string;


### PR DESCRIPTION
Pages that do a js redirect to themselves (e.g. found pages doing some janky A/B testing that would reload after doing a sync XHR) were getting no feedback from the `redirects` audit because the audit was matching requests to navStarts by URL. Repeated navStarts to the same URL would always resolve to the first network request, so the audit would say the redirects took 0ms.

Instead, this PR looks at the navStart `navigationId`, which matches network requests' `requestId` for navigation requests.

Also adds redirect assertions to all the `redirect-*` smoke tests, because we don't have great trace fixture coverage of redirect cases, but we do have great smoke test coverage of them.