### PR TITLE
clients(viewer): rework landing with link to lhci diff tool

### DIFF
--- a/viewer/app/index.html
+++ b/viewer/app/index.html
@@ -37,7 +37,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
             <input id="hidden-file-input" type="file" hidden accept="application/json">
           </li>
           <li>
-            Or, paste the JSON
+            Or, paste the JSON or a Gist URL
             <input type="url" class="viewer-placeholder__url js-gist-url" placeholder="Enter or paste Gist URL">
           </li>
         </ul>

--- a/viewer/app/index.html
+++ b/viewer/app/index.html
@@ -46,7 +46,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
         <hr>
 
-        <p>To collect a fresh report:</p>
+        <p>To collect a fresh report of a public URL:</p>
         <ul>
           <li>Use the Lighthouse browser extension (<a href="https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk">Chrome</a> / <a href="https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/">Firefox</a>)<br>
           <li>Or, use <a href="https://pagespeed.web.dev/">PageSpeed Insights</a>

--- a/viewer/app/index.html
+++ b/viewer/app/index.html
@@ -29,19 +29,34 @@ Unless required by applicable law or agreed to in writing, software distributed 
     </div>
     <div>
       <h1 class="viewer-placeholder__heading">Lighthouse Report Viewer</h1>
-      <div class="viewer-placeholder__help">To view a report: Paste its json or a Gist URL.<br>
-      You can also drag 'n drop the file or click here to select it.<br><br>
-      To get a fresh report, use the Lighthouse browser extension (<a href="https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk">Chrome</a> / <a href="https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/">Firefox</a>)<br>
-      or <a href="https://web.dev/measure">web.dev/measure</a>.</div>
-      <input type="url" class="viewer-placeholder__url js-gist-url"
-             placeholder="Enter or paste Gist URL">
+      <div class="viewer-placeholder__help">
+        <p>To view a report:</p>
+        <ul>
+          <li>
+            Drag 'n drop the file (or <button class="viewer-placeholder__file-button">select a file</button>)
+            <input id="hidden-file-input" type="file" hidden accept="application/json">
+          </li>
+          <li>
+            Or, paste the JSON
+            <input type="url" class="viewer-placeholder__url js-gist-url" placeholder="Enter or paste Gist URL">
+          </li>
+        </ul>
+
+        <p>Also, perhaps visit the <a href="https://googlechrome.github.io/lighthouse-ci/viewer/">Lighthouse Report Diff tool</a> to compare two reports.</p>
+
+        <hr>
+
+        <p>To collect a fresh report:</p>
+        <ul>
+          <li>Use the Lighthouse browser extension (<a href="https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk">Chrome</a> / <a href="https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/">Firefox</a>)<br>
+          <li>Or, use <a href="https://pagespeed.web.dev/">PageSpeed Insights</a>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
 
 <div id="lh-log"></div>
-
-<input id="hidden-file-input" type="file" hidden accept="application/json">
 
 <script src="src/bundled.js" type="module"></script>
 <script>

--- a/viewer/app/src/lighthouse-report-viewer.js
+++ b/viewer/app/src/lighthouse-report-viewer.js
@@ -91,14 +91,9 @@ export class LighthouseReportViewer {
       inputTarget.value = '';
     });
 
-    // A click on the visual placeholder will trigger the hidden file input.
-    const placeholderTarget = find('.viewer-placeholder-inner', document);
-    placeholderTarget.addEventListener('click', e => {
-      const target = /** @type {?Element} */ (e.target);
-
-      if (target && target.localName !== 'input' && target.localName !== 'a') {
-        fileInput.click();
-      }
+    const selectFileEl = find('.viewer-placeholder__file-button', document);
+    selectFileEl.addEventListener('click', _ => {
+      fileInput.click();
     });
   }
 

--- a/viewer/app/styles/viewer.css
+++ b/viewer/app/styles/viewer.css
@@ -62,9 +62,19 @@ body {
   padding: 16px;
   max-width: 80vw;
   border: 2px dashed rgba(0,0,0,0.2);
-  cursor: pointer;
   background-color: #fff;
 }
+
+.viewer-placeholder p {
+  margin-bottom: 0;
+}
+.viewer-placeholder ul {
+  margin: 0;
+}
+.viewer-placeholder hr {
+  margin: 16px 0;
+}
+
 .viewer-placeholder-inner.lh-loading {
   filter: blur(2px) grayscale(1);
   cursor: wait
@@ -77,13 +87,25 @@ body {
 }
 .viewer-placeholder__heading {
   font-weight: 300;
-  margin: 0;
+  margin: 0 0 24px;
   line-height: 32px;
 }
 .viewer-placeholder__help {
-  margin-top: 12px;
   line-height: 1.6;
 }
+
+.viewer-placeholder__file-button {
+  border: 0;
+  background: 0;
+  display: inline;
+  padding: 0;
+  color: #0000ee;
+  color: -webkit-link;
+  font-size: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .viewer-placeholder-logo {
   width: 140px;
   height: 140px;


### PR DESCRIPTION

I've been meaning to add a link to the ci diff tool (aka ci viewer) for a while now. 

* I did that
*  and updated the layout to hopefully be clearer. 
* Also measure.web.dev => PSI. 
* The entire landing div was a click target for selecting a file. I went for a more direct link. I think that's a more clear UI convention.

Before/after:

<img width="2029" alt="image" src="https://user-images.githubusercontent.com/39191/222571529-ce64c3fa-6ba7-4cac-adc4-04bd83055050.png">

