### PR TITLE
misc(lantern-collect): add median lhr to golden zip

### DIFF
--- a/core/scripts/lantern/collect/golden.js
+++ b/core/scripts/lantern/collect/golden.js
@@ -105,6 +105,7 @@ async function main() {
       unthrottled: {
         tracePath: medianUnthrottled.trace,
         devtoolsLogPath: medianUnthrottled.devtoolsLog,
+        lhrPath: medianUnthrottled.lhr,
       },
     });
   }
@@ -118,6 +119,7 @@ async function main() {
     log.progress('making site-index-plus-golden-expectations.json');
     copyToGolden(result.unthrottled.devtoolsLogPath);
     copyToGolden(result.unthrottled.tracePath);
+    copyToGolden(result.unthrottled.lhrPath);
   }
 
   log.progress('archiving ...');

--- a/core/scripts/lantern/download-traces.sh
+++ b/core/scripts/lantern/download-traces.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-VERSION="2019-12-17"
+VERSION="2019-12-17-v2"
 
 DIRNAME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT_PATH="$DIRNAME/../../.."


### PR DESCRIPTION
I wanted to experiment with configuring lantern based on the bidx of runs for our 2019 lantern data, but was missing the LHRs in the zips. I added them, might as well make it stick.