### PR TITLE
deps: upgrade third-party-web to 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "robots-parser": "^3.0.0",
     "semver": "^5.3.0",
     "speedline-core": "^1.4.3",
-    "third-party-web": "^0.20.2",
+    "third-party-web": "^0.22.0",
     "ws": "^7.0.0",
     "yargs": "^17.3.1",
     "yargs-parser": "^21.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7031,10 +7031,10 @@ theredoc@^1.0.0:
   resolved "https://registry.yarnpkg.com/theredoc/-/theredoc-1.0.0.tgz#bcace376af6feb1873efbdd0f91ed026570ff062"
   integrity sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==
 
-third-party-web@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.20.2.tgz#62eb414c648e120f64aa16c926ba120a62cbd6c5"
-  integrity sha512-KFaFBDto+gH2DZW6ooFCGYrR8CGV6b/Ibsc2RTUkKhTPbxOWZuKs0NTftdAMoz0Aivf4bAHgW+kAGKciSQpqFg==
+third-party-web@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.22.0.tgz#4f4f7d25399099231bcd713500d15a75312a3e6c"
+  integrity sha512-n/s3QELstEQeIIuo9a+15dtsCMb9h/hDCQK/3O2oGUG8uxRsK+BJWQIHX/uq44Dr+VxsIVVgqHNmQ9CSyJU8ZA==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
https://github.com/patrickhulce/third-party-web/releases/tag/v0.21.0
https://github.com/patrickhulce/third-party-web/releases/tag/v0.22.0

Only relevant stuff seems to be new entities. A facade was incorrectly added and then removed.
