### PR TITLE
core: create timing entries for `getArtifact`

### DIFF
--- a/core/test/fixtures/fraggle-rock/artifacts/step0/artifacts.json
+++ b/core/test/fixtures/fraggle-rock/artifacts/step0/artifacts.json
@@ -6,160 +6,406 @@
       "entryType": "measure",
       "startTime": 0,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:config:resolveArtifactsToDefns",
       "entryType": "measure",
       "startTime": 1,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:config:resolveNavigationsToDefns",
       "entryType": "measure",
       "startTime": 2,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:runner:gather",
       "entryType": "measure",
       "startTime": 3,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:driver:connect",
       "entryType": "measure",
       "startTime": 4,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:getBenchmarkIndex",
       "entryType": "measure",
       "startTime": 5,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:getVersion",
       "entryType": "measure",
       "startTime": 6,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:prepare:navigationMode",
       "entryType": "measure",
       "startTime": 7,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:prepare:navigation",
       "entryType": "measure",
       "startTime": 8,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:storage:clearDataForOrigin",
       "entryType": "measure",
       "startTime": 9,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:storage:clearBrowserCaches",
       "entryType": "measure",
       "startTime": 10,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:prepareThrottlingAndNetwork",
       "entryType": "measure",
       "startTime": 11,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:driver:navigate",
       "entryType": "measure",
       "startTime": 12,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:DevtoolsLog",
+      "entryType": "measure",
+      "startTime": 13,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Trace",
+      "entryType": "measure",
+      "startTime": 14,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:computed:NetworkRecords",
       "entryType": "measure",
-      "startTime": 13,
+      "startTime": 15,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:DevtoolsLog",
+      "entryType": "measure",
+      "startTime": 16,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Trace",
+      "entryType": "measure",
+      "startTime": 17,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Accessibility",
+      "entryType": "measure",
+      "startTime": 18,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:AnchorElements",
+      "entryType": "measure",
+      "startTime": 19,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ConsoleMessages",
+      "entryType": "measure",
+      "startTime": 20,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:CSSUsage",
+      "entryType": "measure",
+      "startTime": 21,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Doctype",
+      "entryType": "measure",
+      "startTime": 22,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:DOMStats",
+      "entryType": "measure",
+      "startTime": 23,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:EmbeddedContent",
+      "entryType": "measure",
+      "startTime": 24,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:FontSize",
+      "entryType": "measure",
+      "startTime": 25,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Inputs",
+      "entryType": "measure",
+      "startTime": 26,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:GlobalListeners",
+      "entryType": "measure",
+      "startTime": 27,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ImageElements",
+      "entryType": "measure",
+      "startTime": 28,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:InstallabilityErrors",
+      "entryType": "measure",
+      "startTime": 29,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:gather:getInstallabilityErrors",
       "entryType": "measure",
-      "startTime": 14,
+      "startTime": 30,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:InspectorIssues",
+      "entryType": "measure",
+      "startTime": 31,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:JsUsage",
+      "entryType": "measure",
+      "startTime": 32,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:LinkElements",
+      "entryType": "measure",
+      "startTime": 33,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:computed:MainResource",
       "entryType": "measure",
-      "startTime": 15,
+      "startTime": 34,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:MainDocumentContent",
+      "entryType": "measure",
+      "startTime": 35,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:MetaElements",
+      "entryType": "measure",
+      "startTime": 36,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:NetworkUserAgent",
+      "entryType": "measure",
+      "startTime": 37,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:OptimizedImages",
+      "entryType": "measure",
+      "startTime": 38,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ResponseCompression",
+      "entryType": "measure",
+      "startTime": 39,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:RobotsTxt",
+      "entryType": "measure",
+      "startTime": 40,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ServiceWorker",
+      "entryType": "measure",
+      "startTime": 41,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Scripts",
+      "entryType": "measure",
+      "startTime": 42,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:SourceMaps",
+      "entryType": "measure",
+      "startTime": 43,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Stacks",
+      "entryType": "measure",
+      "startTime": 44,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:gather:collectStacks",
       "entryType": "measure",
-      "startTime": 16,
+      "startTime": 45,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:TagsBlockingFirstPaint",
+      "entryType": "measure",
+      "startTime": 46,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:TapTargets",
+      "entryType": "measure",
+      "startTime": 47,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:TraceElements",
+      "entryType": "measure",
+      "startTime": 48,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:computed:ProcessedTrace",
       "entryType": "measure",
-      "startTime": 17,
+      "startTime": 49,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:computed:ProcessedNavigation",
       "entryType": "measure",
-      "startTime": 18,
+      "startTime": 50,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:computed:Responsiveness",
       "entryType": "measure",
-      "startTime": 19,
+      "startTime": 51,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ViewportDimensions",
+      "entryType": "measure",
+      "startTime": 52,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:WebAppManifest",
+      "entryType": "measure",
+      "startTime": 53,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:devtoolsLogs",
+      "entryType": "measure",
+      "startTime": 54,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:traces",
+      "entryType": "measure",
+      "startTime": 55,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:FullPageScreenshot",
+      "entryType": "measure",
+      "startTime": 56,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:BFCacheFailures",
+      "entryType": "measure",
+      "startTime": 57,
+      "duration": 1,
+      "detail": null
     }
   ],
   "LighthouseRunWarnings": [],

--- a/core/test/fixtures/fraggle-rock/artifacts/step1/artifacts.json
+++ b/core/test/fixtures/fraggle-rock/artifacts/step1/artifacts.json
@@ -6,104 +6,224 @@
       "entryType": "measure",
       "startTime": 0,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:config:resolveArtifactsToDefns",
       "entryType": "measure",
       "startTime": 1,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:config:resolveNavigationsToDefns",
       "entryType": "measure",
       "startTime": 2,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:driver:connect",
       "entryType": "measure",
       "startTime": 3,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:getBenchmarkIndex",
       "entryType": "measure",
       "startTime": 4,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:getVersion",
       "entryType": "measure",
       "startTime": 5,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:prepare:timespanMode",
       "entryType": "measure",
       "startTime": 6,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:prepareThrottlingAndNetwork",
       "entryType": "measure",
       "startTime": 7,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:runner:gather",
       "entryType": "measure",
       "startTime": 8,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:DevtoolsLog",
+      "entryType": "measure",
+      "startTime": 9,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Trace",
+      "entryType": "measure",
+      "startTime": 10,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ConsoleMessages",
+      "entryType": "measure",
+      "startTime": 11,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:CSSUsage",
+      "entryType": "measure",
+      "startTime": 12,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:GlobalListeners",
+      "entryType": "measure",
+      "startTime": 13,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ImageElements",
+      "entryType": "measure",
+      "startTime": 14,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:InspectorIssues",
+      "entryType": "measure",
+      "startTime": 15,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:computed:NetworkRecords",
       "entryType": "measure",
-      "startTime": 9,
+      "startTime": 16,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:JsUsage",
+      "entryType": "measure",
+      "startTime": 17,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:NetworkUserAgent",
+      "entryType": "measure",
+      "startTime": 18,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:OptimizedImages",
+      "entryType": "measure",
+      "startTime": 19,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ResponseCompression",
+      "entryType": "measure",
+      "startTime": 20,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Scripts",
+      "entryType": "measure",
+      "startTime": 21,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:SourceMaps",
+      "entryType": "measure",
+      "startTime": 22,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:TraceElements",
+      "entryType": "measure",
+      "startTime": 23,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:computed:ProcessedTrace",
       "entryType": "measure",
-      "startTime": 10,
+      "startTime": 24,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:computed:ProcessedNavigation",
       "entryType": "measure",
-      "startTime": 11,
+      "startTime": 25,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:computed:Responsiveness",
       "entryType": "measure",
-      "startTime": 12,
+      "startTime": 26,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ViewportDimensions",
+      "entryType": "measure",
+      "startTime": 27,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:devtoolsLogs",
+      "entryType": "measure",
+      "startTime": 28,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:traces",
+      "entryType": "measure",
+      "startTime": 29,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:FullPageScreenshot",
+      "entryType": "measure",
+      "startTime": 30,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:BFCacheFailures",
+      "entryType": "measure",
+      "startTime": 31,
+      "duration": 1,
+      "detail": null
     }
   ],
   "LighthouseRunWarnings": [],

--- a/core/test/fixtures/fraggle-rock/artifacts/step2/artifacts.json
+++ b/core/test/fixtures/fraggle-rock/artifacts/step2/artifacts.json
@@ -6,64 +6,154 @@
       "entryType": "measure",
       "startTime": 0,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:config:resolveArtifactsToDefns",
       "entryType": "measure",
       "startTime": 1,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:config:resolveNavigationsToDefns",
       "entryType": "measure",
       "startTime": 2,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:driver:connect",
       "entryType": "measure",
       "startTime": 3,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:runner:gather",
       "entryType": "measure",
       "startTime": 4,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:getBenchmarkIndex",
       "entryType": "measure",
       "startTime": 5,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:getVersion",
       "entryType": "measure",
       "startTime": 6,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Accessibility",
+      "entryType": "measure",
+      "startTime": 7,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:AnchorElements",
+      "entryType": "measure",
+      "startTime": 8,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Doctype",
+      "entryType": "measure",
+      "startTime": 9,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:DOMStats",
+      "entryType": "measure",
+      "startTime": 10,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:EmbeddedContent",
+      "entryType": "measure",
+      "startTime": 11,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:FontSize",
+      "entryType": "measure",
+      "startTime": 12,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Inputs",
+      "entryType": "measure",
+      "startTime": 13,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ImageElements",
+      "entryType": "measure",
+      "startTime": 14,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:MetaElements",
+      "entryType": "measure",
+      "startTime": 15,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:RobotsTxt",
+      "entryType": "measure",
+      "startTime": 16,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Stacks",
+      "entryType": "measure",
+      "startTime": 17,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:gather:collectStacks",
       "entryType": "measure",
-      "startTime": 7,
+      "startTime": 18,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:TapTargets",
+      "entryType": "measure",
+      "startTime": 19,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ViewportDimensions",
+      "entryType": "measure",
+      "startTime": 20,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:FullPageScreenshot",
+      "entryType": "measure",
+      "startTime": 21,
+      "duration": 1,
+      "detail": null
     }
   ],
   "LighthouseRunWarnings": [],

--- a/core/test/fixtures/fraggle-rock/artifacts/step3/artifacts.json
+++ b/core/test/fixtures/fraggle-rock/artifacts/step3/artifacts.json
@@ -6,144 +6,392 @@
       "entryType": "measure",
       "startTime": 0,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:config:resolveArtifactsToDefns",
       "entryType": "measure",
       "startTime": 1,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:config:resolveNavigationsToDefns",
       "entryType": "measure",
       "startTime": 2,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:runner:gather",
       "entryType": "measure",
       "startTime": 3,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:driver:connect",
       "entryType": "measure",
       "startTime": 4,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:getBenchmarkIndex",
       "entryType": "measure",
       "startTime": 5,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:getVersion",
       "entryType": "measure",
       "startTime": 6,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:prepare:navigationMode",
       "entryType": "measure",
       "startTime": 7,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:prepare:navigation",
       "entryType": "measure",
       "startTime": 8,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:gather:prepareThrottlingAndNetwork",
       "entryType": "measure",
       "startTime": 9,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:driver:navigate",
       "entryType": "measure",
       "startTime": 10,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:DevtoolsLog",
+      "entryType": "measure",
+      "startTime": 11,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Trace",
+      "entryType": "measure",
+      "startTime": 12,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:computed:NetworkRecords",
       "entryType": "measure",
-      "startTime": 11,
+      "startTime": 13,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:DevtoolsLog",
+      "entryType": "measure",
+      "startTime": 14,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Trace",
+      "entryType": "measure",
+      "startTime": 15,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Accessibility",
+      "entryType": "measure",
+      "startTime": 16,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:AnchorElements",
+      "entryType": "measure",
+      "startTime": 17,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ConsoleMessages",
+      "entryType": "measure",
+      "startTime": 18,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:CSSUsage",
+      "entryType": "measure",
+      "startTime": 19,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Doctype",
+      "entryType": "measure",
+      "startTime": 20,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:DOMStats",
+      "entryType": "measure",
+      "startTime": 21,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:EmbeddedContent",
+      "entryType": "measure",
+      "startTime": 22,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:FontSize",
+      "entryType": "measure",
+      "startTime": 23,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Inputs",
+      "entryType": "measure",
+      "startTime": 24,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:GlobalListeners",
+      "entryType": "measure",
+      "startTime": 25,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ImageElements",
+      "entryType": "measure",
+      "startTime": 26,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:InstallabilityErrors",
+      "entryType": "measure",
+      "startTime": 27,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:gather:getInstallabilityErrors",
       "entryType": "measure",
