### PR TITLE
core(entity-classification): classify unknown urls as "unattributable"

### DIFF
--- a/core/computed/entity-classification.js
+++ b/core/computed/entity-classification.js
@@ -85,7 +85,6 @@ class EntityClassification {
      */
     function isFirstParty(url) {
       const entityUrl = entityByUrl.get(url);
-      if (!entityUrl) throw new Error('A url not in devtoolsLog was used for first-party check.');
       return entityUrl === firstParty;
     }
 

--- a/core/test/computed/entity-classification-test.js
+++ b/core/test/computed/entity-classification-test.js
@@ -123,8 +123,8 @@ describe('Entity Classification computed artifact', () => {
     // Make sure only valid network urls with a domain is recognized.
     expect(entities).toEqual(['third-party.com']);
     expect(result.entityByUrl.size).toBe(1);
-    // A url that's not present in devtoolsLogs would throw an exception.
-    expect(() => result.isFirstParty('chrome://version'))
-      .toThrow('A url not in devtoolsLog was used for first-party check.');
+    // First party check fails for non-DT-log URLs.
+    expect(result.isFirstParty('chrome-extension://abcdefghijklmnopqrstuvwxyz/foo/bar.js')).toEqual(false);
+    expect(result.isFirstParty('chrome://new-tab-page')).toEqual(false);
   });
 });


### PR DESCRIPTION
Fixes #14996.

Previously, `chrome://` and `chrome-extension://` protocol URLs, as well as URLs that aren't part of devtoolsLogs would fail the audit. This change classifies all unknown as third party and groups them under "Unattributable".

With the _axe_ chrome extension that @adamraine faced an error in #14996, the report now would look like:
<img width="792" alt="image" src="https://user-images.githubusercontent.com/683500/233752960-03736369-9452-4fda-80c2-798c905a4cba.png">
