### PR TITLE
WIP: lantern-lcp-load-delay

### DIFF
--- a/core/computed/metrics/lantern-lcp-load-delay.js
+++ b/core/computed/metrics/lantern-lcp-load-delay.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright 2019 The Lighthouse Authors. All Rights Reserved.
+ * @license Copyright 2023 The Lighthouse Authors. All Rights Reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */

--- a/core/computed/metrics/lantern-lcp-load-delay.js
+++ b/core/computed/metrics/lantern-lcp-load-delay.js
@@ -1,0 +1,89 @@
+/**
+ * @license Copyright 2019 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {makeComputedArtifact} from '../computed-artifact.js';
+import {LanternMetric} from './lantern-metric.js';
+import {LighthouseError} from '../../lib/lh-error.js';
+
+/** @typedef {import('../../lib/dependency-graph/base-node.js').Node} Node */
+
+class LanternLCPLoadDelay extends LanternMetric {
+  /**
+   * @return {LH.Gatherer.Simulation.MetricCoefficients}
+   */
+  static get COEFFICIENTS() {
+    return {
+      intercept: 0,
+      optimistic: 0.5,
+      pessimistic: 0.5,
+    };
+  }
+
+  /**
+   * @param {Node} dependencyGraph
+   * @param {LH.Artifacts.ProcessedNavigation} processedNavigation
+   * @return {Node}
+   */
+  static getLcpRequestNode(dependencyGraph, processedNavigation) {
+    if (!processedNavigation.largestContentfulPaintEvt) {
+      throw new LighthouseError(LighthouseError.errors.NO_LCP);
+    }
+
+    const lcpUrl = processedNavigation.lcpImagePaintEvt?.args.data?.imageUrl;
+    if (!lcpUrl) {
+      throw new Error('LCP was not an image');
+    }
+
+    /** @type {Node|undefined} */
+    let lcpRequestNode = undefined;
+
+    dependencyGraph.traverse(node => {
+      if (node.type !== 'network') return;
+      if (node.record.url !== lcpUrl) return;
+      lcpRequestNode = node;
+    });
+
+    if (!lcpRequestNode) throw new Error('Could not find LCP request node');
+    return lcpRequestNode;
+  }
+
+  /**
+   * @param {Node} dependencyGraph
+   * @param {LH.Artifacts.ProcessedNavigation} processedNavigation
+   * @return {Node}
+   */
+  static getOptimisticGraph(dependencyGraph, processedNavigation) {
+    const lcpRequestNode = this.getLcpRequestNode(dependencyGraph, processedNavigation);
+    return dependencyGraph.cloneWithRelationships(node => {
+      if (node.startTime > lcpRequestNode.startTime) return false;
+      // Assume no CPU nodes block the LCP request in the optimistic graph.
+      if (node.type === 'cpu') return false;
+      if (node.record.priority === 'Low' || node.record.priority === 'VeryLow') return false;
+      return true;
+    });
+  }
+
+  /**
+   * @param {Node} dependencyGraph
+   * @param {LH.Artifacts.ProcessedNavigation} processedNavigation
+   * @return {Node}
+   */
+  static getPessimisticGraph(dependencyGraph, processedNavigation) {
+    const lcpRequestNode = this.getLcpRequestNode(dependencyGraph, processedNavigation);
+    return dependencyGraph.cloneWithRelationships(node => {
+      if (node.startTime > lcpRequestNode.startTime) return false;
+      // Assume all CPU nodes block the LCP request in the pessimistic graph.
+      if (node.type === 'cpu') return true;
+      return true;
+    });
+  }
+}
+
+const LanternLCPLoadDelayComputed = makeComputedArtifact(
+  LanternLCPLoadDelay,
+  ['devtoolsLog', 'gatherContext', 'settings', 'simulator', 'trace', 'URL']
+);
+export {LanternLCPLoadDelayComputed as LanternLCPLoadDelay};