-      "startTime": 12,
+      "startTime": 28,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:InspectorIssues",
+      "entryType": "measure",
+      "startTime": 29,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:JsUsage",
+      "entryType": "measure",
+      "startTime": 30,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:LinkElements",
+      "entryType": "measure",
+      "startTime": 31,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:computed:MainResource",
       "entryType": "measure",
-      "startTime": 13,
+      "startTime": 32,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:MainDocumentContent",
+      "entryType": "measure",
+      "startTime": 33,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:MetaElements",
+      "entryType": "measure",
+      "startTime": 34,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:NetworkUserAgent",
+      "entryType": "measure",
+      "startTime": 35,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:OptimizedImages",
+      "entryType": "measure",
+      "startTime": 36,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ResponseCompression",
+      "entryType": "measure",
+      "startTime": 37,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:RobotsTxt",
+      "entryType": "measure",
+      "startTime": 38,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ServiceWorker",
+      "entryType": "measure",
+      "startTime": 39,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Scripts",
+      "entryType": "measure",
+      "startTime": 40,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:SourceMaps",
+      "entryType": "measure",
+      "startTime": 41,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:Stacks",
+      "entryType": "measure",
+      "startTime": 42,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:gather:collectStacks",
       "entryType": "measure",
-      "startTime": 14,
+      "startTime": 43,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:TagsBlockingFirstPaint",
+      "entryType": "measure",
+      "startTime": 44,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:TapTargets",
+      "entryType": "measure",
+      "startTime": 45,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:TraceElements",
+      "entryType": "measure",
+      "startTime": 46,
+      "duration": 1,
+      "detail": null
     },
     {
       "name": "lh:computed:ProcessedTrace",
       "entryType": "measure",
-      "startTime": 15,
+      "startTime": 47,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:computed:ProcessedNavigation",
       "entryType": "measure",
-      "startTime": 16,
+      "startTime": 48,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
     },
     {
       "name": "lh:computed:Responsiveness",
       "entryType": "measure",
-      "startTime": 17,
+      "startTime": 49,
       "duration": 1,
-      "detail": null,
-      "gather": true
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:ViewportDimensions",
+      "entryType": "measure",
+      "startTime": 50,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:WebAppManifest",
+      "entryType": "measure",
+      "startTime": 51,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:devtoolsLogs",
+      "entryType": "measure",
+      "startTime": 52,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:traces",
+      "entryType": "measure",
+      "startTime": 53,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:FullPageScreenshot",
+      "entryType": "measure",
+      "startTime": 54,
+      "duration": 1,
+      "detail": null
+    },
+    {
+      "name": "lh:gather:getArtifact:BFCacheFailures",
+      "entryType": "measure",
+      "startTime": 55,
+      "duration": 1,
+      "detail": null
     }
   ],
   "LighthouseRunWarnings": [],

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -4802,1314 +4802,1542 @@
             },
             {
               "startTime": 13,
-              "name": "lh:computed:NetworkRecords",
+              "name": "lh:gather:getArtifact:DevtoolsLog",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 14,
-              "name": "lh:gather:getInstallabilityErrors",
+              "name": "lh:gather:getArtifact:Trace",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 15,
-              "name": "lh:computed:MainResource",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 16,
-              "name": "lh:gather:collectStacks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 17,
-              "name": "lh:computed:ProcessedTrace",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 18,
-              "name": "lh:computed:ProcessedNavigation",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 19,
-              "name": "lh:computed:Responsiveness",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 20,
-              "name": "lh:config",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 21,
-              "name": "lh:config:resolveArtifactsToDefns",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 22,
-              "name": "lh:config:resolveNavigationsToDefns",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 23,
-              "name": "lh:runner:audit",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 24,
-              "name": "lh:runner:auditing",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 25,
-              "name": "lh:audit:is-on-https",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 26,
               "name": "lh:computed:NetworkRecords",
               "duration": 1,
               "entryType": "measure"
             },
             {
+              "startTime": 16,
+              "name": "lh:gather:getArtifact:DevtoolsLog",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 17,
+              "name": "lh:gather:getArtifact:Trace",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 18,
+              "name": "lh:gather:getArtifact:Accessibility",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 19,
+              "name": "lh:gather:getArtifact:AnchorElements",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 20,
+              "name": "lh:gather:getArtifact:ConsoleMessages",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 21,
+              "name": "lh:gather:getArtifact:CSSUsage",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 22,
+              "name": "lh:gather:getArtifact:Doctype",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 23,
+              "name": "lh:gather:getArtifact:DOMStats",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 24,
+              "name": "lh:gather:getArtifact:EmbeddedContent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 25,
+              "name": "lh:gather:getArtifact:FontSize",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 26,
+              "name": "lh:gather:getArtifact:Inputs",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
               "startTime": 27,
-              "name": "lh:audit:service-worker",
+              "name": "lh:gather:getArtifact:GlobalListeners",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 28,
-              "name": "lh:audit:viewport",
+              "name": "lh:gather:getArtifact:ImageElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 29,
-              "name": "lh:computed:ViewportMeta",
+              "name": "lh:gather:getArtifact:InstallabilityErrors",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 30,
-              "name": "lh:audit:first-contentful-paint",
+              "name": "lh:gather:getInstallabilityErrors",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 31,
-              "name": "lh:computed:FirstContentfulPaint",
+              "name": "lh:gather:getArtifact:InspectorIssues",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 32,
-              "name": "lh:computed:ProcessedTrace",
+              "name": "lh:gather:getArtifact:JsUsage",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 33,
-              "name": "lh:computed:ProcessedNavigation",
+              "name": "lh:gather:getArtifact:LinkElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 34,
-              "name": "lh:computed:LanternFirstContentfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 35,
-              "name": "lh:computed:PageDependencyGraph",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 36,
-              "name": "lh:computed:LoadSimulator",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 37,
-              "name": "lh:computed:NetworkAnalysis",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 38,
-              "name": "lh:audit:largest-contentful-paint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 39,
-              "name": "lh:computed:LargestContentfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 40,
-              "name": "lh:computed:LanternLargestContentfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 41,
-              "name": "lh:audit:first-meaningful-paint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 42,
-              "name": "lh:computed:FirstMeaningfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 43,
-              "name": "lh:computed:LanternFirstMeaningfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 44,
-              "name": "lh:audit:speed-index",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 45,
-              "name": "lh:computed:SpeedIndex",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 46,
-              "name": "lh:computed:LanternSpeedIndex",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 47,
-              "name": "lh:computed:Speedline",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 48,
-              "name": "lh:audit:screenshot-thumbnails",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 49,
-              "name": "lh:audit:final-screenshot",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 50,
-              "name": "lh:computed:Screenshots",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 51,
-              "name": "lh:audit:total-blocking-time",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 52,
-              "name": "lh:computed:TotalBlockingTime",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 53,
-              "name": "lh:computed:LanternTotalBlockingTime",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 54,
-              "name": "lh:computed:LanternInteractive",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 55,
-              "name": "lh:audit:max-potential-fid",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 56,
-              "name": "lh:computed:MaxPotentialFID",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 57,
-              "name": "lh:computed:LanternMaxPotentialFID",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 58,
-              "name": "lh:audit:cumulative-layout-shift",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 59,
-              "name": "lh:computed:CumulativeLayoutShift",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 60,
-              "name": "lh:audit:errors-in-console",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 61,
-              "name": "lh:computed:JSBundles",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 62,
-              "name": "lh:audit:server-response-time",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 63,
               "name": "lh:computed:MainResource",
               "duration": 1,
               "entryType": "measure"
             },
             {
+              "startTime": 35,
+              "name": "lh:gather:getArtifact:MainDocumentContent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 36,
+              "name": "lh:gather:getArtifact:MetaElements",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 37,
+              "name": "lh:gather:getArtifact:NetworkUserAgent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 38,
+              "name": "lh:gather:getArtifact:OptimizedImages",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 39,
+              "name": "lh:gather:getArtifact:ResponseCompression",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 40,
+              "name": "lh:gather:getArtifact:RobotsTxt",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 41,
+              "name": "lh:gather:getArtifact:ServiceWorker",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 42,
+              "name": "lh:gather:getArtifact:Scripts",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 43,
+              "name": "lh:gather:getArtifact:SourceMaps",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 44,
+              "name": "lh:gather:getArtifact:Stacks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 45,
+              "name": "lh:gather:collectStacks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 46,
+              "name": "lh:gather:getArtifact:TagsBlockingFirstPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 47,
+              "name": "lh:gather:getArtifact:TapTargets",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 48,
+              "name": "lh:gather:getArtifact:TraceElements",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 49,
+              "name": "lh:computed:ProcessedTrace",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 50,
+              "name": "lh:computed:ProcessedNavigation",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 51,
+              "name": "lh:computed:Responsiveness",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 52,
+              "name": "lh:gather:getArtifact:ViewportDimensions",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 53,
+              "name": "lh:gather:getArtifact:WebAppManifest",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 54,
+              "name": "lh:gather:getArtifact:devtoolsLogs",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 55,
+              "name": "lh:gather:getArtifact:traces",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 56,
+              "name": "lh:gather:getArtifact:FullPageScreenshot",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 57,
+              "name": "lh:gather:getArtifact:BFCacheFailures",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 58,
+              "name": "lh:config",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 59,
+              "name": "lh:config:resolveArtifactsToDefns",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 60,
+              "name": "lh:config:resolveNavigationsToDefns",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 61,
+              "name": "lh:runner:audit",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 62,
+              "name": "lh:runner:auditing",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 63,
+              "name": "lh:audit:is-on-https",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
               "startTime": 64,
-              "name": "lh:audit:interactive",
+              "name": "lh:computed:NetworkRecords",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 65,
-              "name": "lh:computed:Interactive",
+              "name": "lh:audit:service-worker",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 66,
-              "name": "lh:audit:user-timings",
+              "name": "lh:audit:viewport",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 67,
-              "name": "lh:computed:UserTimings",
+              "name": "lh:computed:ViewportMeta",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 68,
-              "name": "lh:audit:critical-request-chains",
+              "name": "lh:audit:first-contentful-paint",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 69,
-              "name": "lh:computed:CriticalRequestChains",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 70,
-              "name": "lh:audit:redirects",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 71,
-              "name": "lh:audit:installable-manifest",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 72,
-              "name": "lh:audit:splash-screen",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 73,
-              "name": "lh:computed:ManifestValues",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 74,
-              "name": "lh:audit:themed-omnibox",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 75,
-              "name": "lh:audit:maskable-icon",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 76,
-              "name": "lh:audit:content-width",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 77,
-              "name": "lh:audit:image-aspect-ratio",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 78,
-              "name": "lh:audit:image-size-responsive",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 79,
-              "name": "lh:audit:preload-fonts",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 80,
-              "name": "lh:audit:deprecations",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 81,
-              "name": "lh:audit:mainthread-work-breakdown",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 82,
-              "name": "lh:computed:MainThreadTasks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 83,
-              "name": "lh:audit:bootup-time",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 84,
-              "name": "lh:audit:uses-rel-preload",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 85,
-              "name": "lh:audit:uses-rel-preconnect",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 86,
-              "name": "lh:audit:font-display",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 87,
-              "name": "lh:audit:diagnostics",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 88,
-              "name": "lh:audit:network-requests",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 89,
-              "name": "lh:audit:network-rtt",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 90,
-              "name": "lh:audit:network-server-latency",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 91,
-              "name": "lh:audit:main-thread-tasks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 92,
-              "name": "lh:audit:metrics",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 93,
-              "name": "lh:computed:TimingSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 94,
-              "name": "lh:computed:FirstContentfulPaintAllFrames",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 95,
-              "name": "lh:computed:LargestContentfulPaintAllFrames",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 96,
-              "name": "lh:computed:LCPBreakdown",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 97,
-              "name": "lh:computed:TimeToFirstByte",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 98,
-              "name": "lh:computed:LCPImageRecord",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 99,
-              "name": "lh:audit:performance-budget",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 100,
-              "name": "lh:computed:ResourceSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 101,
-              "name": "lh:computed:EntityClassification",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 102,
-              "name": "lh:audit:timing-budget",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 103,
-              "name": "lh:audit:resource-summary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 104,
-              "name": "lh:audit:third-party-summary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 105,
-              "name": "lh:audit:third-party-facades",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 106,
-              "name": "lh:audit:largest-contentful-paint-element",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 107,
-              "name": "lh:audit:lcp-lazy-loaded",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 108,
-              "name": "lh:audit:layout-shift-elements",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 109,
-              "name": "lh:audit:long-tasks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 110,
-              "name": "lh:audit:no-unload-listeners",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 111,
-              "name": "lh:audit:non-composited-animations",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 112,
-              "name": "lh:audit:unsized-images",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 113,
-              "name": "lh:audit:valid-source-maps",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 114,
-              "name": "lh:audit:prioritize-lcp-image",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 115,
-              "name": "lh:audit:csp-xss",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 116,
-              "name": "lh:audit:script-treemap-data",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 117,
-              "name": "lh:computed:ModuleDuplication",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 118,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 119,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 120,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 121,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 122,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 123,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 124,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 125,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 126,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 127,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 128,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 129,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 130,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 131,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 132,
-              "name": "lh:audit:pwa-cross-browser",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 133,
-              "name": "lh:audit:pwa-page-transitions",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 134,
-              "name": "lh:audit:pwa-each-page-has-url",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 135,
-              "name": "lh:audit:accesskeys",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 136,
-              "name": "lh:audit:aria-allowed-attr",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 137,
-              "name": "lh:audit:aria-command-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 138,
-              "name": "lh:audit:aria-hidden-body",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 139,
-              "name": "lh:audit:aria-hidden-focus",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 140,
-              "name": "lh:audit:aria-input-field-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 141,
-              "name": "lh:audit:aria-meter-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 142,
-              "name": "lh:audit:aria-progressbar-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 143,
-              "name": "lh:audit:aria-required-attr",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 144,
-              "name": "lh:audit:aria-required-children",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 145,
-              "name": "lh:audit:aria-required-parent",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 146,
-              "name": "lh:audit:aria-roles",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 147,
-              "name": "lh:audit:aria-toggle-field-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 148,
-              "name": "lh:audit:aria-tooltip-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 149,
-              "name": "lh:audit:aria-treeitem-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 150,
-              "name": "lh:audit:aria-valid-attr-value",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 151,
-              "name": "lh:audit:aria-valid-attr",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 152,
-              "name": "lh:audit:button-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 153,
-              "name": "lh:audit:bypass",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 154,
-              "name": "lh:audit:color-contrast",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 155,
-              "name": "lh:audit:definition-list",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 156,
-              "name": "lh:audit:dlitem",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 157,
-              "name": "lh:audit:document-title",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 158,
-              "name": "lh:audit:duplicate-id-active",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 159,
-              "name": "lh:audit:duplicate-id-aria",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 160,
-              "name": "lh:audit:form-field-multiple-labels",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 161,
-              "name": "lh:audit:frame-title",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 162,
-              "name": "lh:audit:heading-order",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 163,
-              "name": "lh:audit:html-has-lang",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 164,
-              "name": "lh:audit:html-lang-valid",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 165,
-              "name": "lh:audit:image-alt",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 166,
-              "name": "lh:audit:input-image-alt",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 167,
-              "name": "lh:audit:label",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 168,
-              "name": "lh:audit:link-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 169,
-              "name": "lh:audit:list",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 170,
-              "name": "lh:audit:listitem",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 171,
-              "name": "lh:audit:meta-refresh",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 172,
-              "name": "lh:audit:meta-viewport",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 173,
-              "name": "lh:audit:object-alt",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 174,
-              "name": "lh:audit:tabindex",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 175,
-              "name": "lh:audit:td-headers-attr",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 176,
-              "name": "lh:audit:th-has-data-cells",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 177,
-              "name": "lh:audit:valid-lang",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 178,
-              "name": "lh:audit:video-caption",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 179,
-              "name": "lh:audit:custom-controls-labels",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 180,
-              "name": "lh:audit:custom-controls-roles",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 181,
-              "name": "lh:audit:focus-traps",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 182,
-              "name": "lh:audit:focusable-controls",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 183,
-              "name": "lh:audit:interactive-element-affordance",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 184,
-              "name": "lh:audit:logical-tab-order",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 185,
-              "name": "lh:audit:managed-focus",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 186,
-              "name": "lh:audit:offscreen-content-hidden",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 187,
-              "name": "lh:audit:use-landmarks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 188,
-              "name": "lh:audit:visual-order-follows-dom",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 189,
-              "name": "lh:audit:uses-long-cache-ttl",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 190,
-              "name": "lh:audit:total-byte-weight",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 191,
-              "name": "lh:audit:offscreen-images",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 192,
-              "name": "lh:audit:render-blocking-resources",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 193,
-              "name": "lh:computed:UnusedCSS",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 194,
               "name": "lh:computed:FirstContentfulPaint",
               "duration": 1,
               "entryType": "measure"
             },
             {
+              "startTime": 70,
+              "name": "lh:computed:ProcessedTrace",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 71,
+              "name": "lh:computed:ProcessedNavigation",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 72,
+              "name": "lh:computed:LanternFirstContentfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 73,
+              "name": "lh:computed:PageDependencyGraph",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 74,
+              "name": "lh:computed:LoadSimulator",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 75,
+              "name": "lh:computed:NetworkAnalysis",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 76,
+              "name": "lh:audit:largest-contentful-paint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 77,
+              "name": "lh:computed:LargestContentfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 78,
+              "name": "lh:computed:LanternLargestContentfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 79,
+              "name": "lh:audit:first-meaningful-paint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 80,
+              "name": "lh:computed:FirstMeaningfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 81,
+              "name": "lh:computed:LanternFirstMeaningfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 82,
+              "name": "lh:audit:speed-index",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 83,
+              "name": "lh:computed:SpeedIndex",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 84,
+              "name": "lh:computed:LanternSpeedIndex",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 85,
+              "name": "lh:computed:Speedline",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 86,
+              "name": "lh:audit:screenshot-thumbnails",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 87,
+              "name": "lh:audit:final-screenshot",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 88,
+              "name": "lh:computed:Screenshots",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 89,
+              "name": "lh:audit:total-blocking-time",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 90,
+              "name": "lh:computed:TotalBlockingTime",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 91,
+              "name": "lh:computed:LanternTotalBlockingTime",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 92,
+              "name": "lh:computed:LanternInteractive",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 93,
+              "name": "lh:audit:max-potential-fid",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 94,
+              "name": "lh:computed:MaxPotentialFID",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 95,
+              "name": "lh:computed:LanternMaxPotentialFID",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 96,
+              "name": "lh:audit:cumulative-layout-shift",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 97,
+              "name": "lh:computed:CumulativeLayoutShift",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 98,
+              "name": "lh:audit:errors-in-console",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 99,
+              "name": "lh:computed:JSBundles",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 100,
+              "name": "lh:audit:server-response-time",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 101,
+              "name": "lh:computed:MainResource",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 102,
+              "name": "lh:audit:interactive",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 103,
+              "name": "lh:computed:Interactive",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 104,
+              "name": "lh:audit:user-timings",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 105,
+              "name": "lh:computed:UserTimings",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 106,
+              "name": "lh:audit:critical-request-chains",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 107,
+              "name": "lh:computed:CriticalRequestChains",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 108,
+              "name": "lh:audit:redirects",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 109,
+              "name": "lh:audit:installable-manifest",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 110,
+              "name": "lh:audit:splash-screen",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 111,
+              "name": "lh:computed:ManifestValues",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 112,
+              "name": "lh:audit:themed-omnibox",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 113,
+              "name": "lh:audit:maskable-icon",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 114,
+              "name": "lh:audit:content-width",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 115,
+              "name": "lh:audit:image-aspect-ratio",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 116,
+              "name": "lh:audit:image-size-responsive",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 117,
+              "name": "lh:audit:preload-fonts",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 118,
+              "name": "lh:audit:deprecations",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 119,
+              "name": "lh:audit:mainthread-work-breakdown",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 120,
+              "name": "lh:computed:MainThreadTasks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 121,
+              "name": "lh:audit:bootup-time",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 122,
+              "name": "lh:audit:uses-rel-preload",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 123,
+              "name": "lh:audit:uses-rel-preconnect",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 124,
+              "name": "lh:audit:font-display",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 125,
+              "name": "lh:audit:diagnostics",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 126,
+              "name": "lh:audit:network-requests",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 127,
+              "name": "lh:audit:network-rtt",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 128,
+              "name": "lh:audit:network-server-latency",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 129,
+              "name": "lh:audit:main-thread-tasks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 130,
+              "name": "lh:audit:metrics",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 131,
+              "name": "lh:computed:TimingSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 132,
+              "name": "lh:computed:FirstContentfulPaintAllFrames",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 133,
+              "name": "lh:computed:LargestContentfulPaintAllFrames",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 134,
+              "name": "lh:computed:LCPBreakdown",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 135,
+              "name": "lh:computed:TimeToFirstByte",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 136,
+              "name": "lh:computed:LCPImageRecord",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 137,
+              "name": "lh:audit:performance-budget",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 138,
+              "name": "lh:computed:ResourceSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 139,
+              "name": "lh:computed:EntityClassification",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 140,
+              "name": "lh:audit:timing-budget",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 141,
+              "name": "lh:audit:resource-summary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 142,
+              "name": "lh:audit:third-party-summary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 143,
+              "name": "lh:audit:third-party-facades",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 144,
+              "name": "lh:audit:largest-contentful-paint-element",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 145,
+              "name": "lh:audit:lcp-lazy-loaded",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 146,
+              "name": "lh:audit:layout-shift-elements",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 147,
+              "name": "lh:audit:long-tasks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 148,
+              "name": "lh:audit:no-unload-listeners",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 149,
+              "name": "lh:audit:non-composited-animations",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 150,
+              "name": "lh:audit:unsized-images",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 151,
+              "name": "lh:audit:valid-source-maps",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 152,
+              "name": "lh:audit:prioritize-lcp-image",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 153,
+              "name": "lh:audit:csp-xss",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 154,
+              "name": "lh:audit:script-treemap-data",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 155,
+              "name": "lh:computed:ModuleDuplication",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 156,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 157,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 158,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 159,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 160,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 161,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 162,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 163,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 164,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 165,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 166,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 167,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 168,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 169,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 170,
+              "name": "lh:audit:pwa-cross-browser",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 171,
+              "name": "lh:audit:pwa-page-transitions",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 172,
+              "name": "lh:audit:pwa-each-page-has-url",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 173,
+              "name": "lh:audit:accesskeys",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 174,
+              "name": "lh:audit:aria-allowed-attr",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 175,
+              "name": "lh:audit:aria-command-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 176,
+              "name": "lh:audit:aria-hidden-body",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 177,
+              "name": "lh:audit:aria-hidden-focus",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 178,
+              "name": "lh:audit:aria-input-field-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 179,
+              "name": "lh:audit:aria-meter-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 180,
+              "name": "lh:audit:aria-progressbar-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 181,
+              "name": "lh:audit:aria-required-attr",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 182,
+              "name": "lh:audit:aria-required-children",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 183,
+              "name": "lh:audit:aria-required-parent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 184,
+              "name": "lh:audit:aria-roles",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 185,
+              "name": "lh:audit:aria-toggle-field-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 186,
+              "name": "lh:audit:aria-tooltip-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 187,
+              "name": "lh:audit:aria-treeitem-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 188,
+              "name": "lh:audit:aria-valid-attr-value",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 189,
+              "name": "lh:audit:aria-valid-attr",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 190,
+              "name": "lh:audit:button-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 191,
+              "name": "lh:audit:bypass",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 192,
+              "name": "lh:audit:color-contrast",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 193,
+              "name": "lh:audit:definition-list",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 194,
+              "name": "lh:audit:dlitem",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
               "startTime": 195,
-              "name": "lh:audit:unminified-css",
+              "name": "lh:audit:document-title",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 196,
-              "name": "lh:audit:unminified-javascript",
+              "name": "lh:audit:duplicate-id-active",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 197,
-              "name": "lh:audit:unused-css-rules",
+              "name": "lh:audit:duplicate-id-aria",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 198,
-              "name": "lh:audit:unused-javascript",
+              "name": "lh:audit:form-field-multiple-labels",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 199,
-              "name": "lh:audit:modern-image-formats",
+              "name": "lh:audit:frame-title",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 200,
-              "name": "lh:audit:uses-optimized-images",
+              "name": "lh:audit:heading-order",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 201,
-              "name": "lh:audit:uses-text-compression",
+              "name": "lh:audit:html-has-lang",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 202,
-              "name": "lh:audit:uses-responsive-images",
+              "name": "lh:audit:html-lang-valid",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 203,
-              "name": "lh:computed:ImageRecords",
+              "name": "lh:audit:image-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 204,
-              "name": "lh:audit:efficient-animated-content",
+              "name": "lh:audit:input-image-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 205,
-              "name": "lh:audit:duplicated-javascript",
+              "name": "lh:audit:label",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 206,
-              "name": "lh:audit:legacy-javascript",
+              "name": "lh:audit:link-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 207,
-              "name": "lh:audit:doctype",
+              "name": "lh:audit:list",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 208,
-              "name": "lh:audit:charset",
+              "name": "lh:audit:listitem",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 209,
-              "name": "lh:audit:dom-size",
+              "name": "lh:audit:meta-refresh",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 210,
-              "name": "lh:audit:geolocation-on-start",
+              "name": "lh:audit:meta-viewport",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 211,
-              "name": "lh:audit:inspector-issues",
+              "name": "lh:audit:object-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 212,
-              "name": "lh:audit:no-document-write",
+              "name": "lh:audit:tabindex",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 213,
-              "name": "lh:audit:js-libraries",
+              "name": "lh:audit:td-headers-attr",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 214,
-              "name": "lh:audit:notification-on-start",
+              "name": "lh:audit:th-has-data-cells",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 215,
-              "name": "lh:audit:paste-preventing-inputs",
+              "name": "lh:audit:valid-lang",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 216,
-              "name": "lh:audit:uses-passive-event-listeners",
+              "name": "lh:audit:video-caption",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 217,
-              "name": "lh:audit:meta-description",
+              "name": "lh:audit:custom-controls-labels",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 218,
-              "name": "lh:audit:http-status-code",
+              "name": "lh:audit:custom-controls-roles",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 219,
-              "name": "lh:audit:font-size",
+              "name": "lh:audit:focus-traps",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 220,
-              "name": "lh:audit:link-text",
+              "name": "lh:audit:focusable-controls",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 221,
-              "name": "lh:audit:crawlable-anchors",
+              "name": "lh:audit:interactive-element-affordance",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 222,
-              "name": "lh:audit:is-crawlable",
+              "name": "lh:audit:logical-tab-order",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 223,
-              "name": "lh:audit:robots-txt",
+              "name": "lh:audit:managed-focus",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 224,
-              "name": "lh:audit:tap-targets",
+              "name": "lh:audit:offscreen-content-hidden",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 225,
-              "name": "lh:audit:hreflang",
+              "name": "lh:audit:use-landmarks",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 226,
-              "name": "lh:audit:plugins",
+              "name": "lh:audit:visual-order-follows-dom",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 227,
-              "name": "lh:audit:canonical",
+              "name": "lh:audit:uses-long-cache-ttl",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 228,
-              "name": "lh:audit:structured-data",
+              "name": "lh:audit:total-byte-weight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 229,
-              "name": "lh:audit:bf-cache",
+              "name": "lh:audit:offscreen-images",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 230,
+              "name": "lh:audit:render-blocking-resources",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 231,
+              "name": "lh:computed:UnusedCSS",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 232,
+              "name": "lh:computed:FirstContentfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 233,
+              "name": "lh:audit:unminified-css",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 234,
+              "name": "lh:audit:unminified-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 235,
+              "name": "lh:audit:unused-css-rules",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 236,
+              "name": "lh:audit:unused-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 237,
+              "name": "lh:audit:modern-image-formats",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 238,
+              "name": "lh:audit:uses-optimized-images",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 239,
+              "name": "lh:audit:uses-text-compression",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 240,
+              "name": "lh:audit:uses-responsive-images",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 241,
+              "name": "lh:computed:ImageRecords",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 242,
+              "name": "lh:audit:efficient-animated-content",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 243,
+              "name": "lh:audit:duplicated-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 244,
+              "name": "lh:audit:legacy-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 245,
+              "name": "lh:audit:doctype",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 246,
+              "name": "lh:audit:charset",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 247,
+              "name": "lh:audit:dom-size",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 248,
+              "name": "lh:audit:geolocation-on-start",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 249,
+              "name": "lh:audit:inspector-issues",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 250,
+              "name": "lh:audit:no-document-write",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 251,
+              "name": "lh:audit:js-libraries",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 252,
+              "name": "lh:audit:notification-on-start",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 253,
+              "name": "lh:audit:paste-preventing-inputs",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 254,
+              "name": "lh:audit:uses-passive-event-listeners",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 255,
+              "name": "lh:audit:meta-description",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 256,
+              "name": "lh:audit:http-status-code",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 257,
+              "name": "lh:audit:font-size",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 258,
+              "name": "lh:audit:link-text",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 259,
+              "name": "lh:audit:crawlable-anchors",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 260,
+              "name": "lh:audit:is-crawlable",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 261,
+              "name": "lh:audit:robots-txt",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 262,
+              "name": "lh:audit:tap-targets",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 263,
+              "name": "lh:audit:hreflang",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 264,
+              "name": "lh:audit:plugins",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 265,
+              "name": "lh:audit:canonical",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 266,
+              "name": "lh:audit:structured-data",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 267,
+              "name": "lh:audit:bf-cache",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 268,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 231
+          "total": 269
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -10177,456 +10405,570 @@
             },
             {
               "startTime": 9,
-              "name": "lh:computed:NetworkRecords",
+              "name": "lh:gather:getArtifact:DevtoolsLog",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 10,
-              "name": "lh:computed:ProcessedTrace",
+              "name": "lh:gather:getArtifact:Trace",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 11,
-              "name": "lh:computed:ProcessedNavigation",
+              "name": "lh:gather:getArtifact:ConsoleMessages",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 12,
-              "name": "lh:computed:Responsiveness",
+              "name": "lh:gather:getArtifact:CSSUsage",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 13,
-              "name": "lh:config",
+              "name": "lh:gather:getArtifact:GlobalListeners",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 14,
-              "name": "lh:config:resolveArtifactsToDefns",
+              "name": "lh:gather:getArtifact:ImageElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 15,
-              "name": "lh:config:resolveNavigationsToDefns",
+              "name": "lh:gather:getArtifact:InspectorIssues",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 16,
-              "name": "lh:runner:audit",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 17,
-              "name": "lh:runner:auditing",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 18,
-              "name": "lh:audit:is-on-https",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 19,
               "name": "lh:computed:NetworkRecords",
               "duration": 1,
               "entryType": "measure"
             },
             {
+              "startTime": 17,
+              "name": "lh:gather:getArtifact:JsUsage",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 18,
+              "name": "lh:gather:getArtifact:NetworkUserAgent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 19,
+              "name": "lh:gather:getArtifact:OptimizedImages",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
               "startTime": 20,
-              "name": "lh:audit:screenshot-thumbnails",
+              "name": "lh:gather:getArtifact:ResponseCompression",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 21,
-              "name": "lh:computed:Speedline",
+              "name": "lh:gather:getArtifact:Scripts",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 22,
-              "name": "lh:computed:ProcessedTrace",
+              "name": "lh:gather:getArtifact:SourceMaps",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 23,
-              "name": "lh:audit:final-screenshot",
+              "name": "lh:gather:getArtifact:TraceElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 24,
-              "name": "lh:computed:Screenshots",
+              "name": "lh:computed:ProcessedTrace",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 25,
-              "name": "lh:audit:total-blocking-time",
+              "name": "lh:computed:ProcessedNavigation",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 26,
-              "name": "lh:computed:TotalBlockingTime",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 27,
-              "name": "lh:audit:cumulative-layout-shift",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 28,
-              "name": "lh:computed:CumulativeLayoutShift",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 29,
-              "name": "lh:audit:experimental-interaction-to-next-paint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 30,
               "name": "lh:computed:Responsiveness",
               "duration": 1,
               "entryType": "measure"
             },
             {
+              "startTime": 27,
+              "name": "lh:gather:getArtifact:ViewportDimensions",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 28,
+              "name": "lh:gather:getArtifact:devtoolsLogs",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 29,
+              "name": "lh:gather:getArtifact:traces",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 30,
+              "name": "lh:gather:getArtifact:FullPageScreenshot",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
               "startTime": 31,
-              "name": "lh:audit:errors-in-console",
+              "name": "lh:gather:getArtifact:BFCacheFailures",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 32,
-              "name": "lh:computed:JSBundles",
+              "name": "lh:config",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 33,
-              "name": "lh:audit:user-timings",
+              "name": "lh:config:resolveArtifactsToDefns",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 34,
-              "name": "lh:computed:UserTimings",
+              "name": "lh:config:resolveNavigationsToDefns",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 35,
-              "name": "lh:audit:image-aspect-ratio",
+              "name": "lh:runner:audit",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 36,
-              "name": "lh:audit:image-size-responsive",
+              "name": "lh:runner:auditing",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 37,
-              "name": "lh:audit:preload-fonts",
+              "name": "lh:audit:is-on-https",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 38,
-              "name": "lh:audit:deprecations",
+              "name": "lh:computed:NetworkRecords",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 39,
-              "name": "lh:audit:mainthread-work-breakdown",
+              "name": "lh:audit:screenshot-thumbnails",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 40,
-              "name": "lh:computed:MainThreadTasks",
+              "name": "lh:computed:Speedline",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 41,
-              "name": "lh:audit:bootup-time",
+              "name": "lh:computed:ProcessedTrace",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 42,
-              "name": "lh:audit:network-requests",
+              "name": "lh:audit:final-screenshot",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 43,
-              "name": "lh:audit:network-rtt",
+              "name": "lh:computed:Screenshots",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 44,
-              "name": "lh:computed:NetworkAnalysis",
+              "name": "lh:audit:total-blocking-time",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 45,
-              "name": "lh:audit:network-server-latency",
+              "name": "lh:computed:TotalBlockingTime",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 46,
-              "name": "lh:audit:main-thread-tasks",
+              "name": "lh:audit:cumulative-layout-shift",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 47,
-              "name": "lh:audit:resource-summary",
+              "name": "lh:computed:CumulativeLayoutShift",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 48,
-              "name": "lh:computed:ResourceSummary",
+              "name": "lh:audit:experimental-interaction-to-next-paint",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 49,
-              "name": "lh:computed:EntityClassification",
+              "name": "lh:computed:Responsiveness",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 50,
-              "name": "lh:audit:third-party-summary",
+              "name": "lh:audit:errors-in-console",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 51,
-              "name": "lh:audit:layout-shift-elements",
+              "name": "lh:computed:JSBundles",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 52,
-              "name": "lh:audit:long-tasks",
+              "name": "lh:audit:user-timings",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 53,
-              "name": "lh:audit:no-unload-listeners",
+              "name": "lh:computed:UserTimings",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 54,
-              "name": "lh:audit:non-composited-animations",
+              "name": "lh:audit:image-aspect-ratio",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 55,
-              "name": "lh:audit:unsized-images",
+              "name": "lh:audit:image-size-responsive",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 56,
-              "name": "lh:audit:valid-source-maps",
+              "name": "lh:audit:preload-fonts",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 57,
-              "name": "lh:audit:script-treemap-data",
+              "name": "lh:audit:deprecations",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 58,
-              "name": "lh:computed:ModuleDuplication",
+              "name": "lh:audit:mainthread-work-breakdown",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 59,
-              "name": "lh:computed:UnusedJavascriptSummary",
+              "name": "lh:computed:MainThreadTasks",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 60,
-              "name": "lh:computed:UnusedJavascriptSummary",
+              "name": "lh:audit:bootup-time",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 61,
-              "name": "lh:computed:UnusedJavascriptSummary",
+              "name": "lh:audit:network-requests",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 62,
-              "name": "lh:audit:uses-long-cache-ttl",
+              "name": "lh:audit:network-rtt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 63,
-              "name": "lh:audit:total-byte-weight",
+              "name": "lh:computed:NetworkAnalysis",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 64,
-              "name": "lh:audit:unminified-css",
+              "name": "lh:audit:network-server-latency",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 65,
-              "name": "lh:computed:LoadSimulator",
+              "name": "lh:audit:main-thread-tasks",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 66,
-              "name": "lh:audit:unminified-javascript",
+              "name": "lh:audit:resource-summary",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 67,
-              "name": "lh:audit:unused-css-rules",
+              "name": "lh:computed:ResourceSummary",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 68,
-              "name": "lh:computed:UnusedCSS",
+              "name": "lh:computed:EntityClassification",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 69,
-              "name": "lh:audit:unused-javascript",
+              "name": "lh:audit:third-party-summary",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 70,
-              "name": "lh:audit:modern-image-formats",
+              "name": "lh:audit:layout-shift-elements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 71,
-              "name": "lh:audit:uses-optimized-images",
+              "name": "lh:audit:long-tasks",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 72,
-              "name": "lh:audit:uses-text-compression",
+              "name": "lh:audit:no-unload-listeners",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 73,
-              "name": "lh:audit:uses-responsive-images",
+              "name": "lh:audit:non-composited-animations",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 74,
-              "name": "lh:computed:ImageRecords",
+              "name": "lh:audit:unsized-images",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 75,
-              "name": "lh:audit:efficient-animated-content",
+              "name": "lh:audit:valid-source-maps",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 76,
-              "name": "lh:audit:duplicated-javascript",
+              "name": "lh:audit:script-treemap-data",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 77,
-              "name": "lh:audit:legacy-javascript",
+              "name": "lh:computed:ModuleDuplication",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 78,
-              "name": "lh:audit:inspector-issues",
+              "name": "lh:computed:UnusedJavascriptSummary",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 79,
-              "name": "lh:audit:no-document-write",
+              "name": "lh:computed:UnusedJavascriptSummary",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 80,
-              "name": "lh:audit:uses-passive-event-listeners",
+              "name": "lh:computed:UnusedJavascriptSummary",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 81,
-              "name": "lh:audit:work-during-interaction",
+              "name": "lh:audit:uses-long-cache-ttl",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 82,
-              "name": "lh:audit:bf-cache",
+              "name": "lh:audit:total-byte-weight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 83,
+              "name": "lh:audit:unminified-css",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 84,
+              "name": "lh:computed:LoadSimulator",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 85,
+              "name": "lh:audit:unminified-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 86,
+              "name": "lh:audit:unused-css-rules",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 87,
+              "name": "lh:computed:UnusedCSS",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 88,
+              "name": "lh:audit:unused-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 89,
+              "name": "lh:audit:modern-image-formats",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 90,
+              "name": "lh:audit:uses-optimized-images",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 91,
+              "name": "lh:audit:uses-text-compression",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 92,
+              "name": "lh:audit:uses-responsive-images",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 93,
+              "name": "lh:computed:ImageRecords",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 94,
+              "name": "lh:audit:efficient-animated-content",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 95,
+              "name": "lh:audit:duplicated-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 96,
+              "name": "lh:audit:legacy-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 97,
+              "name": "lh:audit:inspector-issues",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 98,
+              "name": "lh:audit:no-document-write",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 99,
+              "name": "lh:audit:uses-passive-event-listeners",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 100,
+              "name": "lh:audit:work-during-interaction",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 101,
+              "name": "lh:audit:bf-cache",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 102,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 84
+          "total": 103
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -14729,480 +15071,564 @@
             },
             {
               "startTime": 7,
-              "name": "lh:gather:collectStacks",
+              "name": "lh:gather:getArtifact:Accessibility",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 8,
-              "name": "lh:config",
+              "name": "lh:gather:getArtifact:AnchorElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 9,
-              "name": "lh:config:resolveArtifactsToDefns",
+              "name": "lh:gather:getArtifact:Doctype",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 10,
-              "name": "lh:config:resolveNavigationsToDefns",
+              "name": "lh:gather:getArtifact:DOMStats",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 11,
-              "name": "lh:runner:audit",
+              "name": "lh:gather:getArtifact:EmbeddedContent",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 12,
-              "name": "lh:runner:auditing",
+              "name": "lh:gather:getArtifact:FontSize",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 13,
-              "name": "lh:audit:viewport",
+              "name": "lh:gather:getArtifact:Inputs",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 14,
-              "name": "lh:computed:ViewportMeta",
+              "name": "lh:gather:getArtifact:ImageElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 15,
-              "name": "lh:audit:image-aspect-ratio",
+              "name": "lh:gather:getArtifact:MetaElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 16,
-              "name": "lh:audit:image-size-responsive",
+              "name": "lh:gather:getArtifact:RobotsTxt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 17,
-              "name": "lh:audit:unsized-images",
+              "name": "lh:gather:getArtifact:Stacks",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 18,
-              "name": "lh:audit:accesskeys",
+              "name": "lh:gather:collectStacks",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 19,
-              "name": "lh:audit:aria-allowed-attr",
+              "name": "lh:gather:getArtifact:TapTargets",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 20,
-              "name": "lh:audit:aria-command-name",
+              "name": "lh:gather:getArtifact:ViewportDimensions",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 21,
-              "name": "lh:audit:aria-hidden-body",
+              "name": "lh:gather:getArtifact:FullPageScreenshot",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 22,
-              "name": "lh:audit:aria-hidden-focus",
+              "name": "lh:config",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 23,
-              "name": "lh:audit:aria-input-field-name",
+              "name": "lh:config:resolveArtifactsToDefns",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 24,
-              "name": "lh:audit:aria-meter-name",
+              "name": "lh:config:resolveNavigationsToDefns",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 25,
-              "name": "lh:audit:aria-progressbar-name",
+              "name": "lh:runner:audit",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 26,
-              "name": "lh:audit:aria-required-attr",
+              "name": "lh:runner:auditing",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 27,
-              "name": "lh:audit:aria-required-children",
+              "name": "lh:audit:viewport",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 28,
-              "name": "lh:audit:aria-required-parent",
+              "name": "lh:computed:ViewportMeta",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 29,
-              "name": "lh:audit:aria-roles",
+              "name": "lh:audit:image-aspect-ratio",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 30,
-              "name": "lh:audit:aria-toggle-field-name",
+              "name": "lh:audit:image-size-responsive",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 31,
-              "name": "lh:audit:aria-tooltip-name",
+              "name": "lh:audit:unsized-images",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 32,
-              "name": "lh:audit:aria-treeitem-name",
+              "name": "lh:audit:accesskeys",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 33,
-              "name": "lh:audit:aria-valid-attr-value",
+              "name": "lh:audit:aria-allowed-attr",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 34,
-              "name": "lh:audit:aria-valid-attr",
+              "name": "lh:audit:aria-command-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 35,
-              "name": "lh:audit:button-name",
+              "name": "lh:audit:aria-hidden-body",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 36,
-              "name": "lh:audit:bypass",
+              "name": "lh:audit:aria-hidden-focus",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 37,
-              "name": "lh:audit:color-contrast",
+              "name": "lh:audit:aria-input-field-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 38,
-              "name": "lh:audit:definition-list",
+              "name": "lh:audit:aria-meter-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 39,
-              "name": "lh:audit:dlitem",
+              "name": "lh:audit:aria-progressbar-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 40,
-              "name": "lh:audit:document-title",
+              "name": "lh:audit:aria-required-attr",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 41,
-              "name": "lh:audit:duplicate-id-active",
+              "name": "lh:audit:aria-required-children",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 42,
-              "name": "lh:audit:duplicate-id-aria",
+              "name": "lh:audit:aria-required-parent",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 43,
-              "name": "lh:audit:form-field-multiple-labels",
+              "name": "lh:audit:aria-roles",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 44,
-              "name": "lh:audit:frame-title",
+              "name": "lh:audit:aria-toggle-field-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 45,
-              "name": "lh:audit:heading-order",
+              "name": "lh:audit:aria-tooltip-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 46,
-              "name": "lh:audit:html-has-lang",
+              "name": "lh:audit:aria-treeitem-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 47,
-              "name": "lh:audit:html-lang-valid",
+              "name": "lh:audit:aria-valid-attr-value",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 48,
-              "name": "lh:audit:image-alt",
+              "name": "lh:audit:aria-valid-attr",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 49,
-              "name": "lh:audit:input-image-alt",
+              "name": "lh:audit:button-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 50,
-              "name": "lh:audit:label",
+              "name": "lh:audit:bypass",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 51,
-              "name": "lh:audit:link-name",
+              "name": "lh:audit:color-contrast",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 52,
-              "name": "lh:audit:list",
+              "name": "lh:audit:definition-list",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 53,
-              "name": "lh:audit:listitem",
+              "name": "lh:audit:dlitem",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 54,
-              "name": "lh:audit:meta-refresh",
+              "name": "lh:audit:document-title",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 55,
-              "name": "lh:audit:meta-viewport",
+              "name": "lh:audit:duplicate-id-active",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 56,
-              "name": "lh:audit:object-alt",
+              "name": "lh:audit:duplicate-id-aria",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 57,
-              "name": "lh:audit:tabindex",
+              "name": "lh:audit:form-field-multiple-labels",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 58,
-              "name": "lh:audit:td-headers-attr",
+              "name": "lh:audit:frame-title",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 59,
-              "name": "lh:audit:th-has-data-cells",
+              "name": "lh:audit:heading-order",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 60,
-              "name": "lh:audit:valid-lang",
+              "name": "lh:audit:html-has-lang",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 61,
-              "name": "lh:audit:video-caption",
+              "name": "lh:audit:html-lang-valid",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 62,
-              "name": "lh:audit:custom-controls-labels",
+              "name": "lh:audit:image-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 63,
-              "name": "lh:audit:custom-controls-roles",
+              "name": "lh:audit:input-image-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 64,
-              "name": "lh:audit:focus-traps",
+              "name": "lh:audit:label",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 65,
-              "name": "lh:audit:focusable-controls",
+              "name": "lh:audit:link-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 66,
-              "name": "lh:audit:interactive-element-affordance",
+              "name": "lh:audit:list",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 67,
-              "name": "lh:audit:logical-tab-order",
+              "name": "lh:audit:listitem",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 68,
-              "name": "lh:audit:managed-focus",
+              "name": "lh:audit:meta-refresh",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 69,
-              "name": "lh:audit:offscreen-content-hidden",
+              "name": "lh:audit:meta-viewport",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 70,
-              "name": "lh:audit:use-landmarks",
+              "name": "lh:audit:object-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 71,
-              "name": "lh:audit:visual-order-follows-dom",
+              "name": "lh:audit:tabindex",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 72,
-              "name": "lh:audit:uses-responsive-images-snapshot",
+              "name": "lh:audit:td-headers-attr",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 73,
-              "name": "lh:audit:doctype",
+              "name": "lh:audit:th-has-data-cells",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 74,
-              "name": "lh:audit:dom-size",
+              "name": "lh:audit:valid-lang",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 75,
-              "name": "lh:audit:js-libraries",
+              "name": "lh:audit:video-caption",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 76,
-              "name": "lh:audit:paste-preventing-inputs",
+              "name": "lh:audit:custom-controls-labels",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 77,
-              "name": "lh:audit:meta-description",
+              "name": "lh:audit:custom-controls-roles",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 78,
-              "name": "lh:audit:font-size",
+              "name": "lh:audit:focus-traps",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 79,
-              "name": "lh:audit:link-text",
+              "name": "lh:audit:focusable-controls",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 80,
-              "name": "lh:audit:crawlable-anchors",
+              "name": "lh:audit:interactive-element-affordance",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 81,
-              "name": "lh:audit:robots-txt",
+              "name": "lh:audit:logical-tab-order",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 82,
-              "name": "lh:audit:tap-targets",
+              "name": "lh:audit:managed-focus",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 83,
-              "name": "lh:audit:plugins",
+              "name": "lh:audit:offscreen-content-hidden",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 84,
-              "name": "lh:audit:structured-data",
+              "name": "lh:audit:use-landmarks",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 85,
+              "name": "lh:audit:visual-order-follows-dom",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 86,
+              "name": "lh:audit:uses-responsive-images-snapshot",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 87,
+              "name": "lh:audit:doctype",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 88,
+              "name": "lh:audit:dom-size",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 89,
+              "name": "lh:audit:js-libraries",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 90,
+              "name": "lh:audit:paste-preventing-inputs",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 91,
+              "name": "lh:audit:meta-description",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 92,
+              "name": "lh:audit:font-size",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 93,
+              "name": "lh:audit:link-text",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 94,
+              "name": "lh:audit:crawlable-anchors",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 95,
+              "name": "lh:audit:robots-txt",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 96,
+              "name": "lh:audit:tap-targets",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 97,
+              "name": "lh:audit:plugins",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 98,
+              "name": "lh:audit:structured-data",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 99,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 86
+          "total": 100
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -20719,1308 +21145,1536 @@
             },
             {
               "startTime": 11,
-              "name": "lh:computed:NetworkRecords",
+              "name": "lh:gather:getArtifact:DevtoolsLog",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 12,
-              "name": "lh:gather:getInstallabilityErrors",
+              "name": "lh:gather:getArtifact:Trace",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 13,
-              "name": "lh:computed:MainResource",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 14,
-              "name": "lh:gather:collectStacks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 15,
-              "name": "lh:computed:ProcessedTrace",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 16,
-              "name": "lh:computed:ProcessedNavigation",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 17,
-              "name": "lh:computed:Responsiveness",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 18,
-              "name": "lh:config",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 19,
-              "name": "lh:config:resolveArtifactsToDefns",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 20,
-              "name": "lh:config:resolveNavigationsToDefns",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 21,
-              "name": "lh:runner:audit",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 22,
-              "name": "lh:runner:auditing",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 23,
-              "name": "lh:audit:is-on-https",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 24,
               "name": "lh:computed:NetworkRecords",
               "duration": 1,
               "entryType": "measure"
             },
             {
+              "startTime": 14,
+              "name": "lh:gather:getArtifact:DevtoolsLog",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 15,
+              "name": "lh:gather:getArtifact:Trace",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 16,
+              "name": "lh:gather:getArtifact:Accessibility",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 17,
+              "name": "lh:gather:getArtifact:AnchorElements",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 18,
+              "name": "lh:gather:getArtifact:ConsoleMessages",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 19,
+              "name": "lh:gather:getArtifact:CSSUsage",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 20,
+              "name": "lh:gather:getArtifact:Doctype",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 21,
+              "name": "lh:gather:getArtifact:DOMStats",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 22,
+              "name": "lh:gather:getArtifact:EmbeddedContent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 23,
+              "name": "lh:gather:getArtifact:FontSize",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 24,
+              "name": "lh:gather:getArtifact:Inputs",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
               "startTime": 25,
-              "name": "lh:audit:service-worker",
+              "name": "lh:gather:getArtifact:GlobalListeners",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 26,
-              "name": "lh:audit:viewport",
+              "name": "lh:gather:getArtifact:ImageElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 27,
-              "name": "lh:computed:ViewportMeta",
+              "name": "lh:gather:getArtifact:InstallabilityErrors",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 28,
-              "name": "lh:audit:first-contentful-paint",
+              "name": "lh:gather:getInstallabilityErrors",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 29,
-              "name": "lh:computed:FirstContentfulPaint",
+              "name": "lh:gather:getArtifact:InspectorIssues",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 30,
-              "name": "lh:computed:ProcessedTrace",
+              "name": "lh:gather:getArtifact:JsUsage",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 31,
-              "name": "lh:computed:ProcessedNavigation",
+              "name": "lh:gather:getArtifact:LinkElements",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 32,
-              "name": "lh:computed:LanternFirstContentfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 33,
-              "name": "lh:computed:PageDependencyGraph",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 34,
-              "name": "lh:computed:LoadSimulator",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 35,
-              "name": "lh:computed:NetworkAnalysis",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 36,
-              "name": "lh:audit:largest-contentful-paint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 37,
-              "name": "lh:computed:LargestContentfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 38,
-              "name": "lh:computed:LanternLargestContentfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 39,
-              "name": "lh:audit:first-meaningful-paint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 40,
-              "name": "lh:computed:FirstMeaningfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 41,
-              "name": "lh:computed:LanternFirstMeaningfulPaint",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 42,
-              "name": "lh:audit:speed-index",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 43,
-              "name": "lh:computed:SpeedIndex",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 44,
-              "name": "lh:computed:LanternSpeedIndex",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 45,
-              "name": "lh:computed:Speedline",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 46,
-              "name": "lh:audit:screenshot-thumbnails",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 47,
-              "name": "lh:audit:final-screenshot",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 48,
-              "name": "lh:computed:Screenshots",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 49,
-              "name": "lh:audit:total-blocking-time",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 50,
-              "name": "lh:computed:TotalBlockingTime",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 51,
-              "name": "lh:computed:LanternTotalBlockingTime",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 52,
-              "name": "lh:computed:LanternInteractive",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 53,
-              "name": "lh:audit:max-potential-fid",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 54,
-              "name": "lh:computed:MaxPotentialFID",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 55,
-              "name": "lh:computed:LanternMaxPotentialFID",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 56,
-              "name": "lh:audit:cumulative-layout-shift",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 57,
-              "name": "lh:computed:CumulativeLayoutShift",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 58,
-              "name": "lh:audit:errors-in-console",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 59,
-              "name": "lh:computed:JSBundles",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 60,
-              "name": "lh:audit:server-response-time",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 61,
               "name": "lh:computed:MainResource",
               "duration": 1,
               "entryType": "measure"
             },
             {
+              "startTime": 33,
+              "name": "lh:gather:getArtifact:MainDocumentContent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 34,
+              "name": "lh:gather:getArtifact:MetaElements",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 35,
+              "name": "lh:gather:getArtifact:NetworkUserAgent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 36,
+              "name": "lh:gather:getArtifact:OptimizedImages",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 37,
+              "name": "lh:gather:getArtifact:ResponseCompression",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 38,
+              "name": "lh:gather:getArtifact:RobotsTxt",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 39,
+              "name": "lh:gather:getArtifact:ServiceWorker",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 40,
+              "name": "lh:gather:getArtifact:Scripts",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 41,
+              "name": "lh:gather:getArtifact:SourceMaps",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 42,
+              "name": "lh:gather:getArtifact:Stacks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 43,
+              "name": "lh:gather:collectStacks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 44,
+              "name": "lh:gather:getArtifact:TagsBlockingFirstPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 45,
+              "name": "lh:gather:getArtifact:TapTargets",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 46,
+              "name": "lh:gather:getArtifact:TraceElements",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 47,
+              "name": "lh:computed:ProcessedTrace",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 48,
+              "name": "lh:computed:ProcessedNavigation",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 49,
+              "name": "lh:computed:Responsiveness",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 50,
+              "name": "lh:gather:getArtifact:ViewportDimensions",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 51,
+              "name": "lh:gather:getArtifact:WebAppManifest",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 52,
+              "name": "lh:gather:getArtifact:devtoolsLogs",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 53,
+              "name": "lh:gather:getArtifact:traces",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 54,
+              "name": "lh:gather:getArtifact:FullPageScreenshot",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 55,
+              "name": "lh:gather:getArtifact:BFCacheFailures",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 56,
+              "name": "lh:config",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 57,
+              "name": "lh:config:resolveArtifactsToDefns",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 58,
+              "name": "lh:config:resolveNavigationsToDefns",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 59,
+              "name": "lh:runner:audit",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 60,
+              "name": "lh:runner:auditing",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 61,
+              "name": "lh:audit:is-on-https",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
               "startTime": 62,
-              "name": "lh:audit:interactive",
+              "name": "lh:computed:NetworkRecords",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 63,
-              "name": "lh:computed:Interactive",
+              "name": "lh:audit:service-worker",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 64,
-              "name": "lh:audit:user-timings",
+              "name": "lh:audit:viewport",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 65,
-              "name": "lh:computed:UserTimings",
+              "name": "lh:computed:ViewportMeta",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 66,
-              "name": "lh:audit:critical-request-chains",
+              "name": "lh:audit:first-contentful-paint",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 67,
-              "name": "lh:computed:CriticalRequestChains",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 68,
-              "name": "lh:audit:redirects",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 69,
-              "name": "lh:audit:installable-manifest",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 70,
-              "name": "lh:audit:splash-screen",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 71,
-              "name": "lh:computed:ManifestValues",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 72,
-              "name": "lh:audit:themed-omnibox",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 73,
-              "name": "lh:audit:maskable-icon",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 74,
-              "name": "lh:audit:content-width",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 75,
-              "name": "lh:audit:image-aspect-ratio",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 76,
-              "name": "lh:audit:image-size-responsive",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 77,
-              "name": "lh:audit:preload-fonts",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 78,
-              "name": "lh:audit:deprecations",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 79,
-              "name": "lh:audit:mainthread-work-breakdown",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 80,
-              "name": "lh:computed:MainThreadTasks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 81,
-              "name": "lh:audit:bootup-time",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 82,
-              "name": "lh:audit:uses-rel-preload",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 83,
-              "name": "lh:audit:uses-rel-preconnect",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 84,
-              "name": "lh:audit:font-display",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 85,
-              "name": "lh:audit:diagnostics",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 86,
-              "name": "lh:audit:network-requests",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 87,
-              "name": "lh:audit:network-rtt",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 88,
-              "name": "lh:audit:network-server-latency",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 89,
-              "name": "lh:audit:main-thread-tasks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 90,
-              "name": "lh:audit:metrics",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 91,
-              "name": "lh:computed:TimingSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 92,
-              "name": "lh:computed:FirstContentfulPaintAllFrames",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 93,
-              "name": "lh:computed:LargestContentfulPaintAllFrames",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 94,
-              "name": "lh:computed:LCPBreakdown",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 95,
-              "name": "lh:computed:TimeToFirstByte",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 96,
-              "name": "lh:computed:LCPImageRecord",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 97,
-              "name": "lh:audit:performance-budget",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 98,
-              "name": "lh:computed:ResourceSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 99,
-              "name": "lh:computed:EntityClassification",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 100,
-              "name": "lh:audit:timing-budget",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 101,
-              "name": "lh:audit:resource-summary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 102,
-              "name": "lh:audit:third-party-summary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 103,
-              "name": "lh:audit:third-party-facades",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 104,
-              "name": "lh:audit:largest-contentful-paint-element",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 105,
-              "name": "lh:audit:lcp-lazy-loaded",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 106,
-              "name": "lh:audit:layout-shift-elements",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 107,
-              "name": "lh:audit:long-tasks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 108,
-              "name": "lh:audit:no-unload-listeners",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 109,
-              "name": "lh:audit:non-composited-animations",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 110,
-              "name": "lh:audit:unsized-images",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 111,
-              "name": "lh:audit:valid-source-maps",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 112,
-              "name": "lh:audit:prioritize-lcp-image",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 113,
-              "name": "lh:audit:csp-xss",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 114,
-              "name": "lh:audit:script-treemap-data",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 115,
-              "name": "lh:computed:ModuleDuplication",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 116,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 117,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 118,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 119,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 120,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 121,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 122,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 123,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 124,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 125,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 126,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 127,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 128,
-              "name": "lh:computed:UnusedJavascriptSummary",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 129,
-              "name": "lh:audit:pwa-cross-browser",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 130,
-              "name": "lh:audit:pwa-page-transitions",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 131,
-              "name": "lh:audit:pwa-each-page-has-url",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 132,
-              "name": "lh:audit:accesskeys",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 133,
-              "name": "lh:audit:aria-allowed-attr",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 134,
-              "name": "lh:audit:aria-command-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 135,
-              "name": "lh:audit:aria-hidden-body",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 136,
-              "name": "lh:audit:aria-hidden-focus",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 137,
-              "name": "lh:audit:aria-input-field-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 138,
-              "name": "lh:audit:aria-meter-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 139,
-              "name": "lh:audit:aria-progressbar-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 140,
-              "name": "lh:audit:aria-required-attr",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 141,
-              "name": "lh:audit:aria-required-children",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 142,
-              "name": "lh:audit:aria-required-parent",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 143,
-              "name": "lh:audit:aria-roles",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 144,
-              "name": "lh:audit:aria-toggle-field-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 145,
-              "name": "lh:audit:aria-tooltip-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 146,
-              "name": "lh:audit:aria-treeitem-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 147,
-              "name": "lh:audit:aria-valid-attr-value",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 148,
-              "name": "lh:audit:aria-valid-attr",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 149,
-              "name": "lh:audit:button-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 150,
-              "name": "lh:audit:bypass",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 151,
-              "name": "lh:audit:color-contrast",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 152,
-              "name": "lh:audit:definition-list",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 153,
-              "name": "lh:audit:dlitem",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 154,
-              "name": "lh:audit:document-title",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 155,
-              "name": "lh:audit:duplicate-id-active",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 156,
-              "name": "lh:audit:duplicate-id-aria",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 157,
-              "name": "lh:audit:form-field-multiple-labels",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 158,
-              "name": "lh:audit:frame-title",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 159,
-              "name": "lh:audit:heading-order",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 160,
-              "name": "lh:audit:html-has-lang",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 161,
-              "name": "lh:audit:html-lang-valid",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 162,
-              "name": "lh:audit:image-alt",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 163,
-              "name": "lh:audit:input-image-alt",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 164,
-              "name": "lh:audit:label",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 165,
-              "name": "lh:audit:link-name",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 166,
-              "name": "lh:audit:list",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 167,
-              "name": "lh:audit:listitem",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 168,
-              "name": "lh:audit:meta-refresh",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 169,
-              "name": "lh:audit:meta-viewport",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 170,
-              "name": "lh:audit:object-alt",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 171,
-              "name": "lh:audit:tabindex",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 172,
-              "name": "lh:audit:td-headers-attr",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 173,
-              "name": "lh:audit:th-has-data-cells",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 174,
-              "name": "lh:audit:valid-lang",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 175,
-              "name": "lh:audit:video-caption",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 176,
-              "name": "lh:audit:custom-controls-labels",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 177,
-              "name": "lh:audit:custom-controls-roles",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 178,
-              "name": "lh:audit:focus-traps",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 179,
-              "name": "lh:audit:focusable-controls",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 180,
-              "name": "lh:audit:interactive-element-affordance",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 181,
-              "name": "lh:audit:logical-tab-order",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 182,
-              "name": "lh:audit:managed-focus",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 183,
-              "name": "lh:audit:offscreen-content-hidden",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 184,
-              "name": "lh:audit:use-landmarks",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 185,
-              "name": "lh:audit:visual-order-follows-dom",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 186,
-              "name": "lh:audit:uses-long-cache-ttl",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 187,
-              "name": "lh:audit:total-byte-weight",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 188,
-              "name": "lh:audit:offscreen-images",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 189,
-              "name": "lh:audit:render-blocking-resources",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 190,
-              "name": "lh:computed:UnusedCSS",
-              "duration": 1,
-              "entryType": "measure"
-            },
-            {
-              "startTime": 191,
               "name": "lh:computed:FirstContentfulPaint",
               "duration": 1,
               "entryType": "measure"
             },
             {
+              "startTime": 68,
+              "name": "lh:computed:ProcessedTrace",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 69,
+              "name": "lh:computed:ProcessedNavigation",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 70,
+              "name": "lh:computed:LanternFirstContentfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 71,
+              "name": "lh:computed:PageDependencyGraph",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 72,
+              "name": "lh:computed:LoadSimulator",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 73,
+              "name": "lh:computed:NetworkAnalysis",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 74,
+              "name": "lh:audit:largest-contentful-paint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 75,
+              "name": "lh:computed:LargestContentfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 76,
+              "name": "lh:computed:LanternLargestContentfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 77,
+              "name": "lh:audit:first-meaningful-paint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 78,
+              "name": "lh:computed:FirstMeaningfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 79,
+              "name": "lh:computed:LanternFirstMeaningfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 80,
+              "name": "lh:audit:speed-index",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 81,
+              "name": "lh:computed:SpeedIndex",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 82,
+              "name": "lh:computed:LanternSpeedIndex",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 83,
+              "name": "lh:computed:Speedline",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 84,
+              "name": "lh:audit:screenshot-thumbnails",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 85,
+              "name": "lh:audit:final-screenshot",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 86,
+              "name": "lh:computed:Screenshots",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 87,
+              "name": "lh:audit:total-blocking-time",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 88,
+              "name": "lh:computed:TotalBlockingTime",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 89,
+              "name": "lh:computed:LanternTotalBlockingTime",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 90,
+              "name": "lh:computed:LanternInteractive",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 91,
+              "name": "lh:audit:max-potential-fid",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 92,
+              "name": "lh:computed:MaxPotentialFID",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 93,
+              "name": "lh:computed:LanternMaxPotentialFID",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 94,
+              "name": "lh:audit:cumulative-layout-shift",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 95,
+              "name": "lh:computed:CumulativeLayoutShift",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 96,
+              "name": "lh:audit:errors-in-console",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 97,
+              "name": "lh:computed:JSBundles",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 98,
+              "name": "lh:audit:server-response-time",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 99,
+              "name": "lh:computed:MainResource",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 100,
+              "name": "lh:audit:interactive",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 101,
+              "name": "lh:computed:Interactive",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 102,
+              "name": "lh:audit:user-timings",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 103,
+              "name": "lh:computed:UserTimings",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 104,
+              "name": "lh:audit:critical-request-chains",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 105,
+              "name": "lh:computed:CriticalRequestChains",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 106,
+              "name": "lh:audit:redirects",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 107,
+              "name": "lh:audit:installable-manifest",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 108,
+              "name": "lh:audit:splash-screen",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 109,
+              "name": "lh:computed:ManifestValues",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 110,
+              "name": "lh:audit:themed-omnibox",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 111,
+              "name": "lh:audit:maskable-icon",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 112,
+              "name": "lh:audit:content-width",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 113,
+              "name": "lh:audit:image-aspect-ratio",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 114,
+              "name": "lh:audit:image-size-responsive",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 115,
+              "name": "lh:audit:preload-fonts",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 116,
+              "name": "lh:audit:deprecations",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 117,
+              "name": "lh:audit:mainthread-work-breakdown",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 118,
+              "name": "lh:computed:MainThreadTasks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 119,
+              "name": "lh:audit:bootup-time",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 120,
+              "name": "lh:audit:uses-rel-preload",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 121,
+              "name": "lh:audit:uses-rel-preconnect",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 122,
+              "name": "lh:audit:font-display",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 123,
+              "name": "lh:audit:diagnostics",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 124,
+              "name": "lh:audit:network-requests",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 125,
+              "name": "lh:audit:network-rtt",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 126,
+              "name": "lh:audit:network-server-latency",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 127,
+              "name": "lh:audit:main-thread-tasks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 128,
+              "name": "lh:audit:metrics",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 129,
+              "name": "lh:computed:TimingSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 130,
+              "name": "lh:computed:FirstContentfulPaintAllFrames",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 131,
+              "name": "lh:computed:LargestContentfulPaintAllFrames",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 132,
+              "name": "lh:computed:LCPBreakdown",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 133,
+              "name": "lh:computed:TimeToFirstByte",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 134,
+              "name": "lh:computed:LCPImageRecord",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 135,
+              "name": "lh:audit:performance-budget",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 136,
+              "name": "lh:computed:ResourceSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 137,
+              "name": "lh:computed:EntityClassification",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 138,
+              "name": "lh:audit:timing-budget",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 139,
+              "name": "lh:audit:resource-summary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 140,
+              "name": "lh:audit:third-party-summary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 141,
+              "name": "lh:audit:third-party-facades",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 142,
+              "name": "lh:audit:largest-contentful-paint-element",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 143,
+              "name": "lh:audit:lcp-lazy-loaded",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 144,
+              "name": "lh:audit:layout-shift-elements",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 145,
+              "name": "lh:audit:long-tasks",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 146,
+              "name": "lh:audit:no-unload-listeners",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 147,
+              "name": "lh:audit:non-composited-animations",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 148,
+              "name": "lh:audit:unsized-images",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 149,
+              "name": "lh:audit:valid-source-maps",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 150,
+              "name": "lh:audit:prioritize-lcp-image",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 151,
+              "name": "lh:audit:csp-xss",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 152,
+              "name": "lh:audit:script-treemap-data",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 153,
+              "name": "lh:computed:ModuleDuplication",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 154,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 155,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 156,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 157,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 158,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 159,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 160,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 161,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 162,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 163,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 164,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 165,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 166,
+              "name": "lh:computed:UnusedJavascriptSummary",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 167,
+              "name": "lh:audit:pwa-cross-browser",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 168,
+              "name": "lh:audit:pwa-page-transitions",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 169,
+              "name": "lh:audit:pwa-each-page-has-url",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 170,
+              "name": "lh:audit:accesskeys",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 171,
+              "name": "lh:audit:aria-allowed-attr",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 172,
+              "name": "lh:audit:aria-command-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 173,
+              "name": "lh:audit:aria-hidden-body",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 174,
+              "name": "lh:audit:aria-hidden-focus",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 175,
+              "name": "lh:audit:aria-input-field-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 176,
+              "name": "lh:audit:aria-meter-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 177,
+              "name": "lh:audit:aria-progressbar-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 178,
+              "name": "lh:audit:aria-required-attr",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 179,
+              "name": "lh:audit:aria-required-children",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 180,
+              "name": "lh:audit:aria-required-parent",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 181,
+              "name": "lh:audit:aria-roles",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 182,
+              "name": "lh:audit:aria-toggle-field-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 183,
+              "name": "lh:audit:aria-tooltip-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 184,
+              "name": "lh:audit:aria-treeitem-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 185,
+              "name": "lh:audit:aria-valid-attr-value",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 186,
+              "name": "lh:audit:aria-valid-attr",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 187,
+              "name": "lh:audit:button-name",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 188,
+              "name": "lh:audit:bypass",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 189,
+              "name": "lh:audit:color-contrast",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 190,
+              "name": "lh:audit:definition-list",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 191,
+              "name": "lh:audit:dlitem",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
               "startTime": 192,
-              "name": "lh:audit:unminified-css",
+              "name": "lh:audit:document-title",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 193,
-              "name": "lh:audit:unminified-javascript",
+              "name": "lh:audit:duplicate-id-active",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 194,
-              "name": "lh:audit:unused-css-rules",
+              "name": "lh:audit:duplicate-id-aria",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 195,
-              "name": "lh:audit:unused-javascript",
+              "name": "lh:audit:form-field-multiple-labels",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 196,
-              "name": "lh:audit:modern-image-formats",
+              "name": "lh:audit:frame-title",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 197,
-              "name": "lh:audit:uses-optimized-images",
+              "name": "lh:audit:heading-order",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 198,
-              "name": "lh:audit:uses-text-compression",
+              "name": "lh:audit:html-has-lang",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 199,
-              "name": "lh:audit:uses-responsive-images",
+              "name": "lh:audit:html-lang-valid",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 200,
-              "name": "lh:computed:ImageRecords",
+              "name": "lh:audit:image-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 201,
-              "name": "lh:audit:efficient-animated-content",
+              "name": "lh:audit:input-image-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 202,
-              "name": "lh:audit:duplicated-javascript",
+              "name": "lh:audit:label",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 203,
-              "name": "lh:audit:legacy-javascript",
+              "name": "lh:audit:link-name",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 204,
-              "name": "lh:audit:doctype",
+              "name": "lh:audit:list",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 205,
-              "name": "lh:audit:charset",
+              "name": "lh:audit:listitem",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 206,
-              "name": "lh:audit:dom-size",
+              "name": "lh:audit:meta-refresh",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 207,
-              "name": "lh:audit:geolocation-on-start",
+              "name": "lh:audit:meta-viewport",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 208,
-              "name": "lh:audit:inspector-issues",
+              "name": "lh:audit:object-alt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 209,
-              "name": "lh:audit:no-document-write",
+              "name": "lh:audit:tabindex",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 210,
-              "name": "lh:audit:js-libraries",
+              "name": "lh:audit:td-headers-attr",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 211,
-              "name": "lh:audit:notification-on-start",
+              "name": "lh:audit:th-has-data-cells",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 212,
-              "name": "lh:audit:paste-preventing-inputs",
+              "name": "lh:audit:valid-lang",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 213,
-              "name": "lh:audit:uses-passive-event-listeners",
+              "name": "lh:audit:video-caption",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 214,
-              "name": "lh:audit:meta-description",
+              "name": "lh:audit:custom-controls-labels",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 215,
-              "name": "lh:audit:http-status-code",
+              "name": "lh:audit:custom-controls-roles",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 216,
-              "name": "lh:audit:font-size",
+              "name": "lh:audit:focus-traps",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 217,
-              "name": "lh:audit:link-text",
+              "name": "lh:audit:focusable-controls",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 218,
-              "name": "lh:audit:crawlable-anchors",
+              "name": "lh:audit:interactive-element-affordance",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 219,
-              "name": "lh:audit:is-crawlable",
+              "name": "lh:audit:logical-tab-order",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 220,
-              "name": "lh:audit:robots-txt",
+              "name": "lh:audit:managed-focus",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 221,
-              "name": "lh:audit:tap-targets",
+              "name": "lh:audit:offscreen-content-hidden",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 222,
-              "name": "lh:audit:hreflang",
+              "name": "lh:audit:use-landmarks",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 223,
-              "name": "lh:audit:plugins",
+              "name": "lh:audit:visual-order-follows-dom",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 224,
-              "name": "lh:audit:canonical",
+              "name": "lh:audit:uses-long-cache-ttl",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 225,
-              "name": "lh:audit:structured-data",
+              "name": "lh:audit:total-byte-weight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 226,
-              "name": "lh:audit:bf-cache",
+              "name": "lh:audit:offscreen-images",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 227,
+              "name": "lh:audit:render-blocking-resources",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 228,
+              "name": "lh:computed:UnusedCSS",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 229,
+              "name": "lh:computed:FirstContentfulPaint",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 230,
+              "name": "lh:audit:unminified-css",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 231,
+              "name": "lh:audit:unminified-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 232,
+              "name": "lh:audit:unused-css-rules",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 233,
+              "name": "lh:audit:unused-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 234,
+              "name": "lh:audit:modern-image-formats",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 235,
+              "name": "lh:audit:uses-optimized-images",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 236,
+              "name": "lh:audit:uses-text-compression",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 237,
+              "name": "lh:audit:uses-responsive-images",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 238,
+              "name": "lh:computed:ImageRecords",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 239,
+              "name": "lh:audit:efficient-animated-content",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 240,
+              "name": "lh:audit:duplicated-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 241,
+              "name": "lh:audit:legacy-javascript",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 242,
+              "name": "lh:audit:doctype",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 243,
+              "name": "lh:audit:charset",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 244,
+              "name": "lh:audit:dom-size",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 245,
+              "name": "lh:audit:geolocation-on-start",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 246,
+              "name": "lh:audit:inspector-issues",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 247,
+              "name": "lh:audit:no-document-write",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 248,
+              "name": "lh:audit:js-libraries",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 249,
+              "name": "lh:audit:notification-on-start",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 250,
+              "name": "lh:audit:paste-preventing-inputs",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 251,
+              "name": "lh:audit:uses-passive-event-listeners",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 252,
+              "name": "lh:audit:meta-description",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 253,
+              "name": "lh:audit:http-status-code",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 254,
+              "name": "lh:audit:font-size",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 255,
+              "name": "lh:audit:link-text",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 256,
+              "name": "lh:audit:crawlable-anchors",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 257,
+              "name": "lh:audit:is-crawlable",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 258,
+              "name": "lh:audit:robots-txt",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 259,
+              "name": "lh:audit:tap-targets",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 260,
+              "name": "lh:audit:hreflang",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 261,
+              "name": "lh:audit:plugins",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 262,
+              "name": "lh:audit:canonical",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 263,
+              "name": "lh:audit:structured-data",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 264,
+              "name": "lh:audit:bf-cache",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 265,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 228
+          "total": 266
         },
         "i18n": {
           "rendererFormattedStrings": {

--- a/core/test/results/artifacts/artifacts.json
+++ b/core/test/results/artifacts/artifacts.json
@@ -186,164 +186,483 @@
   },
   "Timing": [
     {
-      "startTime": 0,
       "name": "lh:config",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 0,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 1,
       "name": "lh:config:resolveArtifactsToDefns",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 1,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 2,
       "name": "lh:config:resolveNavigationsToDefns",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 2,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 3,
       "name": "lh:runner:gather",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 3,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 4,
       "name": "lh:driver:connect",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 4,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:driver:navigate",
+      "entryType": "measure",
       "startTime": 5,
-      "name": "lh:driver:navigate",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 6,
       "name": "lh:gather:getBenchmarkIndex",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 6,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:gather:getVersion",
+      "entryType": "measure",
       "startTime": 7,
-      "name": "lh:gather:getVersion",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 8,
       "name": "lh:prepare:navigationMode",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 8,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:driver:navigate",
+      "entryType": "measure",
       "startTime": 9,
-      "name": "lh:driver:navigate",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 10,
       "name": "lh:prepare:navigation",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 10,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 11,
       "name": "lh:storage:clearDataForOrigin",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 11,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 12,
       "name": "lh:storage:clearBrowserCaches",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 12,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 13,
       "name": "lh:gather:prepareThrottlingAndNetwork",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 13,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 14,
       "name": "lh:driver:navigate",
-      "duration": 1,
       "entryType": "measure",
+      "startTime": 14,
+      "duration": 1,
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:gather:getArtifact:DevtoolsLog",
+      "entryType": "measure",
       "startTime": 15,
-      "name": "lh:computed:NetworkRecords",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:gather:getArtifact:Trace",
+      "entryType": "measure",
       "startTime": 16,
-      "name": "lh:gather:getInstallabilityErrors",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:computed:NetworkRecords",
+      "entryType": "measure",
       "startTime": 17,
-      "name": "lh:computed:MainResource",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:gather:getArtifact:DevtoolsLog",
+      "entryType": "measure",
       "startTime": 18,
-      "name": "lh:gather:getVersion",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:gather:getArtifact:Trace",
+      "entryType": "measure",
       "startTime": 19,
-      "name": "lh:gather:getVersion",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:gather:getArtifact:Accessibility",
+      "entryType": "measure",
       "startTime": 20,
-      "name": "lh:gather:collectStacks",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
+      "name": "lh:gather:getArtifact:AnchorElements",
+      "entryType": "measure",
       "startTime": 21,
-      "name": "lh:computed:ProcessedTrace",
       "duration": 1,
-      "entryType": "measure",
+      "detail": null,
       "gather": true
     },
     {
-      "startTime": 22,
-      "name": "lh:computed:ProcessedNavigation",
-      "duration": 1,
+      "name": "lh:gather:getArtifact:ConsoleMessages",
       "entryType": "measure",
+      "startTime": 22,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:CSSUsage",
+      "entryType": "measure",
+      "startTime": 23,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:Doctype",
+      "entryType": "measure",
+      "startTime": 24,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:DOMStats",
+      "entryType": "measure",
+      "startTime": 25,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:EmbeddedContent",
+      "entryType": "measure",
+      "startTime": 26,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:FontSize",
+      "entryType": "measure",
+      "startTime": 27,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:Inputs",
+      "entryType": "measure",
+      "startTime": 28,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:GlobalListeners",
+      "entryType": "measure",
+      "startTime": 29,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:ImageElements",
+      "entryType": "measure",
+      "startTime": 30,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:InstallabilityErrors",
+      "entryType": "measure",
+      "startTime": 31,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getInstallabilityErrors",
+      "entryType": "measure",
+      "startTime": 32,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:InspectorIssues",
+      "entryType": "measure",
+      "startTime": 33,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:JsUsage",
+      "entryType": "measure",
+      "startTime": 34,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:LinkElements",
+      "entryType": "measure",
+      "startTime": 35,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:computed:MainResource",
+      "entryType": "measure",
+      "startTime": 36,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:MainDocumentContent",
+      "entryType": "measure",
+      "startTime": 37,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:MetaElements",
+      "entryType": "measure",
+      "startTime": 38,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:NetworkUserAgent",
+      "entryType": "measure",
+      "startTime": 39,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:OptimizedImages",
+      "entryType": "measure",
+      "startTime": 40,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:ResponseCompression",
+      "entryType": "measure",
+      "startTime": 41,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:RobotsTxt",
+      "entryType": "measure",
+      "startTime": 42,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:ServiceWorker",
+      "entryType": "measure",
+      "startTime": 43,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:Scripts",
+      "entryType": "measure",
+      "startTime": 44,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:SourceMaps",
+      "entryType": "measure",
+      "startTime": 45,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:Stacks",
+      "entryType": "measure",
+      "startTime": 46,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:collectStacks",
+      "entryType": "measure",
+      "startTime": 47,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:TagsBlockingFirstPaint",
+      "entryType": "measure",
+      "startTime": 48,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:TapTargets",
+      "entryType": "measure",
+      "startTime": 49,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:TraceElements",
+      "entryType": "measure",
+      "startTime": 50,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:computed:ProcessedTrace",
+      "entryType": "measure",
+      "startTime": 51,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:computed:ProcessedNavigation",
+      "entryType": "measure",
+      "startTime": 52,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:computed:Responsiveness",
+      "entryType": "measure",
+      "startTime": 53,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:ViewportDimensions",
+      "entryType": "measure",
+      "startTime": 54,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:WebAppManifest",
+      "entryType": "measure",
+      "startTime": 55,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:devtoolsLogs",
+      "entryType": "measure",
+      "startTime": 56,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:traces",
+      "entryType": "measure",
+      "startTime": 57,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:FullPageScreenshot",
+      "entryType": "measure",
+      "startTime": 58,
+      "duration": 1,
+      "detail": null,
+      "gather": true
+    },
+    {
+      "name": "lh:gather:getArtifact:BFCacheFailures",
+      "entryType": "measure",
+      "startTime": 59,
+      "duration": 1,
+      "detail": null,
       "gather": true
     }
   ],

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -7077,7 +7077,103 @@
       },
       {
         "startTime": 0,
+        "name": "lh:gather:getArtifact:DevtoolsLog",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:Trace",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:computed:NetworkRecords",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:DevtoolsLog",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:Trace",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:Accessibility",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:AnchorElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:ConsoleMessages",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:CSSUsage",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:Doctype",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:DOMStats",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:EmbeddedContent",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:FontSize",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:Inputs",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:GlobalListeners",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:ImageElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:InstallabilityErrors",
         "duration": 100,
         "entryType": "measure"
       },
