### PR TITLE
core(index.cjs): make cjs index similar to esm one

### DIFF
--- a/core/index.cjs
+++ b/core/index.cjs
@@ -41,9 +41,97 @@ const snapshot = async function snapshot(...args) {
   return snapshot(...args);
 };
 
+/** @type {import('./index.js')['generateReport']} */
+const generateReport = async function generateReport(...args) {
+  const {generateReport} = await import('./index.js');
+  return generateReport(...args);
+};
+
+/** @type {import('./index.js')['auditFlowArtifacts']} */
+const auditFlowArtifacts = async function auditFlowArtifacts(...args) {
+  const {auditFlowArtifacts} = await import('./index.js');
+  return auditFlowArtifacts(...args);
+};
+
+/** @type {import('./index.js')['getAuditList']} */
+const getAuditList = async function getAuditList(...args) {
+  const {getAuditList} = await import('./index.js');
+  return getAuditList(...args);
+};
+
+/**
+ * @return {Promise<import('./index.js')['traceCategories']>} 
+ */
+const getTraceCategories = async function getTraceCategories() {
+  const {traceCategories} = await import('./index.js');
+
+  return traceCategories
+};
+
+/**
+ * @return {Promise<import('./index.js')['Audit']>} 
+ */
+const getAudit = async function getAudit() {
+  const {Audit} = await import('./index.js');
+  return Audit
+};
+
+/**
+ * @return {Promise<import('./index.js')['Gatherer']>} 
+ */
+const getGatherer = async function getGatherer() {
+  const {Gatherer} = await import('./index.js');
+  return Gatherer
+};
+
+/**
+ * @return {Promise<import('./index.js')['NetworkRecords']>} 
+ */
+const getNetworkRecords = async function getNetworkRecords() {
+  const {NetworkRecords} = await import('./index.js');
+  return NetworkRecords
+};
+
+/**
+ * @return {Promise<import('./index.js')['desktopConfig']>} 
+ */
+const getDesktopConfig = async function getDesktopConfig() {
+  const {desktopConfig} = await import('./index.js');
+  return desktopConfig
+};
+
+/**
+ * @return {Promise<import('./index.js')['defaultConfig']>} 
+ */
+const getDefaultConfig = async function getDefaultConfig() {
+  const {defaultConfig} = await import('./index.js');
+
+  return defaultConfig
+};
+
+/**
+ * @return {Promise<import('./index.js')>} 
+ */
+const asyncImport = async function asyncImport() {
+  const esm = await import('./index.js');
+  return esm
+};
+
 module.exports = lighthouse;
+module.exports.asyncImport = asyncImport
+module.exports.getAudit = getAudit;
+module.exports.getGatherer = getGatherer;
+module.exports.getNetworkRecords = getNetworkRecords;
+
+module.exports.getDesktopConfig = getDesktopConfig;
+module.exports.getDefaultConfig = getDefaultConfig;
+
 module.exports.legacyNavigation = legacyNavigation;
 module.exports.startFlow = startFlow;
 module.exports.navigation = navigation;
 module.exports.startTimespan = startTimespan;
 module.exports.snapshot = snapshot;
+module.exports.generateReport = generateReport;
+module.exports.auditFlowArtifacts = auditFlowArtifacts;
+module.exports.getAuditList = getAuditList;
+module.exports.getTraceCategories = getTraceCategories;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
- Methods mirrored, properties made as getters.
- I have also included the possibility to import whole esm index (`asyncImport` method).
- Feel free to edit the code

**Related Issues/PRs**
https://github.com/GoogleChrome/lighthouse/issues/15130
