### PR TITLE
tests: fix seo-tap-targets in high DPI

### DIFF
--- a/cli/test/fixtures/seo/seo-tap-targets.html
+++ b/cli/test/fixtures/seo/seo-tap-targets.html
@@ -16,6 +16,13 @@
   }
   body {
     margin: 0;
+
+    /* Without an explicit body font size, elements are more likely to have fractional sizes, which
+       complicates the tap target + finger overlap calculations. They can end up just 5% different
+       in different DPIs.
+       (Essentially caused by the the accumulation of rounding to integer css pixels for DPI=1)
+       */
+    font-size: 14px;
   }
   </style>
   <script>
@@ -39,7 +46,7 @@
         It should not fail though because overlap with a sticky element depends on the scroll position.
       </a>
     </div>
-      
+
     <h1>SEO Tap targets</h1>
 
     <!-- Invisible nodes don't cause failures -->
@@ -61,7 +68,7 @@
     </div>
     <br/><br/>
 
-    
+
     <div style="overflow: hidden; position: relative">
       <!-- Should be counted as visible although part of it is outside the scroll container -->
       <a data-gathered-target="target-with-client-rect-outside-scroll-container">
@@ -95,7 +102,7 @@
 
     <br/><br/>
 
-    <!-- The left tap target has a large client rect that would normally overlap with the right tap target, 
+    <!-- The left tap target has a large client rect that would normally overlap with the right tap target,
          but the left link is overflow hidden, so there should be no failure. We should however
          detect both tap targets (and not say the left one is invisible because the center of the big client rect is invisible) -->
     <div style="overflow: hidden">
@@ -103,7 +110,7 @@
         data-gathered-target="child-client-rect-hidden-by-overflow-hidden"
         style="display: block; height: 40px; width: 40px; background: #fca; float: left; overflow: hidden; position: relative;">
         <div style="background: #afa; height: 40px; width: 80px; position: absolute; left: 30px">
-          left    
+          left
         </div>
       </a>
       <a
@@ -119,7 +126,7 @@
         data-gathered-target="child-client-rect-overlapping-other-target"
         style="display: block; height: 40px; width: 40px; background: #fca; float: left; position: relative;">
         <div style="background: #afa; height: 40px; width: 30px; position: absolute; left: 30px">
-          left    
+          left
         </div>
       </a>
       <a


### PR DESCRIPTION
fixes #13557 

The failure was 
<img width="548" alt="image" src="https://user-images.githubusercontent.com/39191/223570189-1243b02c-1c28-46c0-b75c-b5969714ed90.png">

The case was these two elements: (zero width target and passing target)
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/39191/223570424-e2ae42a0-2a0f-4700-ba9b-689bba297b21.png">

In taptargets we take each target (eg zero width target) as a rect. then we place a hypothetical 48x48 finger at the center of the rect. Then we see how many pixels of overlap it has with the adjacent target (passing target)

Test said it should be 720 pixels of overlap area, but on a high dpi screen it was 696.  They're both right. 

In hidpi you can have fractional CSS pixels.. so.. a lot of things are 18.5px tall. And that ends up with a very similar but slightly off result in these rect overlap calculations.

Fixing it with a font-size on the body was a guess. I never understood [this whole thing](https://www.aleksandrhovhannisyan.com/blog/62-5-percent-font-size-trick/) but it probably is related.

------

The discrepancy above points to a problem with the implementation of emulation. I can repro this difference while emulating DPR=2 on my dpi1 screen and emulating DPR=2 on my dpi2 screen. One says 18px tall, the other 18.5px tall.  Thats not supposed to happen.  That said, this subtlety probably isn't causing us large problems, so I'm not concerned.