### PR TITLE
clients(lr): remove FCP 3G from config

### DIFF
--- a/core/config/lr-mobile-config.js
+++ b/core/config/lr-mobile-config.js
@@ -17,17 +17,6 @@ const config = {
       'bf-cache',
     ],
   },
-  audits: [
-    'metrics/first-contentful-paint-3g',
-  ],
-  categories: {
-    // TODO(bckenny): type extended Config where e.g. category.title isn't required
-    performance: /** @type {LH.Config.CategoryJson} */({
-      auditRefs: [
-        {id: 'first-contentful-paint-3g', weight: 0},
-      ],
-    }),
-  },
 };
 
 export default config;


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/lighthouse/issues/14905

Removing audits completely is usually a breaking change, but this audit is not included in the default config. I'm still ok to defer the complete removal to 11.0 though.