### PR TITLE
misc: support node 10 in lighthouse-logger

### DIFF
--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -1,8 +1,9 @@
 {
   "type": "module",
   "name": "lighthouse-logger",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "Apache-2.0",
+  "main": "./dist/index.cjs",
   "exports": {
     "require": "./dist/index.cjs",
     "import": "./index.js"


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/issues/15085

Old node/npm clients (Node 10) don't support `exports` so the fix in 1.4.1 didn't resolve the issue. We don't support node 10 anymore, but we haven't done a breaking release on `lighthouse-logger` since dropping node 10 support.

`exports` takes precedence over `main` so newer clients will still access the ESM version if they can but old clients can fall back to the CJS version by default.