### PR TITLE
tests: remove most usages of `afterPass`

### DIFF
--- a/core/test/gather/gatherers/accessibility-test.js
+++ b/core/test/gather/gatherers/accessibility-test.js
@@ -23,7 +23,7 @@ describe('Accessibility gatherer', () => {
 
   it('propagates error retrieving the results', () => {
     const error = 'There was an error.';
-    return accessibilityGather.afterPass({
+    return accessibilityGather.getArtifact({
       driver: {
         executionContext: {
           async evaluate() {

--- a/core/test/gather/gatherers/cache-contents-test.js
+++ b/core/test/gather/gatherers/cache-contents-test.js
@@ -17,7 +17,7 @@ describe('Cache Contents gatherer', () => {
   });
 
   it('throws an error when cache getter returns nothing', () => {
-    return cacheContentGather.afterPass({
+    return cacheContentGather.getArtifact({
       driver: {
         evaluateAsync() {
           return Promise.resolve();

--- a/core/test/gather/gatherers/console-messages-test.js
+++ b/core/test/gather/gatherers/console-messages-test.js
@@ -62,9 +62,10 @@ describe('ConsoleMessages', () => {
     const driver = new MockDriver();
     const options = {driver};
 
-    await consoleGatherer.beforePass(options);
+    await consoleGatherer.startInstrumentation(options);
     driver.defaultSession.fireForTest('Runtime.exceptionThrown', runtimeEx);
 
+    await consoleGatherer.stopInstrumentation(options);
     const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
@@ -104,9 +105,10 @@ describe('ConsoleMessages', () => {
     const driver = new MockDriver();
     const options = {driver};
 
-    await consoleGatherer.beforePass(options);
+    await consoleGatherer.startInstrumentation(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleWarnEvent);
 
+    await consoleGatherer.stopInstrumentation(options);
     const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
@@ -136,9 +138,10 @@ describe('ConsoleMessages', () => {
     const driver = new MockDriver();
     const options = {driver};
 
-    await consoleGatherer.beforePass(options);
+    await consoleGatherer.startInstrumentation(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleWarnEvent);
 
+    await consoleGatherer.stopInstrumentation(options);
     const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
@@ -260,9 +263,10 @@ describe('ConsoleMessages', () => {
     const driver = new MockDriver();
     const options = {driver};
 
-    await consoleGatherer.beforePass(options);
+    await consoleGatherer.startInstrumentation(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleWarnEvent);
 
+    await consoleGatherer.stopInstrumentation(options);
     const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
@@ -318,9 +322,10 @@ describe('ConsoleMessages', () => {
     const driver = new MockDriver();
     const options = {driver};
 
-    await consoleGatherer.beforePass(options);
+    await consoleGatherer.startInstrumentation(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleErrorEvent);
 
+    await consoleGatherer.stopInstrumentation(options);
     const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
@@ -358,9 +363,10 @@ describe('ConsoleMessages', () => {
     const driver = new MockDriver();
     const options = {driver};
 
-    await consoleGatherer.beforePass(options);
+    await consoleGatherer.startInstrumentation(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleLog);
 
+    await consoleGatherer.stopInstrumentation(options);
     const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 0);
@@ -406,10 +412,11 @@ describe('ConsoleMessages', () => {
     const driver = new MockDriver();
     const options = {driver};
 
-    await consoleGatherer.beforePass(options);
+    await consoleGatherer.startInstrumentation(options);
     driver.defaultSession.fireForTest('Log.entryAdded', logEntries[0]);
     driver.defaultSession.fireForTest('Log.entryAdded', logEntries[1]);
 
+    await consoleGatherer.stopInstrumentation(options);
     const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 2);

--- a/core/test/gather/gatherers/console-messages-test.js
+++ b/core/test/gather/gatherers/console-messages-test.js
@@ -65,7 +65,7 @@ describe('ConsoleMessages', () => {
     await consoleGatherer.beforePass(options);
     driver.defaultSession.fireForTest('Runtime.exceptionThrown', runtimeEx);
 
-    const artifact = await consoleGatherer.afterPass(options);
+    const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
     assert.equal(artifact[0].source, 'exception');
@@ -107,7 +107,7 @@ describe('ConsoleMessages', () => {
     await consoleGatherer.beforePass(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleWarnEvent);
 
-    const artifact = await consoleGatherer.afterPass(options);
+    const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
     assert.equal(artifact[0].source, 'console.warn');
@@ -139,7 +139,7 @@ describe('ConsoleMessages', () => {
     await consoleGatherer.beforePass(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleWarnEvent);
 
-    const artifact = await consoleGatherer.afterPass(options);
+    const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
     assert.equal(artifact[0].source, 'console.warn');
@@ -263,7 +263,7 @@ describe('ConsoleMessages', () => {
     await consoleGatherer.beforePass(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleWarnEvent);
 
-    const artifact = await consoleGatherer.afterPass(options);
+    const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
     assert.equal(artifact[0].source, 'console.warn');
@@ -321,7 +321,7 @@ describe('ConsoleMessages', () => {
     await consoleGatherer.beforePass(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleErrorEvent);
 
-    const artifact = await consoleGatherer.afterPass(options);
+    const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 1);
     assert.equal(artifact[0].source, 'console.error');
@@ -361,7 +361,7 @@ describe('ConsoleMessages', () => {
     await consoleGatherer.beforePass(options);
     driver.defaultSession.fireForTest('Runtime.consoleAPICalled', consoleLog);
 
-    const artifact = await consoleGatherer.afterPass(options);
+    const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 0);
   });
@@ -410,7 +410,7 @@ describe('ConsoleMessages', () => {
     driver.defaultSession.fireForTest('Log.entryAdded', logEntries[0]);
     driver.defaultSession.fireForTest('Log.entryAdded', logEntries[1]);
 
-    const artifact = await consoleGatherer.afterPass(options);
+    const artifact = await consoleGatherer.getArtifact(options);
 
     assert.equal(artifact.length, 2);
 

--- a/core/test/gather/gatherers/dobetterweb/optimized-images-test.js
+++ b/core/test/gather/gatherers/dobetterweb/optimized-images-test.js
@@ -5,109 +5,13 @@
  */
 
 import OptimizedImages from '../../../../gather/gatherers/dobetterweb/optimized-images.js';
-import {NetworkRequest} from '../../../../lib/network-request.js';
 import {createMockContext} from '../../../gather/mock-driver.js';
-
-let context = createMockContext();
-let optimizedImages;
-
-const traceData = {
-  networkRecords: [
-    {
-      requestId: '1',
-      url: 'http://google.com/image.jpg',
-      mimeType: 'image/jpeg',
-      resourceSize: 10000000,
-      transferSize: 20000000,
-      resourceType: 'Image',
-      finished: true,
-    },
-    {
-      requestId: '1',
-      url: 'http://google.com/transparent.png',
-      mimeType: 'image/png',
-      resourceSize: 11000,
-      transferSize: 20000,
-      resourceType: 'Image',
-      finished: true,
-    },
-    {
-      requestId: '1',
-      url: 'http://google.com/image.bmp',
-      mimeType: 'image/bmp',
-      resourceSize: 12000,
-      transferSize: 9000, // bitmap was compressed another way
-      resourceType: 'Image',
-      finished: true,
-    },
-    {
-      requestId: '1',
-      url: 'http://google.com/image.bmp',
-      mimeType: 'image/bmp',
-      resourceSize: 12000,
-      transferSize: 20000,
-      resourceType: 'Image',
-      finished: true,
-    },
-    {
-      requestId: '1',
-      url: 'http://google.com/vector.svg',
-      mimeType: 'image/svg+xml',
-      resourceSize: 13000,
-      transferSize: 20000,
-      resourceType: 'Image',
-      finished: true,
-    },
-    {
-      requestId: '1',
-      url: 'http://gmail.com/image.jpg',
-      mimeType: 'image/jpeg',
-      resourceSize: 15000,
-      transferSize: 20000,
-      resourceType: 'Image',
-      finished: true,
-    },
-    {
-      requestId: '1',
-      url: 'http://gmail.com/image-oopif.jpg',
-      mimeType: 'image/jpeg',
-      resourceSize: 15000,
-      transferSize: 20000,
-      resourceType: 'Image',
-      finished: true,
-      sessionTargetType: 'iframe', // ignore for being an oopif
-    },
-    {
-      requestId: '1',
-      url: 'data: image/jpeg ; base64 ,SgVcAT32587935321...',
-      mimeType: 'image/jpeg',
-      resourceType: 'Image',
-      resourceSize: 14000,
-      transferSize: 20000,
-      finished: true,
-    },
-    {
-      requestId: '1',
-      url: 'http://google.com/big-image.bmp',
-      mimeType: 'image/bmp',
-      resourceType: 'Image',
-      resourceSize: 12000,
-      transferSize: 20000,
-      finished: false, // ignore for not finishing
-    },
-    {
-      requestId: '1',
-      url: 'http://google.com/not-an-image.bmp',
-      mimeType: 'image/bmp',
-      resourceType: 'Document', // ignore for not really being an image
-      resourceSize: 12000,
-      transferSize: 20000,
-      finished: true,
-    },
-  ].map((record) => Object.assign(new NetworkRequest(), record)),
-};
+import {networkRecordsToDevtoolsLog} from '../../../network-records-to-devtools-log.js';
 
 describe('Optimized images', () => {
+  let context = createMockContext();
+  let optimizedImages;
+
   // Reset the Gatherer before each test.
   beforeEach(() => {
     optimizedImages = new OptimizedImages();
@@ -117,10 +21,102 @@ describe('Optimized images', () => {
       const encodedSize = params.encoding === 'webp' ? 60 : 80;
       return Promise.resolve({encodedSize});
     });
+
+    context.dependencies.DevtoolsLog = networkRecordsToDevtoolsLog([
+      {
+        requestId: '1',
+        url: 'http://google.com/image.jpg',
+        mimeType: 'image/jpeg',
+        resourceSize: 10000000,
+        transferSize: 20000000,
+        resourceType: 'Image',
+        finished: true,
+      },
+      {
+        requestId: '2',
+        url: 'http://google.com/transparent.png',
+        mimeType: 'image/png',
+        resourceSize: 11000,
+        transferSize: 20000,
+        resourceType: 'Image',
+        finished: true,
+      },
+      {
+        requestId: '3',
+        url: 'http://google.com/image.bmp',
+        mimeType: 'image/bmp',
+        resourceSize: 12000,
+        transferSize: 9000, // bitmap was compressed another way
+        resourceType: 'Image',
+        finished: true,
+      },
+      {
+        requestId: '4',
+        url: 'http://google.com/image.bmp',
+        mimeType: 'image/bmp',
+        resourceSize: 12000,
+        transferSize: 20000,
+        resourceType: 'Image',
+        finished: true,
+      },
+      {
+        requestId: '5',
+        url: 'http://google.com/vector.svg',
+        mimeType: 'image/svg+xml',
+        resourceSize: 13000,
+        transferSize: 20000,
+        resourceType: 'Image',
+        finished: true,
+      },
+      {
+        requestId: '6',
+        url: 'http://gmail.com/image.jpg',
+        mimeType: 'image/jpeg',
+        resourceSize: 15000,
+        transferSize: 20000,
+        resourceType: 'Image',
+        finished: true,
+      },
+      {
+        requestId: '7',
+        url: 'http://gmail.com/image-oopif.jpg',
+        mimeType: 'image/jpeg',
+        resourceSize: 15000,
+        transferSize: 20000,
+        resourceType: 'Image',
+        finished: true,
+        sessionTargetType: 'iframe', // ignore for being an oopif
+      },
+      {
+        requestId: '8',
+        url: 'data: image/jpeg ; base64 ,SgVcAT32587935321...',
+        mimeType: 'image/jpeg',
+        resourceType: 'Image',
+        resourceSize: 14000,
+        transferSize: 20000,
+        finished: true,
+      },
+      {
+        requestId: '9',
+        url: 'http://google.com/big-image.bmp',
+        mimeType: 'image/bmp',
+        resourceType: 'Image',
+        finished: false, // ignore for not finishing
+      },
+      {
+        requestId: '10',
+        url: 'http://google.com/not-an-image.bmp',
+        mimeType: 'image/bmp',
+        resourceType: 'Document', // ignore for not really being an image
+        resourceSize: 12000,
+        transferSize: 20000,
+        finished: true,
+      },
+    ]);
   });
 
   it('returns all images, sorted with sizes', async () => {
-    const artifact = await optimizedImages.afterPass(context, traceData);
+    const artifact = await optimizedImages.getArtifact(context);
     expect(artifact).toHaveLength(5);
     expect(artifact).toMatchObject([
       {
@@ -167,7 +163,7 @@ describe('Optimized images', () => {
       }
     });
 
-    return optimizedImages.afterPass(context, traceData).then(artifact => {
+    return optimizedImages.getArtifact(context).then(artifact => {
       const failed = artifact.find(record => record.failed);
 
       expect(artifact).toHaveLength(5);
@@ -176,40 +172,34 @@ describe('Optimized images', () => {
   });
 
   it('handles non-standard mime types too', async () => {
-    const traceData = {
-      networkRecords: [
-        {
-          requestId: '1',
-          url: 'http://google.com/image.bmp?x-ms',
-          mimeType: 'image/x-ms-bmp',
-          resourceSize: 12000,
-          transferSize: 0,
-          resourceType: 'Image',
-          finished: true,
-        },
-      ].map((record) => Object.assign(new NetworkRequest(), record)),
-    };
-
-    const artifact = await optimizedImages.afterPass(context, traceData);
+    context.dependencies.DevtoolsLog = networkRecordsToDevtoolsLog([
+      {
+        requestId: '1',
+        url: 'http://google.com/image.bmp?x-ms',
+        mimeType: 'image/x-ms-bmp',
+        resourceSize: 12000,
+        transferSize: 0,
+        resourceType: 'Image',
+        finished: true,
+      },
+    ]);
+    const artifact = await optimizedImages.getArtifact(context);
     expect(artifact).toHaveLength(1);
   });
 
   it('handles cached images', async () => {
-    const traceData = {
-      networkRecords: [
-        {
-          requestId: '1',
-          url: 'http://google.com/image.jpg',
-          mimeType: 'image/jpeg',
-          resourceSize: 10000000,
-          transferSize: 0,
-          resourceType: 'Image',
-          finished: true,
-        },
-      ].map((record) => Object.assign(new NetworkRequest(), record)),
-    };
-
-    const artifact = await optimizedImages.afterPass(context, traceData);
+    context.dependencies.DevtoolsLog = networkRecordsToDevtoolsLog([
+      {
+        requestId: '1',
+        url: 'http://google.com/image.jpg',
+        mimeType: 'image/jpeg',
+        resourceSize: 10000000,
+        transferSize: 0,
+        resourceType: 'Image',
+        finished: true,
+      },
+    ]);
+    const artifact = await optimizedImages.getArtifact(context);
     expect(artifact).toHaveLength(1);
   });
 });

--- a/core/test/gather/gatherers/global-listeners-test.js
+++ b/core/test/gather/gatherers/global-listeners-test.js
@@ -53,7 +53,7 @@ describe('Global Listener Gatherer', () => {
     connectionStub.sendCommand = sendCommandMock;
     const driver = new Driver(connectionStub);
 
-    const globalListeners = await globalListenerGatherer.afterPass({driver});
+    const globalListeners = await globalListenerGatherer.getArtifact({driver});
     return expect(globalListeners).toMatchObject(expectedOutput);
   });
 });

--- a/core/test/gather/gatherers/seo/font-size-test.js
+++ b/core/test/gather/gatherers/seo/font-size-test.js
@@ -144,7 +144,7 @@ describe('Font size gatherer', () => {
     };
     const driver = {defaultSession: session};
 
-    const artifact = await fontSizeGather.afterPass({driver});
+    const artifact = await fontSizeGather.getArtifact({driver});
     const expectedFailingTextLength = Array.from(smallText.trim()).length;
     const expectedTotalTextLength =
       Array.from(smallText.trim()).length +

--- a/core/test/gather/gatherers/viewport-dimensions-test.js
+++ b/core/test/gather/gatherers/viewport-dimensions-test.js
@@ -17,7 +17,7 @@ describe('ViewportDimensions gatherer', () => {
   });
 
   it('returns an artifact', () => {
-    return gatherer.afterPass({
+    return gatherer.getArtifact({
       driver: {
         executionContext: {
           async evaluate() {

--- a/core/test/network-records-to-devtools-log.js
+++ b/core/test/network-records-to-devtools-log.js
@@ -437,7 +437,10 @@ function networkRecordsToDevtoolsLog(networkRecords, options = {}) {
 
     devtoolsLog.push(getResponseReceivedEvent(networkRecord, index, normalizedTiming));
     devtoolsLog.push(getDataReceivedEvent(networkRecord, index));
-    devtoolsLog.push(getLoadingFinishedEvent(networkRecord, index, normalizedTiming));
+
+    if (networkRecord.finished !== false) {
+      devtoolsLog.push(getLoadingFinishedEvent(networkRecord, index, normalizedTiming));
+    }
   });
 
   // If in a test, assert that the log will turn into an equivalent networkRecords.


### PR DESCRIPTION
In the same vein as https://github.com/GoogleChrome/lighthouse/pull/15047

Our tests should avoid testing gatherers via the legacy navigation methods.

Some tests still call `afterPass` for legacy compat reasons. These tests will be removed once the legacy runner is removed.
