### PR TITLE
tests(devtools): use new `primaryPageTarget` function

### DIFF
--- a/cli/test/smokehouse/config/exclusions.js
+++ b/cli/test/smokehouse/config/exclusions.js
@@ -25,6 +25,8 @@ const exclusions = {
     'metrics-tricky-tti', 'metrics-tricky-tti-late-fcp', 'screenshot',
     // Disabled because of differences that need further investigation
     'byte-efficiency', 'byte-gzip', 'perf-preload',
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1420418
+    'issues-mixed-content',
   ],
 };
 

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -104,7 +104,8 @@ async function waitForFunction(session, fn, deps) {
   while (true) {
     try {
       return await evaluateInSession(session, fn, deps);
-    } catch {
+    } catch (e) {
+      console.error(e);
       await new Promise(r => setTimeout(r, 500));
     }
   }
@@ -172,14 +173,14 @@ async function waitForLighthouseReady() {
   }
   // @ts-expect-error global
   const targetManager = SDK.targetManager || (SDK.TargetManager.TargetManager || SDK.TargetManager).instance();
-  if (targetManager.mainTarget() === null) {
+  if (targetManager.primaryPageTarget() === null) {
     if (targetManager?.observeTargets) {
       await new Promise(resolve => targetManager.observeTargets({
         targetAdded: resolve,
         targetRemoved: () => {},
       }));
     } else {
-      while (targetManager.mainTarget() === null) {
+      while (targetManager.primaryPageTarget() === null) {
         await new Promise(resolve => setTimeout(resolve, 100));
       }
     }

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -104,8 +104,7 @@ async function waitForFunction(session, fn, deps) {
   while (true) {
     try {
       return await evaluateInSession(session, fn, deps);
-    } catch (e) {
-      console.error(e);
+    } catch {
       await new Promise(r => setTimeout(r, 500));
     }
   }


### PR DESCRIPTION
DevTools tests were hanging forever because `primaryPageTarget` has replaced the `mainTarget` function.