@@ -7089,25 +7185,109 @@
       },
       {
         "startTime": 0,
+        "name": "lh:gather:getArtifact:InspectorIssues",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:JsUsage",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:LinkElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:computed:MainResource",
         "duration": 100,
         "entryType": "measure"
       },
       {
         "startTime": 0,
-        "name": "lh:gather:getVersion",
+        "name": "lh:gather:getArtifact:MainDocumentContent",
         "duration": 100,
         "entryType": "measure"
       },
       {
         "startTime": 0,
-        "name": "lh:gather:getVersion",
+        "name": "lh:gather:getArtifact:MetaElements",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:NetworkUserAgent",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:OptimizedImages",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:ResponseCompression",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:RobotsTxt",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:ServiceWorker",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:Scripts",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:SourceMaps",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:Stacks",
         "duration": 100,
         "entryType": "measure"
       },
       {
         "startTime": 0,
         "name": "lh:gather:collectStacks",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:TagsBlockingFirstPaint",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:TapTargets",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:TraceElements",
         "duration": 100,
         "entryType": "measure"
       },
@@ -7120,6 +7300,48 @@
       {
         "startTime": 0,
         "name": "lh:computed:ProcessedNavigation",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:computed:Responsiveness",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:ViewportDimensions",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:WebAppManifest",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:devtoolsLogs",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:traces",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:FullPageScreenshot",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
+        "name": "lh:gather:getArtifact:BFCacheFailures",
         "duration": 100,
         "entryType": "measure"
       },


### PR DESCRIPTION
This was just a cosmetic issue before but I noticed that we weren't generating `Timing` artifact entries for the `getArtifact` phase. Legacy navigation mode *was* generating `Timing` entries for `afterPass`.

| Before | After |
| ------ | ------ |
| ![Screenshot 2023-04-27 at 12 37 52 PM](https://user-images.githubusercontent.com/6752989/234973028-4ae1416b-fb49-4f13-90df-66ccaaa20d84.png) | ![Screenshot 2023-04-27 at 12 37 05 PM](https://user-images.githubusercontent.com/6752989/234972843-9d31eee5-62ac-4596-9193-ed6b07cf9f5a.png) |




Related:
https://github.com/GoogleChrome/lighthouse/discussions/14998