### PR TITLE
tests(smoke): add expectations for network-rtt, network-server-latency

### DIFF
--- a/cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -468,7 +468,7 @@ if (location.search === '') {
 <script>window.fetch = () => new Promise(r => setTimeout(r, 90000));</script>
 
 <!-- FAIL(is-on-https): requires a non-localhost http file -->
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="http://0.0.0.0:10503/dobetterweb/third_party/fake-jquery.js"></script>
 
 <!-- Filesystem URL shouldn't be flagged is-on-https. -->
 <script>

--- a/cli/test/fixtures/dobetterweb/third_party/fake-jquery.js
+++ b/cli/test/fixtures/dobetterweb/third_party/fake-jquery.js
@@ -1,0 +1,1 @@
+window.$ = {fn: {jquery: '2.1.1'}};

--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -307,7 +307,7 @@ const expectations = {
         details: {
           items: [
             {
-              url: 'http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js',
+              url: 'http://0.0.0.0:10503/dobetterweb/third_party/fake-jquery.js',
               resolution: 'Allowed',
             },
           ],

--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -585,6 +585,22 @@ const expectations = {
           },
         },
       },
+      'network-rtt': {
+        details: {
+          items: [
+            {origin: 'http://localhost:10200', rtt: '>0'},
+            {origin: 'http://0.0.0.0:10503', rtt: '>0'},
+          ],
+        },
+      },
+      'network-server-latency': {
+        details: {
+          items: [
+            {origin: 'http://localhost:10200', serverResponseTime: '>0'},
+            {origin: 'http://0.0.0.0:10503', serverResponseTime: '>0'},
+          ],
+        },
+      },
       'metrics': {
         // Flaky in DevTools
         _excludeRunner: 'devtools',


### PR DESCRIPTION
We don't have any non-skipped smoke fixtures that test these two audits in Smokerider, which would have prevented #15075 (and alerted us years ago to that fact that these audits are always empty empty in LR) (eventually fixed in LR by #15091)

(note: #15111 lands first)