### PR TITLE
core(installability): deprecate scheme support warning

### DIFF
--- a/core/audits/installable-manifest.js
+++ b/core/audits/installable-manifest.js
@@ -97,6 +97,7 @@ const UIStrings = {
   /** Message logged when the web app has been uninstalled o desktop, signalling that the install banner state is being reset. */
   'pipeline-restarted': 'PWA has been uninstalled and installability checks resetting.',
   /**
+   * TODO: This error was removed in M114, we can remove this message when it hits stable.
    * @description Error message explaining that the URL of the manifest uses a scheme that is not supported on Android.
    * @example {data:} scheme
    */

--- a/third-party/chromium-synchronization/installability-errors-test.js
+++ b/third-party/chromium-synchronization/installability-errors-test.js
@@ -65,7 +65,6 @@ Array [
   "platform-not-supported-on-android",
   "prefer-related-applications",
   "prefer-related-applications-only-beta-stable",
-  "scheme-not-supported-for-webapk",
   "start-url-not-valid",
   "url-not-supported-for-webapk",
   "warn-not-offline-capable",


### PR DESCRIPTION
Unit tests start failing because this was removed.

https://chromium-review.googlesource.com/c/chromium/src/+/4402851
