### PR TITLE
tests(smoke): expect server-response-time to be greater than 0

### DIFF
--- a/cli/test/smokehouse/test-definitions/perf-preload.js
+++ b/cli/test/smokehouse/test-definitions/perf-preload.js
@@ -93,7 +93,7 @@ const expectations = {
       },
       'server-response-time': {
         // Assert greater than 0 but not more than 1000.
-        numericValue: '500 +/- 499',
+        numericValue: '500 +/- 499.99',
       },
       'network-requests': {
         details: {

--- a/cli/test/smokehouse/test-definitions/perf-preload.js
+++ b/cli/test/smokehouse/test-definitions/perf-preload.js
@@ -92,8 +92,8 @@ const expectations = {
         score: '>=0.90', // primarily just making sure it didn't fail/go crazy, specific value isn't that important
       },
       'server-response-time': {
-        // Can be flaky, so test float numericValue instead of binary score
-        numericValue: '<1000',
+        // Assert greater than 0 but not more than 1000.
+        numericValue: '500 +/- 499',
       },
       'network-requests': {
         details: {


### PR DESCRIPTION
This audit being zero is a sign of a bug, which is the current behavior in PSI.