### PR TITLE
tests(devtools): reenable `issues-mixed-content`

### DIFF
--- a/cli/test/smokehouse/config/exclusions.js
+++ b/cli/test/smokehouse/config/exclusions.js
@@ -25,8 +25,6 @@ const exclusions = {
     'metrics-tricky-tti', 'metrics-tricky-tti-late-fcp', 'screenshot',
     // Disabled because of differences that need further investigation
     'byte-efficiency', 'byte-gzip', 'perf-preload',
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=1420418
-    'issues-mixed-content',
   ],
 };
 


### PR DESCRIPTION
Fixes #14841 

I can't repro the error locally anymore on latest ToT, seems like the issue was resolved even if my bug report wasn't helpful.

Still need to verify on CI though.