### PR TITLE
cli: fix `--channel` flag

### DIFF
--- a/cli/run.js
+++ b/cli/run.js
@@ -241,7 +241,7 @@ async function runLighthouse(url, flags, config) {
     if (flags.legacyNavigation) {
       log.warn('CLI', 'Legacy navigation CLI is deprecated');
       flags.channel = 'legacy-navigation-cli';
-    } else if(!flags.channel) {
+    } else if (!flags.channel) {
       flags.channel = 'cli';
     }
 

--- a/cli/run.js
+++ b/cli/run.js
@@ -241,7 +241,7 @@ async function runLighthouse(url, flags, config) {
     if (flags.legacyNavigation) {
       log.warn('CLI', 'Legacy navigation CLI is deprecated');
       flags.channel = 'legacy-navigation-cli';
-    } else {
+    } else if(!flags.channel) {
       flags.channel = 'cli';
     }
 


### PR DESCRIPTION
channel is always 'cli' although we set it to any value

<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
