### PR TITLE
core(config): remove dead config format code

### DIFF
--- a/core/config/config.js
+++ b/core/config/config.js
@@ -30,7 +30,6 @@ import {
   mergeConfigFragmentArrayByKey,
 } from './config-helpers.js';
 import {getModuleDirectory} from '../../esm-utils.js';
-import * as format from '../../shared/localization/format.js';
 
 const defaultConfigPath = path.join(
   getModuleDirectory(import.meta),
@@ -294,51 +293,7 @@ async function initializeConfig(gatherMode, config, flags = {}) {
   return {resolvedConfig, warnings};
 }
 
-/**
- * @param {LH.Config.ResolvedConfig} resolvedConfig
- * @return {string}
- */
-function getConfigDisplayString(resolvedConfig) {
-  /** @type {LH.Config.ResolvedConfig} */
-  const resolvedConfigCopy = JSON.parse(JSON.stringify(resolvedConfig));
-
-  if (resolvedConfigCopy.navigations) {
-    for (const navigation of resolvedConfigCopy.navigations) {
-      for (let i = 0; i < navigation.artifacts.length; ++i) {
-        // @ts-expect-error Breaking the Config.AnyArtifactDefn type.
-        navigation.artifacts[i] = navigation.artifacts[i].id;
-      }
-    }
-  }
-
-  if (resolvedConfigCopy.artifacts) {
-    for (const artifactDefn of resolvedConfigCopy.artifacts) {
-      // @ts-expect-error Breaking the Config.AnyArtifactDefn type.
-      artifactDefn.gatherer = artifactDefn.gatherer.path;
-      // Dependencies are not declared on Config JSON
-      artifactDefn.dependencies = undefined;
-    }
-  }
-
-  if (resolvedConfigCopy.audits) {
-    for (const auditDefn of resolvedConfigCopy.audits) {
-      // @ts-expect-error Breaking the Config.AuditDefn type.
-      auditDefn.implementation = undefined;
-      if (Object.keys(auditDefn.options).length === 0) {
-        // @ts-expect-error Breaking the Config.AuditDefn type.
-        auditDefn.options = undefined;
-      }
-    }
-  }
-
-  // Printed config is more useful with localized strings.
-  format.replaceIcuMessages(resolvedConfigCopy, resolvedConfigCopy.settings.locale);
-
-  return JSON.stringify(resolvedConfigCopy, null, 2);
-}
-
 export {
   resolveWorkingCopy,
   initializeConfig,
-  getConfigDisplayString,
 };

--- a/core/legacy/config/config.js
+++ b/core/legacy/config/config.js
@@ -10,7 +10,6 @@ import log from 'lighthouse-logger';
 
 import legacyDefaultConfig from './legacy-default-config.js';
 import * as constants from '../../config/constants.js';
-import * as format from '../../../shared/localization/format.js';
 import * as validation from '../../config/validation.js';
 import {Runner} from '../../runner.js';
 import {
@@ -226,41 +225,6 @@ class LegacyResolvedConfig {
 
     assertValidPasses(this.passes, this.audits);
     validation.assertValidCategories(this.categories, this.audits, this.groups);
-  }
-
-  /**
-   * Provides a cleaned-up, stringified version of this config. Gatherer and
-   * Audit `implementation` and `instance` do not survive this process.
-   * @return {string}
-   */
-  getPrintString() {
-    const jsonConfig = deepClone(this);
-
-    if (jsonConfig.passes) {
-      for (const pass of jsonConfig.passes) {
-        for (const gathererDefn of pass.gatherers) {
-          gathererDefn.implementation = undefined;
-          // @ts-expect-error Breaking the Config.GathererDefn type.
-          gathererDefn.instance = undefined;
-        }
-      }
-    }
-
-    if (jsonConfig.audits) {
-      for (const auditDefn of jsonConfig.audits) {
-        // @ts-expect-error Breaking the Config.AuditDefn type.
-        auditDefn.implementation = undefined;
-        if (Object.keys(auditDefn.options).length === 0) {
-          // @ts-expect-error Breaking the Config.AuditDefn type.
-          auditDefn.options = undefined;
-        }
-      }
-    }
-
-    // Printed config is more useful with localized strings.
-    format.replaceIcuMessages(jsonConfig, jsonConfig.settings.locale);
-
-    return JSON.stringify(jsonConfig, null, 2);
   }
 
   /**

--- a/core/test/legacy/config/config-test.js
+++ b/core/test/legacy/config/config-test.js
@@ -16,7 +16,6 @@ import * as constants from '../../../config/constants.js';
 import {Gatherer} from '../../../gather/gatherers/gatherer.js';
 import {Audit} from '../../../audits/audit.js';
 import * as i18n from '../../../lib/i18n/i18n.js';
-import * as format from '../../../../shared/localization/format.js';
 import {getModuleDirectory, getModulePath} from '../../../../esm-utils.js';
 
 const require = createRequire(import.meta.url);
@@ -1500,66 +1499,6 @@ describe('Config', () => {
 
       await assert.rejects(loadGatherer(`${root}/missing-after-pass`),
         /afterPass\(\) method/);
-    });
-  });
-
-  describe('#getPrintString', () => {
-    it('doesn\'t include empty audit options in output', async () => {
-      const aOpt = 'auditOption';
-      const config = {
-        extends: 'lighthouse:default',
-        passes: [{
-          passName: 'defaultPass',
-          gatherers: [
-            {path: 'script-elements'},
-          ],
-        }],
-        audits: [
-          // `options` merged into default `metrics` audit.
-          {path: 'metrics', options: {aOpt}},
-        ],
-      };
-
-      const printed = (await LegacyResolvedConfig.fromJson(config)).getPrintString();
-      const printedConfig = JSON.parse(printed);
-
-      // Check that options weren't completely eliminated.
-      const metricsAudit = printedConfig.audits.find(a => a.path === 'metrics');
-      assert.strictEqual(metricsAudit.options.aOpt, aOpt);
-
-      for (const audit of printedConfig.audits) {
-        if (audit.options) {
-          assert.ok(Object.keys(audit.options).length > 0);
-        }
-      }
-    });
-
-    it('prints localized category titles', async () => {
-      const printed = (await LegacyResolvedConfig.fromJson(legacyDefaultConfig)).getPrintString();
-      const printedConfig = JSON.parse(printed);
-      let localizableCount = 0;
-
-      Object.entries(printedConfig.categories).forEach(([printedCategoryId, printedCategory]) => {
-        const origTitle = origConfig.categories[printedCategoryId].title;
-        if (format.isIcuMessage(origTitle)) localizableCount++;
-        const i18nOrigTitle = format.getFormatted(origTitle, origConfig.settings.locale);
-
-        assert.strictEqual(printedCategory.title, i18nOrigTitle);
-      });
-
-      // Should have localized at least one string.
-      assert.ok(localizableCount > 0);
-    });
-
-    it('prints a valid config that can make an identical Config', async () => {
-      // depends on defaultConfig having a `path` for all gatherers and audits.
-      const firstConfig = await LegacyResolvedConfig.fromJson(legacyDefaultConfig);
-      const firstPrint = firstConfig.getPrintString();
-
-      const secondConfig = await LegacyResolvedConfig.fromJson(JSON.parse(firstPrint));
-      const secondPrint = secondConfig.getPrintString();
-
-      assert.strictEqual(firstPrint, secondPrint);
     });
   });
 });


### PR DESCRIPTION
We stopped using this code everywhere in 10.0, but didn't actually remove it because we thought someone out there might still want to dig into our internals if need be. I don't think anyone has asked us about this, so I think it's safe to remove at this point.
