### PR TITLE
core(config): Throw an error if an onlyX filter is an empty array

### DIFF
--- a/core/config/filters.js
+++ b/core/config/filters.js
@@ -287,6 +287,12 @@ function filterConfigByGatherMode(resolvedConfig, mode) {
  */
 function filterConfigByExplicitFilters(resolvedConfig, filters) {
   const {onlyAudits, onlyCategories, skipAudits} = filters;
+  if (onlyAudits && !onlyAudits.length) {
+    throw new Error(`onlyAudits cannot be an empty array.`);
+  }
+  if (onlyCategories && !onlyCategories.length) {
+    throw new Error(`onlyCategories cannot be an empty array.`);
+  }
 
   warnOnUnknownOnlyCategories(resolvedConfig.categories, onlyCategories);
 

--- a/core/test/config/filters-test.js
+++ b/core/test/config/filters-test.js
@@ -634,5 +634,31 @@ describe('Fraggle Rock Config Filtering', () => {
         artifacts: [{id: 'Snapshot'}, {id: 'Timespan'}],
       });
     });
+
+    it('should not allow to pass an empty array to onlyAudits', () => {
+      resolvedConfig = {
+        ...resolvedConfig,
+      };
+      expect(() => {
+        filters.filterConfigByExplicitFilters(resolvedConfig, {
+          onlyAudits: [],
+          onlyCategories: null,
+          skipAudits: null,
+        });
+      }).toThrow('onlyAudits cannot be an empty array.');
+    });
+
+    it('should not allow to pass an empty array to onlyCategories', () => {
+      resolvedConfig = {
+        ...resolvedConfig,
+      };
+      expect(() => {
+        filters.filterConfigByExplicitFilters(resolvedConfig, {
+          onlyAudits: null,
+          onlyCategories: [],
+          skipAudits: null,
+        });
+      }).toThrow('onlyCategories cannot be an empty array.');
+    });
   });
 });


### PR DESCRIPTION
**Summary**
This is a bugfix, which fixes this issue:
https://github.com/GoogleChrome/lighthouse/issues/14986
Logic fix and relevant unit tests were added.

**Description**
_TLDR_: Throw an Error In case and empty array of `onlyCategories` / `onlyAudits` is passed

In the case an empty array of `onlyCategories` is passed, all categories are filtered (as only 0 categories are to be kept).
This results in an unexpected behavior, as an empty array might be interpreted as "don't filter anything".
Since passing an empty array serves no use, an error is thrown.

**TBD**
The original issue referred to throwing an error also for the case in which `audits` is left empty after filtering, however empty/missing `audits` is being handled in following code, and throwing an error breaks this logic. 
Throwing an error for empty `audits` also breaks 30 tests.

I would suggest not changing any `audits` logic, or logging a warning only.