### PR TITLE
core: single network monitor kept on Driver

### DIFF
--- a/core/gather/driver.js
+++ b/core/gather/driver.js
@@ -83,6 +83,7 @@ class Driver {
     this._targetManager = new TargetManager(cdpSession);
     await this._targetManager.enable();
     this._networkMonitor = new NetworkMonitor(this._targetManager);
+    await this._networkMonitor.enable();
     this.defaultSession = this._targetManager.rootSession();
     this._executionContext = new ExecutionContext(this.defaultSession);
     this._fetcher = new Fetcher(this.defaultSession);
@@ -93,6 +94,7 @@ class Driver {
   async disconnect() {
     if (this.defaultSession === throwingSession) return;
     await this._targetManager?.disable();
+    await this._networkMonitor?.disable();
     await this.defaultSession.dispose();
   }
 }

--- a/core/gather/driver.js
+++ b/core/gather/driver.js
@@ -9,6 +9,7 @@ import log from 'lighthouse-logger';
 import {ExecutionContext} from './driver/execution-context.js';
 import {TargetManager} from './driver/target-manager.js';
 import {Fetcher} from './fetcher.js';
+import {NetworkMonitor} from './driver/network-monitor.js';
 
 /** @return {*} */
 const throwNotConnectedFn = () => {
@@ -37,6 +38,8 @@ class Driver {
     this._page = page;
     /** @type {TargetManager|undefined} */
     this._targetManager = undefined;
+    /** @type {NetworkMonitor|undefined} */
+    this._networkMonitor = undefined;
     /** @type {ExecutionContext|undefined} */
     this._executionContext = undefined;
     /** @type {Fetcher|undefined} */
@@ -51,7 +54,6 @@ class Driver {
     return this._executionContext;
   }
 
-  /** @return {Fetcher} */
   get fetcher() {
     if (!this._fetcher) return throwNotConnectedFn();
     return this._fetcher;
@@ -60,6 +62,11 @@ class Driver {
   get targetManager() {
     if (!this._targetManager) return throwNotConnectedFn();
     return this._targetManager;
+  }
+
+  get networkMonitor() {
+    if (!this._networkMonitor) return throwNotConnectedFn();
+    return this._networkMonitor;
   }
 
   /** @return {Promise<string>} */
@@ -75,6 +82,7 @@ class Driver {
     const cdpSession = await this._page.target().createCDPSession();
     this._targetManager = new TargetManager(cdpSession);
     await this._targetManager.enable();
+    this._networkMonitor = new NetworkMonitor(this._targetManager);
     this.defaultSession = this._targetManager.rootSession();
     this._executionContext = new ExecutionContext(this.defaultSession);
     this._fetcher = new Fetcher(this.defaultSession);

--- a/core/gather/driver/navigation.js
+++ b/core/gather/driver/navigation.js
@@ -6,7 +6,6 @@
 
 import log from 'lighthouse-logger';
 
-import {NetworkMonitor} from './network-monitor.js';
 import {waitForFullyLoaded, waitForFrameNavigated, waitForUserToContinue} from './wait-for-condition.js'; // eslint-disable-line max-len
 import * as constants from '../../config/constants.js';
 import * as i18n from '../../lib/i18n/i18n.js';
@@ -89,7 +88,7 @@ async function gotoURL(driver, requestor, options) {
   log.time(status);
 
   const session = driver.defaultSession;
-  const networkMonitor = new NetworkMonitor(driver.targetManager);
+  const networkMonitor = driver.networkMonitor;
 
   // Enable the events and network monitor needed to track navigation progress.
   await networkMonitor.enable();

--- a/core/gather/driver/navigation.js
+++ b/core/gather/driver/navigation.js
@@ -91,7 +91,6 @@ async function gotoURL(driver, requestor, options) {
   const networkMonitor = driver.networkMonitor;
 
   // Enable the events and network monitor needed to track navigation progress.
-  await networkMonitor.enable();
   await session.sendCommand('Page.enable');
   await session.sendCommand('Page.setLifecycleEventsEnabled', {enabled: true});
 
@@ -143,7 +142,6 @@ async function gotoURL(driver, requestor, options) {
 
   // Bring `Page.navigate` errors back into the promise chain. See https://github.com/GoogleChrome/lighthouse/pull/6739.
   await waitForNavigationTriggered;
-  await networkMonitor.disable();
 
   if (options.debugNavigation) {
     await waitForUserToContinue(driver);

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -9,7 +9,6 @@
 import FRGatherer from '../base-gatherer.js';
 import * as emulation from '../../lib/emulation.js';
 import {pageFunctions} from '../../lib/page-functions.js';
-import {NetworkMonitor} from '../driver/network-monitor.js';
 import {waitForNetworkIdle} from '../driver/wait-for-condition.js';
 
 // JPEG quality setting
@@ -89,7 +88,7 @@ class FullPageScreenshot extends FRGatherer {
     const height = Math.min(fullHeight, MAX_WEBP_SIZE);
 
     // Setup network monitor before we change the viewport.
-    const networkMonitor = new NetworkMonitor(context.driver.targetManager);
+    const networkMonitor = context.driver.networkMonitor;
     const waitForNetworkIdleResult = waitForNetworkIdle(session, networkMonitor, {
       pretendDCLAlreadyFired: true,
       networkQuietThresholdMs: 1000,

--- a/core/gather/gatherers/full-page-screenshot.js
+++ b/core/gather/gatherers/full-page-screenshot.js
@@ -96,7 +96,6 @@ class FullPageScreenshot extends FRGatherer {
       idleEvent: 'network-critical-idle',
       isIdle: recorder => recorder.isCriticalIdle(),
     });
-    await networkMonitor.enable();
 
     await session.sendCommand('Emulation.setDeviceMetricsOverride', {
       mobile: deviceMetrics.mobile,
@@ -112,7 +111,6 @@ class FullPageScreenshot extends FRGatherer {
       waitForNetworkIdleResult.promise,
     ]);
     waitForNetworkIdleResult.cancel();
-    await networkMonitor.disable();
 
     // Now that new resources are (probably) fetched, wait long enough for a layout.
     await context.driver.executionContext.evaluate(waitForDoubleRaf, {args: []});

--- a/core/legacy/gather/driver.js
+++ b/core/legacy/gather/driver.js
@@ -17,6 +17,7 @@ import {DevtoolsMessageLog} from '../../gather/gatherers/devtools-log.js';
 import TraceGatherer from '../../gather/gatherers/trace.js';
 import {getBrowserVersion} from '../../gather/driver/environment.js';
 import {enableAsyncStacks} from '../../gather/driver/prepare.js';
+import {NetworkMonitor} from '../../gather/driver/network-monitor.js';
 
 // Controls how long to wait for a response after sending a DevTools protocol command.
 const DEFAULT_PROTOCOL_TIMEOUT = 30000;
@@ -118,6 +119,8 @@ class Driver {
         this._connection.off('protocolevent', callback);
       },
     };
+
+    this.networkMonitor = new NetworkMonitor(this.targetManager);
   }
 
   /** @deprecated - Not available on Fraggle Rock driver. */

--- a/core/test/gather/driver/navigation-test.js
+++ b/core/test/gather/driver/navigation-test.js
@@ -42,6 +42,7 @@ describe('.gotoURL', () => {
 
   it('will track redirects through gotoURL load with warning', async () => {
     mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    await driver.networkMonitor.enable();
 
     const url = 'http://example.com';
 
@@ -94,6 +95,7 @@ describe('.gotoURL', () => {
 
   it('backfills requestedUrl when using a callback requestor', async () => {
     mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    await driver.networkMonitor.enable();
 
     const requestor = () => Promise.resolve();
 
@@ -113,6 +115,7 @@ describe('.gotoURL', () => {
 
   it('throws if no navigations found using a callback requestor', async () => {
     mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    await driver.networkMonitor.enable();
 
     const requestor = () => Promise.resolve();
 
@@ -132,6 +135,7 @@ describe('.gotoURL', () => {
 
   it('does not add warnings when URLs are equal', async () => {
     mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    await driver.networkMonitor.enable();
 
     const url = 'https://www.example.com';
 
@@ -148,6 +152,7 @@ describe('.gotoURL', () => {
 
   it('waits for Page.frameNavigated', async () => {
     mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    await driver.networkMonitor.enable();
 
     const url = 'https://www.example.com';
 
@@ -166,6 +171,7 @@ describe('.gotoURL', () => {
 
   it('waits for page load', async () => {
     mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    await driver.networkMonitor.enable();
 
     const url = 'https://www.example.com';
 
@@ -195,6 +201,7 @@ describe('.gotoURL', () => {
 
   it('waits for page FCP', async () => {
     mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    await driver.networkMonitor.enable();
 
     const url = 'https://www.example.com';
 
@@ -229,6 +236,7 @@ describe('.gotoURL', () => {
 
   it('throws when asked to wait for FCP without waiting for load', async () => {
     mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    await driver.networkMonitor.enable();
 
     const url = 'https://www.example.com';
 

--- a/core/test/gather/mock-driver.js
+++ b/core/test/gather/mock-driver.js
@@ -18,6 +18,7 @@ import {
 } from './mock-commands.js';
 import * as constants from '../../config/constants.js';
 import {fnAny} from '../test-utils.js';
+import {NetworkMonitor} from '../../gather/driver/network-monitor.js';
 
 /** @typedef {import('../../gather/driver.js').Driver} Driver */
 /** @typedef {import('../../gather/driver/execution-context.js')} ExecutionContext */
@@ -140,7 +141,8 @@ function createMockTargetManager(session) {
     on: createMockOnFn(),
     off: fnAny(),
 
-    /** @return {import('../../gather/driver/target-manager.js')} */
+    // TODO(FR-COMPAT): switch to real TargetManager when legacy removed.
+    /** @return {LH.Gatherer.FRTransitionalDriver['targetManager']} */
     asTargetManager() {
       // @ts-expect-error - We'll rely on the tests passing to know this matches.
       return this;
@@ -164,6 +166,7 @@ function createMockDriver() {
     disconnect: fnAny(),
     executionContext: context.asExecutionContext(),
     targetManager: targetManager.asTargetManager(),
+    networkMonitor: new NetworkMonitor(targetManager.asTargetManager()),
 
     /** @return {Driver} */
     asDriver() {

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -12,6 +12,7 @@ import {CPUNode as _CPUNode} from '../core/lib/dependency-graph/cpu-node.js';
 import {Simulator as _Simulator} from '../core/lib/dependency-graph/simulator/simulator.js';
 import {Driver} from '../core/legacy/gather/driver.js';
 import {ExecutionContext} from '../core/gather/driver/execution-context.js';
+import {NetworkMonitor} from '../core/gather/driver/network-monitor.js';
 import {Fetcher} from '../core/gather/fetcher.js';
 import {ArbitraryEqualityMap} from '../core/lib/arbitrary-equality-map.js';
 
@@ -50,6 +51,7 @@ declare module Gatherer {
       on(event: 'protocolevent', callback: (payload: Protocol.RawEventMessage) => void): void
       off(event: 'protocolevent', callback: (payload: Protocol.RawEventMessage) => void): void
     };
+    networkMonitor: NetworkMonitor;
   }
 
   /** The limited context interface shared between pre and post Fraggle Rock Lighthouse. */


### PR DESCRIPTION
ref #14078

Moves `NetworkMonitor` to `Driver`, so that the navigation runner and FPS gatherer can use the same instance.

No change to the lifecycle of the monitor - the navigation runner enables/disables it for `goToURL` only, and the FPS does the same in `getArtifact` (so after the monitor has been disabled in navigation mode - but for the first and only time in other modes). If a gatherer wanted to use the monitor in earlier gathering stages, we need to modify how the monitor is enabled. One option is to track a counter of enables/disables (like we do for protocol domains). Another is to just enable unconditionally in `Driver.connect`, so it's on constantly for all modes and gatherers. The second commit in the PR tries this approach.