### PR TITLE
misc(logger): add warn level

### DIFF
--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -89,6 +89,9 @@ class Log {
       case 'verbose':
         debug.enable('LH:*');
         break;
+      case 'warn':
+        debug.enable('-LH:*, LH:*:warn, LH:*:error');
+        break;
       case 'error':
         debug.enable('-LH:*, LH:*:error');
         break;

--- a/types/externs.d.ts
+++ b/types/externs.d.ts
@@ -18,7 +18,7 @@ export interface Flags extends SharedFlagsSettings {
   /** The hostname to use for the debugging protocol, if manually connecting. */
   hostname?: string;
   /** The level of logging to enable. */
-  logLevel?: 'silent'|'error'|'info'|'verbose';
+  logLevel?: 'silent'|'error'|'warn'|'info'|'verbose';
   /** The path to the config JSON. */
   configPath?: string;
   /** Run the specified plugins. */


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
There is a missing log level between error and info which is simply `warn` to show just errors and warnings and nothing else. Very small and simple change required to add some better experience.

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->
