### PR TITLE
core: support ts targets before es2022

### DIFF
--- a/core/lib/lh-error.js
+++ b/core/lib/lh-error.js
@@ -111,11 +111,16 @@ const ERROR_SENTINEL = '__ErrorSentinel';
  * @typedef {{sentinel: '__ErrorSentinel', message: string, code?: string, stack?: string, cause?: unknown}} SerializedBaseError
  */
 
+/**
+ * The {@link ErrorOptions} type wasn't added until es2022 (Node 16), so we recreate it here to support ts targets before es2022.
+ * @typedef {{cause: unknown}} LHErrorOptions
+ */
+
 class LighthouseError extends Error {
   /**
    * @param {LighthouseErrorDefinition} errorDefinition
    * @param {Record<string, string|undefined>=} properties
-   * @param {ErrorOptions=} options
+   * @param {LHErrorOptions=} options
    */
   constructor(errorDefinition, properties, options) {
     super(errorDefinition.code, options);

--- a/core/lib/lh-error.js
+++ b/core/lib/lh-error.js
@@ -113,6 +113,7 @@ const ERROR_SENTINEL = '__ErrorSentinel';
 
 /**
  * The {@link ErrorOptions} type wasn't added until es2022 (Node 16), so we recreate it here to support ts targets before es2022.
+ * TODO: Just use `ErrorOptions` if we can't support targets before es2022 in the docs test.
  * @typedef {{cause: unknown}} LHErrorOptions
  */
 

--- a/docs/recipes/type-checking/package.json
+++ b/docs/recipes/type-checking/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "tsc && tsc --moduleResolution node"
+    "test": "tsc && tsc --moduleResolution node && tsc --target es2020"
   },
   "devDependencies": {
     "lighthouse": "file:../../../dist/lighthouse.tgz",


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/15186

It's a pretty simple fix, but the `options` param on `Error` was first added in Node 16 which is our minimum node version. If someone encounters a type error like in #15186, is that just a sign that their ts target is too old for us to support?
