### PR TITLE
report: append utm query params to stack pack links

### DIFF
--- a/report/renderer/category-renderer.js
+++ b/report/renderer/category-renderer.js
@@ -89,7 +89,9 @@ export class CategoryRenderer {
         packElmImg.src = pack.iconDataURL;
         packElmImg.alt = pack.title;
 
-        const snippets = this.dom.convertMarkdownLinkSnippets(pack.description);
+        const snippets = this.dom.convertMarkdownLinkSnippets(pack.description, {
+          alwaysAppendUtmSource: true,
+        });
         const packElm = this.dom.createElement('div', 'lh-audit__stackpack');
         packElm.append(packElmImg, snippets);
 

--- a/report/renderer/dom.js
+++ b/report/renderer/dom.js
@@ -127,9 +127,10 @@ export class DOM {
 
   /**
    * @param {string} text
+   * @param {{alwaysAppendUtmSource?: boolean}} opts
    * @return {Element}
    */
-  convertMarkdownLinkSnippets(text) {
+  convertMarkdownLinkSnippets(text, opts = {}) {
     const element = this.createElement('span');
 
     for (const segment of Util.splitMarkdownLink(text)) {
@@ -147,7 +148,7 @@ export class DOM {
       const url = new URL(segment.linkHref);
 
       const DOCS_ORIGINS = ['https://developers.google.com', 'https://web.dev', 'https://developer.chrome.com'];
-      if (DOCS_ORIGINS.includes(url.origin)) {
+      if (DOCS_ORIGINS.includes(url.origin) || opts.alwaysAppendUtmSource) {
         url.searchParams.set('utm_source', 'lighthouse');
         url.searchParams.set('utm_medium', this._lighthouseChannel);
       }

--- a/report/test/renderer/dom-test.js
+++ b/report/test/renderer/dom-test.js
@@ -171,6 +171,13 @@ describe('DOM', () => {
       const result = dom.convertMarkdownLinkSnippets(text);
       assert.equal(result.innerHTML, '<a rel="noopener" target="_blank" href="https://example.com/info">Learn more</a>.');
     });
+
+    it('doesn\'t append utm params to other (non-docs) origins (unless forced)', () => {
+      const text = '[Learn more](https://example.com/info).';
+
+      const result = dom.convertMarkdownLinkSnippets(text, {alwaysAppendUtmSource: true});
+      assert.equal(result.innerHTML, '<a rel="noopener" target="_blank" href="https://example.com/info?utm_source=lighthouse&amp;utm_medium=someChannel">Learn more</a>.');
+    });
   });
 
   describe('convertMarkdownCodeSnippets', () => {


### PR DESCRIPTION
This would be useful for external stack pack contributors.