### PR TITLE
tests(smoke): add expectation for lcp-element

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -594,6 +594,31 @@ const expectations = {
           lcpLoadEnd: '7750+/-500',
         }}},
       },
+      'largest-contentful-paint-element': {
+        score: null,
+        displayValue: '1 element found',
+        details: {
+          items: [
+            {
+              items: [{
+                node: {
+                  type: 'node',
+                  nodeLabel: 'Do better web tester page',
+                  path: '2,HTML,1,BODY,9,DIV,2,H2',
+                },
+              }],
+            },
+            {
+              items: [
+                {timing: '>0'},
+                {timing: '>0'},
+                {timing: '>0'},
+                {timing: '>0'},
+              ],
+            },
+          ],
+        },
+      },
     },
     fullPageScreenshot: {
       screenshot: {


### PR DESCRIPTION
Smokerider did not catch the error from #15075 because we have no smoke tests that check `largest-contentful-paint-element` with simulated throttling.