### PR TITLE
core(predictive-perf): add URL as requiredArtifact

### DIFF
--- a/core/audits/predictive-perf.js
+++ b/core/audits/predictive-perf.js
@@ -34,7 +34,7 @@ class PredictivePerf extends Audit {
         'a cellular connection on a mobile device.',
       scoreDisplayMode: Audit.SCORING_MODES.NUMERIC,
       supportedModes: ['navigation'],
-      requiredArtifacts: ['traces', 'devtoolsLogs', 'GatherContext'],
+      requiredArtifacts: ['traces', 'devtoolsLogs', 'GatherContext', 'URL'],
     };
   }
 


### PR DESCRIPTION
URL was going through as `undefined` here, but apparently didn't cause an error until #14941 landed (MainResource in the TTFB computed artifact ends up throwing for [lack of a `mainDocumentUrl`](https://github.com/GoogleChrome/lighthouse/blob/ecc76b8a41226f22d132ac37fbce3846e2559747/core/computed/main-resource.js#L23)).

Not noticed because we don't have smoke tests for predictive-perf, but predictive-perf is also not really intended for actually running, just for one-off testing runs 🤷 

Thanks to @benschwarz for reporting