### PR TITLE
docs(readme): add unit test tips

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -297,6 +297,12 @@ for more info.
 # lint and test all files
 yarn test
 
+# run all unit tests
+yarn unit
+
+# run a given unit test (e.g. core/test/audits/byte-efficiency/uses-long-cache-ttl-test.js)
+yarn mocha uses-long-cache-ttl
+
 # watch for file changes and run tests
 #   Requires http://entrproject.org : brew install entr
 yarn watch


### PR DESCRIPTION
In this PR: 

- [x] Update `README.md` to describe how to run all unit tests (more prominently than previously) or, a given unit test