### PR TITLE
core: cap byte-efficiency-audit scores to a max of 1

### DIFF
--- a/core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -39,12 +39,14 @@ const WASTED_MS_FOR_SCORE_OF_ZERO = 5000;
 class ByteEfficiencyAudit extends Audit {
   /**
    * Creates a score based on the wastedMs value using linear interpolation between control points.
+   * A negative wastedMs is scored as 1, assuming time is not being wasted with respect to the
+   * opportunity being measured.
    *
    * @param {number} wastedMs
    * @return {number}
    */
   static scoreForWastedMs(wastedMs) {
-    if (wastedMs === 0) {
+    if (wastedMs <= 0) {
       return 1;
     } else if (wastedMs < WASTED_MS_FOR_AVERAGE) {
       return linearInterpolation(0, 1, WASTED_MS_FOR_AVERAGE, 0.75, wastedMs);
@@ -214,6 +216,8 @@ class ByteEfficiencyAudit extends Audit {
 
     const wastedBytes = results.reduce((sum, item) => sum + item.wastedBytes, 0);
 
+    // `wastedMs` may be negative, if making the opportunity change could be detrimental.
+    // This is useful information in the LHR and should be preserved.
     let wastedMs;
     if (gatherContext.gatherMode === 'navigation') {
       if (!graph) throw Error('Page dependency graph should always be computed in navigation mode');


### PR DESCRIPTION
Sometimes enacting an opportunity could actually regress performance and its audit could measure a negative `wastedMs`/`overallSavingsMs`. It turns out `byte-efficiency-audit` doesn't have any guard against this case and gives those results a `score` greater than 1, which triggers an [out-of-range score error](https://github.com/GoogleChrome/lighthouse/blob/90797a1e5fd4e0066a9906408d29e44c1c07b8f1/core/audits/audit.js#L340), and so what should be a passing result turns into an audit error.

This PR caps the `byte-efficiency-audit` score so negative savings still max out at a score of 1 and returns in a valid audit result.

For context, this doesn't happen often, e.g. ~0.09% for `prioritize-lcp-image` in the last HTTP Archive run and similar rates for the other `byte-efficiency-audit`s, but obviously important to get right.