### PR TITLE
misc: add cjs path for logger

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,7 @@
 
 cli/test/fixtures/byte-efficiency/bundle.js
 
-**/dist/**
+dist/**
 
 coverage/**
 

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,7 @@
 
 cli/test/fixtures/byte-efficiency/bundle.js
 
-/dist/**
+**/dist/**
 
 coverage/**
 

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,7 @@
 
 cli/test/fixtures/byte-efficiency/bundle.js
 
-dist/**
+dist
 
 coverage/**
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ npm-debug.log
 .tmp_env
 .tgz
 
-/dist
+**/dist
 coverage
 lcov.info
 .nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ npm-debug.log
 .tmp_env
 .tgz
 
-**/dist
+dist
 coverage
 lcov.info
 .nyc_output

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "lighthouse-logger",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^2.6.9",

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "lighthouse-logger",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "Apache-2.0",
   "exports": {
     "require": "./dist/index.cjs",

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -3,6 +3,14 @@
   "name": "lighthouse-logger",
   "version": "1.4.0",
   "license": "Apache-2.0",
+  "exports": {
+    "require": "./dist/index.cjs",
+    "import": "./index.js"
+  },
+  "scripts": {
+    "prepack": "yarn build-cjs",
+    "build-cjs": "npx rollup --format=cjs --file=dist/index.cjs -- index.js"
+  },
   "dependencies": {
     "debug": "^2.6.9",
     "marky": "^1.2.2"


### PR DESCRIPTION
We need to do a patch release to restore cjs since the update today broke some folks downstream.

I packaged this logger and verified that chrome launcher passed all it's tests with it.