### PR TITLE
core(uses-responsive-images-snapshot): ignore CSS images

### DIFF
--- a/core/audits/byte-efficiency/uses-responsive-images-snapshot.js
+++ b/core/audits/byte-efficiency/uses-responsive-images-snapshot.js
@@ -56,6 +56,10 @@ class UsesResponsiveImagesSnapshot extends Audit {
     /** @type {LH.Audit.Details.TableItem[]} */
     const items = [];
     for (const image of artifacts.ImageElements) {
+      // Ignore CSS images because it's difficult to determine what is a spritesheet,
+      // and the reward-to-effort ratio for responsive CSS images is quite low https://css-tricks.com/responsive-images-css/.
+      if (image.isCss) continue;
+
       if (!image.naturalDimensions) continue;
       const actual = image.naturalDimensions;
       const displayed = UsesResponsiveImages.default.getDisplayedDimensions(


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/14888

Navigation mode will ignore CSS images for this audit. I consider this a byproduct of having 2 different implementations. Long term we should find a way to unify these two audits.
