### PR TITLE
clients(viewer): link to diff tool's new URL

### DIFF
--- a/viewer/app/index.html
+++ b/viewer/app/index.html
@@ -42,7 +42,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
           </li>
         </ul>
 
-        <p>Also, perhaps visit the <a href="https://googlechrome.github.io/lighthouse-ci/viewer/">Lighthouse Report Diff tool</a> to compare two reports.</p>
+        <p>Also, perhaps visit the <a href="https://googlechrome.github.io/lighthouse-ci/difftool/">Lighthouse Report Diff tool</a> to compare two reports.</p>
 
         <hr>
 


### PR DESCRIPTION
I published the lhci diff viewer at [/lighthouse-ci/difftool](https://googlechrome.github.io/lighthouse-ci/difftool/).
It's also still published at /lighthouse-ci/viewer

But I think it's a tad easier to only have one /viewer in our world. ;)