--- a/core/computed/metrics/lcp-load-delay.js
+++ b/core/computed/metrics/lcp-load-delay.js
@@ -37,7 +37,7 @@ class LCPLoadDelay extends NavigationMetric {
     const networkRecords = await NetworkRecords.request(data.devtoolsLog, context);
 
     const lcpRecord =
-      PrioritizeLcpImage.getLcpRecord(data.trace, processedNavigation, networkRecords);
+      PrioritizeLcpImage.getLcpRecord(processedNavigation, networkRecords);
 
     if (!lcpRecord) {
       throw new Error('LCP is not an image');

--- a/core/computed/metrics/lcp-load-delay.js
+++ b/core/computed/metrics/lcp-load-delay.js
@@ -1,0 +1,60 @@
+/**
+ * @license Copyright 2023 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {makeComputedArtifact} from '../computed-artifact.js';
+import {NavigationMetric} from './navigation-metric.js';
+import {LighthouseError} from '../../lib/lh-error.js';
+import PrioritizeLcpImage from '../../audits/prioritize-lcp-image.js';
+import {NetworkRecords} from '../network-records.js';
+import {LanternLCPLoadDelay} from './lantern-lcp-load-delay.js';
+
+class LCPLoadDelay extends NavigationMetric {
+  /**
+   * @param {LH.Artifacts.NavigationMetricComputationData} data
+   * @param {LH.Artifacts.ComputedContext} context
+   * @return {Promise<LH.Artifacts.LanternMetric>}
+   */
+  static computeSimulatedMetric(data, context) {
+    const metricData = NavigationMetric.getMetricComputationInput(data);
+    return LanternLCPLoadDelay.request(metricData, context);
+  }
+
+  /**
+   * @param {LH.Artifacts.NavigationMetricComputationData} data
+   * @param {LH.Artifacts.ComputedContext} context
+   * @return {Promise<LH.Artifacts.Metric>}
+   */
+  static async computeObservedMetric(data, context) {
+    const {processedNavigation} = data;
+    if (processedNavigation.timings.largestContentfulPaint === undefined) {
+      throw new LighthouseError(LighthouseError.errors.NO_LCP);
+    }
+
+    const timeOriginTs = processedNavigation.timestamps.timeOrigin;
+    const networkRecords = await NetworkRecords.request(data.devtoolsLog, context);
+
+    const lcpRecord =
+      PrioritizeLcpImage.getLcpRecord(data.trace, processedNavigation, networkRecords);
+
+    if (!lcpRecord) {
+      throw new Error('LCP is not an image');
+    }
+
+    const loadDelayTs = lcpRecord.networkRequestTime * 1000;
+    const loadDelayTiming = (loadDelayTs - timeOriginTs) / 1000;
+
+    return {
+      timing: loadDelayTiming,
+      timestamp: loadDelayTs,
+    };
+  }
+}
+
+const LCPLoadDelayComputed = makeComputedArtifact(
+  LCPLoadDelay,
+  ['devtoolsLog', 'gatherContext', 'settings', 'simulator', 'trace', 'URL']
+);
+export {LCPLoadDelayComputed as LCPLoadDelay};

--- a/core/computed/metrics/timing-summary.js
+++ b/core/computed/metrics/timing-summary.js
@@ -18,6 +18,7 @@ import {SpeedIndex} from './speed-index.js';
 import {MaxPotentialFID} from './max-potential-fid.js';
 import {TotalBlockingTime} from './total-blocking-time.js';
 import {makeComputedArtifact} from '../computed-artifact.js';
+import {LCPLoadDelay} from './lcp-load-delay.js';
 
 class TimingSummary {
   /**
@@ -57,6 +58,7 @@ class TimingSummary {
     const maxPotentialFID = await requestOrUndefined(MaxPotentialFID, metricComputationData);
     const speedIndex = await requestOrUndefined(SpeedIndex, metricComputationData);
     const totalBlockingTime = await requestOrUndefined(TotalBlockingTime, metricComputationData);
+    const lcpLoadDelay = await requestOrUndefined(LCPLoadDelay, metricComputationData);
 
     const {
       cumulativeLayoutShift,
@@ -86,6 +88,8 @@ class TimingSummary {
       cumulativeLayoutShift,
       cumulativeLayoutShiftMainFrame,
       totalCumulativeLayoutShift,
+      lcpLoadDelay: lcpLoadDelay?.timing,
+      lcpLoadDelayTs: lcpLoadDelay?.timestamp,
 
       // Include all timestamps of interest from the processed trace
       observedTimeOrigin: processedTrace.timings.timeOrigin,

--- a/core/lib/tracehouse/trace-processor.js
+++ b/core/lib/tracehouse/trace-processor.js
@@ -864,7 +864,6 @@ class TraceProcessor {
       fmpFellBack: frameTimings.fmpFellBack,
       lcpInvalidated: frameTimings.lcpInvalidated,
       lcpImagePaintEvt,
-      processedTrace,
     };
   }
 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -746,6 +746,7 @@ declare module Artifacts {
     largestContentfulPaintEvt?: TraceEvent;
     /** The trace event marking largestContentfulPaint from all frames, if it was found. */
     largestContentfulPaintAllFramesEvt?: TraceEvent;
+    /** The trace event marking largestContentfulPaint image paint, if LCP was an image and it was found. */
     lcpImagePaintEvt?: TraceEvent;
     /** The trace event marking loadEventEnd, if it was found. */
     loadEvt?: TraceEvent;
@@ -758,7 +759,6 @@ declare module Artifacts {
     fmpFellBack: boolean;
     /** Whether LCP was invalidated without a new candidate. */
     lcpInvalidated: boolean;
-    processedTrace: ProcessedTrace;
   }
 
   /** Information on a tech stack (e.g. a JS library) used by the page. */

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -746,6 +746,7 @@ declare module Artifacts {
     largestContentfulPaintEvt?: TraceEvent;
     /** The trace event marking largestContentfulPaint from all frames, if it was found. */
     largestContentfulPaintAllFramesEvt?: TraceEvent;
+    lcpImagePaintEvt?: TraceEvent;
     /** The trace event marking loadEventEnd, if it was found. */
     loadEvt?: TraceEvent;
     /** The trace event marking domContentLoadedEventEnd, if it was found. */
@@ -757,6 +758,7 @@ declare module Artifacts {
     fmpFellBack: boolean;
     /** Whether LCP was invalidated without a new candidate. */
     lcpInvalidated: boolean;
+    processedTrace: ProcessedTrace;
   }
 
   /** Information on a tech stack (e.g. a JS library) used by the page. */
@@ -784,6 +786,8 @@ declare module Artifacts {
     largestContentfulPaintTs: number | undefined;
     largestContentfulPaintAllFrames: number | undefined;
     largestContentfulPaintAllFramesTs: number | undefined;
+    lcpLoadDelay: number | undefined;
+    lcpLoadDelayTs: number | undefined;
     interactive: number | undefined;
     interactiveTs: number | undefined;
     speedIndex: number | undefined;


### PR DESCRIPTION
This is required before we can land https://github.com/GoogleChrome/lighthouse/pull/14891. Simply grabbing the LCP timing from the simulated LCP graph does not seem to give us an accurate load delay.

Still todo in this PR:
- [ ] Tune lantern coefficients
- [ ] Possibly handle missing lcp image better (when LCP is a text node)

Todo after this PR:
- [ ] Create simulated metric for LCP load time (possibly without complete lantern graph)
- [ ] Finish UI in https://github.com/GoogleChrome/lighthouse/pull/14891