### PR TITLE
misc(compare-runs): allow for multiple args to lighthouse

### DIFF
--- a/core/scripts/compare-runs.js
+++ b/core/scripts/compare-runs.js
@@ -143,8 +143,15 @@ async function gather() {
   const outputDir = dir(argv.name);
   if (fs.existsSync(outputDir)) {
     console.log('Collection already started - resuming.');
+  } else {
+    await mkdir(outputDir, {recursive: true});
+    fs.writeFileSync(`${outputDir}/meta.json`, JSON.stringify({
+      name: argv.name,
+      lhFlags: argv.lhFlags.split(' '),
+      urls: argv.urls,
+      n: argv.n,
+    }, null, 2));
   }
-  await mkdir(outputDir, {recursive: true});
 
   const progress = new ProgressLogger();
   progress.log('Gathering…');
@@ -167,7 +174,7 @@ async function gather() {
         `${LH_ROOT}/cli`,
         url,
         `--gather-mode=${gatherDir}`,
-        argv.lhFlags,
+        ...argv.lhFlags.split(' '),
       ]);
     }
   }
@@ -202,8 +209,8 @@ async function audit() {
           `--audit-mode=${gatherDir}`,
           `--output-path=${outputPath}`,
           '--output=json',
+          ...argv.lhFlags.split(' '),
         ];
-        if (argv.lhFlags) args.push(argv.lhFlags);
         await execFile('node', args);
       } catch (e) {
         console.error('audit error:', e);

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -111,7 +111,7 @@ Alternatively, you can instruct Chrome to ignore the invalid certificate by addi
 
 Lighthouse can run against a real mobile device. You can follow the [Remote Debugging on Android (Legacy Workflow)](https://developer.chrome.com/devtools/docs/remote-debugging-legacy) up through step 3.3, but the TL;DR is install & run adb, enable USB debugging, then port forward 9222 from the device to the machine with Lighthouse.
 
-You'll likely want to use the CLI flags `--screenEmulation.disabled --throttling.cpuSlowdownMultiplier=1` to disable any additional emulation.
+You'll likely want to use the CLI flags `--screenEmulation.disabled --throttling.cpuSlowdownMultiplier=1 --throttling-method=provided` to disable any additional emulation.
 
 > **Warning:** If you are running Lighthouse 10.x with any chrome version older than M112 (<=M111) you will need to add the `--legacy-navigation` to the `lighthouse` command. See https://github.com/GoogleChrome/lighthouse/issues/14746 for more info.
 
@@ -125,7 +125,7 @@ $ adb devices -l
 
 $ adb forward tcp:9222 localabstract:chrome_devtools_remote
 
-$ lighthouse --port=9222 --screenEmulation.disabled --throttling.cpuSlowdownMultiplier=1 https://example.com
+$ lighthouse --port=9222 --screenEmulation.disabled --throttling.cpuSlowdownMultiplier=1 --throttling-method=provided https://example.com
 ```
 
 ## Lighthouse as trace processor


### PR DESCRIPTION
Was using this script to collect some traces from a mobile device...

```
node core/scripts/compare-runs.js --name motopower --collect -n 3 --lh-flags='--port 9223 --legacy-navigation --screenEmulation.disabled --throttling.cpuSlowdownMultiplier=1 --throttling-method=provided' --urls https://www.example.com https://www.nyt.com
```

and found that the lhArgs parameter is broken.

Also updated some stuff in readme about testing on mobile. It overlooked disabling network throttling, for some reason.