### PR TITLE
docs: update pptr options example

### DIFF
--- a/docs/puppeteer.md
+++ b/docs/puppeteer.md
@@ -19,10 +19,13 @@ import lighthouse from 'lighthouse';
 
 const url = 'https://chromestatus.com/features';
 
-// Use Puppeteer to launch headful Chrome and don't use its default 800x600 viewport.
+// Use Puppeteer to launch headful Chrome
+// - Omit `--enable-automation` (See https://github.com/GoogleChrome/lighthouse/issues/12988)
+// - Don't use 800x600 default viewport
 const browser = await puppeteer.launch({
   headless: false,
   defaultViewport: null,
+  ignoreDefaultArgs: ['--enable-automation']
 });
 const page = await browser.newPage();
 


### PR DESCRIPTION
In this PR:

- [x] Updates `docs/puppeteer.md` to remove usage of `--enable-automation` (pptr default)

Before this change, if someone ran the example, it would result in screenshots cropped to the browser window rather than the emulated viewport.

**Related Issues/PRs**
- #12988 
