### PR TITLE
core(long-tasks): add more task information to debugData

### DIFF
--- a/core/audits/long-tasks.js
+++ b/core/audits/long-tasks.js
@@ -14,6 +14,9 @@ import {getJavaScriptURLs, getAttributableURLForTask} from '../lib/tracehouse/ta
 
 /** We don't always have timing data for short tasks, if we're missing timing data. Treat it as though it were 0ms. */
 const DEFAULT_TIMING = {startTime: 0, endTime: 0, duration: 0};
+const DISPLAYED_TASK_COUNT = 20;
+// 99% of the May 2023 HTTP Archive run had fewer than 150 long tasks.
+const DEBUG_TASK_COUNT = 150;
 
 const UIStrings = {
   /** Title of a diagnostic LH audit that provides details on the longest running tasks that occur when the page loads. */
@@ -31,6 +34,30 @@ const UIStrings = {
 
 const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
+/**
+ * Insert `url` into `urls` array if not already present. Returns
+ * the index of `url` in `urls` for later lookup.
+ * @param {Array<string>} urls
+ * @param {string} url
+ */
+function insertUrl(urls, url) {
+  const index = urls.indexOf(url);
+  if (index > -1) return index;
+  return urls.push(url) - 1;
+}
+
+/**
+ * @param {number} value
+ * @return {number}
+ */
+function roundTenths(value) {
+  return Math.round(value * 10) / 10;
+}
+
+/** @typedef {import('../lib/tracehouse/task-groups.js').TaskGroupIds} TaskGroupIds */
+/** @typedef {{startTime: number, duration: number}} Timing */
+/** @typedef {Timing & {urlIndex: number, [p: string]: number}} DebugTask */
+
 class LongTasks extends Audit {
   /**
    * @return {LH.Audit.Meta}
@@ -46,6 +73,102 @@ class LongTasks extends Audit {
   }
 
   /**
+   * Returns the timing information for the given task, recursively walking the
+   * task's children and adding up time spent in each type of task activity.
+   * If `taskTimingsByEvent` is present, it will be used for task timing instead
+   * of the timings on the tasks themselves.
+   * If `timeByTaskGroup` is not provided, a new Map will be populated with
+   * timing breakdown; if one is provided, timing breakdown will be added to the
+   * existing breakdown.
+   *
+   * TODO: when simulated, a significant number of child tasks are dropped, so
+   * most time will be attributed to 'other' (the category of the top-level
+   * RunTask). See pruning in `PageDependencyGraph.linkCPUNodes`.
+   * @param {LH.Artifacts.TaskNode} task
+   * @param {Map<LH.TraceEvent, LH.Gatherer.Simulation.NodeTiming>|undefined} taskTimingsByEvent
+   * @param {Map<TaskGroupIds, number>} [timeByTaskGroup]
+   * @return {{startTime: number, duration: number, timeByTaskGroup: Map<TaskGroupIds, number>}}
+   */
+  static getTimingBreakdown(task, taskTimingsByEvent, timeByTaskGroup = new Map()) {
+    const taskTiming = LongTasks.getTiming(task, taskTimingsByEvent);
+
+    // Add up child time, while recursively stepping in to accumulate group times.
+    let childrenTime = 0;
+    if (taskTiming.duration > 0) {
+      for (const child of task.children) {
+        const {duration} = LongTasks.getTimingBreakdown(child, taskTimingsByEvent, timeByTaskGroup);
+        childrenTime += duration;
+      }
+    }
+
+    // Add this task's selfTime to its group's total time.
+    const selfTime = taskTiming.duration - childrenTime;
+    const taskGroupTime = timeByTaskGroup.get(task.group.id) || 0;
+    timeByTaskGroup.set(task.group.id, taskGroupTime + selfTime);
+
+    return {
+      startTime: taskTiming.startTime,
+      duration: taskTiming.duration,
+      timeByTaskGroup,
+    };
+  }
+
+  /**
+   * @param {Array<LH.Artifacts.TaskNode>} longTasks
+   * @param {Set<string>} jsUrls
+   * @param {Map<LH.TraceEvent, LH.Gatherer.Simulation.NodeTiming>|undefined} taskTimingsByEvent
+   * @return {LH.Audit.Details.DebugData}
+   */
+  static makeDebugData(longTasks, jsUrls, taskTimingsByEvent) {
+    /** @type {Array<string>} */
+    const urls = [];
+    /** @type {Array<DebugTask>} */
+    const tasks = [];
+
+    for (const longTask of longTasks) {
+      const attributableUrl = getAttributableURLForTask(longTask, jsUrls);
+
+      const {startTime, duration, timeByTaskGroup} =
+          LongTasks.getTimingBreakdown(longTask, taskTimingsByEvent);
+
+      // Round time per group and sort entries so order is consistent.
+      const timeByTaskGroupEntries = [...timeByTaskGroup]
+        .map(/** @return {[TaskGroupIds, number]} */ ([group, time]) => [group, roundTenths(time)])
+        .sort((a, b) => a[0].localeCompare(b[0]));
+
+      tasks.push({
+        urlIndex: insertUrl(urls, attributableUrl),
+        startTime: roundTenths(startTime),
+        duration: roundTenths(duration),
+        ...Object.fromEntries(timeByTaskGroupEntries),
+      });
+    }
+
+    return {
+      type: 'debugdata',
+      urls,
+      tasks,
+    };
+  }
+
+  /**
+   * Get timing from task, overridden by taskTimingsByEvent if provided.
+   * @param {LH.Artifacts.TaskNode} task
+   * @param {Map<LH.TraceEvent, LH.Gatherer.Simulation.NodeTiming>|undefined} taskTimingsByEvent
+   * @return {Timing}
+   */
+  static getTiming(task, taskTimingsByEvent) {
+    /** @type {Timing} */
+    let timing = task;
+    if (taskTimingsByEvent) {
+      timing = taskTimingsByEvent.get(task.event) || DEFAULT_TIMING;
+    }
+
+    const {duration, startTime} = timing;
+    return {duration, startTime};
+  }
+
+  /**
    * @param {LH.Artifacts} artifacts
    * @param {LH.Audit.Context} context
    * @return {Promise<LH.Audit.Product>}
@@ -58,10 +181,12 @@ class LongTasks extends Audit {
     const devtoolsLog = artifacts.devtoolsLogs[LongTasks.DEFAULT_PASS];
     const networkRecords = await NetworkRecords.request(devtoolsLog, context);
 
-    /** @type {Map<LH.TraceEvent, LH.Gatherer.Simulation.NodeTiming>} */
-    const taskTimingsByEvent = new Map();
+    /** @type {Map<LH.TraceEvent, LH.Gatherer.Simulation.NodeTiming>|undefined} */
+    let taskTimingsByEvent;
 
     if (settings.throttlingMethod === 'simulate') {
+      taskTimingsByEvent = new Map();
+
       const simulatorOptions = {devtoolsLog, settings: context.settings};
       const pageGraph = await PageDependencyGraph.request({trace, devtoolsLog, URL}, context);
       const simulator = await LoadSimulator.request(simulatorOptions, context);
@@ -70,30 +195,32 @@ class LongTasks extends Audit {
         if (node.type !== 'cpu') continue;
         taskTimingsByEvent.set(node.event, timing);
       }
-    } else {
-      for (const task of tasks) {
-        if (task.unbounded || task.parent) continue;
-        taskTimingsByEvent.set(task.event, task);
-      }
     }
 
     const jsURLs = getJavaScriptURLs(networkRecords);
-    // Only consider up to 20 long, top-level (no parent) tasks that have an explicit endTime
-    const longtasks = tasks
-      .map(t => {
-        const timing = taskTimingsByEvent.get(t.event) || DEFAULT_TIMING;
-        return {...t, duration: timing.duration, startTime: timing.startTime};
+
+    // Only consider top-level (no parent) long tasks that have an explicit endTime.
+    const longTasks = tasks
+      .map(task => {
+        // Use duration from simulation, if available.
+        const {duration} = LongTasks.getTiming(task, taskTimingsByEvent);
+        return {task, duration};
       })
-      .filter(t => t.duration >= 50 && !t.unbounded && !t.parent)
+      .filter(({task, duration}) => {
+        return duration >= 50 && !task.unbounded && !task.parent;
+      })
       .sort((a, b) => b.duration - a.duration)
-      .slice(0, 20);
+      .map(({task}) => task);
 
     // TODO(beytoven): Add start time that matches with the simulated throttling
-    const results = longtasks.map(task => ({
-      url: getAttributableURLForTask(task, jsURLs),
-      duration: task.duration,
-      startTime: task.startTime,
-    }));
+    const results = longTasks.map(task => {
+      const timing = LongTasks.getTiming(task, taskTimingsByEvent);
+      return {
+        url: getAttributableURLForTask(task, jsURLs),
+        duration: timing.duration,
+        startTime: timing.startTime,
+      };
+    }).slice(0, DISPLAYED_TASK_COUNT);
 
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [
@@ -107,6 +234,9 @@ class LongTasks extends Audit {
     const tableDetails = Audit.makeTableDetails(headings, results,
       {sortedBy: ['duration'], skipSumming: ['startTime']});
 
+    const debugTasks = longTasks.splice(0, DEBUG_TASK_COUNT);
+    tableDetails.debugData = LongTasks.makeDebugData(debugTasks, jsURLs, taskTimingsByEvent);
+
     let displayValue;
     if (results.length > 0) {
       displayValue = str_(UIStrings.displayValue, {itemCount: results.length});
@@ -114,7 +244,6 @@ class LongTasks extends Audit {
 
     return {
       score: results.length === 0 ? 1 : 0,
-      notApplicable: results.length === 0,
       details: tableDetails,
       displayValue,
     };

--- a/core/audits/long-tasks.js
+++ b/core/audits/long-tasks.js
@@ -244,6 +244,7 @@ class LongTasks extends Audit {
 
     return {
       score: results.length === 0 ? 1 : 0,
+      notApplicable: results.length === 0,
       details: tableDetails,
       displayValue,
     };

--- a/core/audits/long-tasks.js
+++ b/core/audits/long-tasks.js
@@ -15,8 +15,6 @@ import {getJavaScriptURLs, getAttributableURLForTask} from '../lib/tracehouse/ta
 /** We don't always have timing data for short tasks, if we're missing timing data. Treat it as though it were 0ms. */
 const DEFAULT_TIMING = {startTime: 0, endTime: 0, duration: 0};
 const DISPLAYED_TASK_COUNT = 20;
-// 99% of the May 2023 HTTP Archive run had fewer than 150 long tasks.
-const DEBUG_TASK_COUNT = 150;
 
 const UIStrings = {
   /** Title of a diagnostic LH audit that provides details on the longest running tasks that occur when the page loads. */
@@ -234,8 +232,7 @@ class LongTasks extends Audit {
     const tableDetails = Audit.makeTableDetails(headings, results,
       {sortedBy: ['duration'], skipSumming: ['startTime']});
 
-    const debugTasks = longTasks.splice(0, DEBUG_TASK_COUNT);
-    tableDetails.debugData = LongTasks.makeDebugData(debugTasks, jsURLs, taskTimingsByEvent);
+    tableDetails.debugData = LongTasks.makeDebugData(longTasks, jsURLs, taskTimingsByEvent);
 
     let displayValue;
     if (results.length > 0) {

--- a/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
+++ b/core/test/fixtures/fraggle-rock/reports/sample-flow-result.json
@@ -1825,7 +1825,38 @@
               ],
               "skipSumming": [
                 "startTime"
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "urls": [
+                  "https://www.mikescerealshack.co/_next/static/chunks/framework.9d524150d48315f49e80.js",
+                  "https://www.mikescerealshack.co/"
+                ],
+                "tasks": [
+                  {
+                    "urlIndex": 0,
+                    "startTime": 2135.7,
+                    "duration": 193,
+                    "other": 193,
+                    "scriptEvaluation": 0
+                  },
+                  {
+                    "urlIndex": 1,
+                    "startTime": 769.8,
+                    "duration": 127,
+                    "other": 127,
+                    "scriptEvaluation": 0
+                  },
+                  {
+                    "urlIndex": 1,
+                    "startTime": 965.8,
+                    "duration": 96,
+                    "other": 96,
+                    "paintCompositeRender": 0,
+                    "styleLayout": 0
+                  }
+                ]
+              }
             }
           },
           "no-unload-listeners": {
@@ -9393,7 +9424,24 @@
               ],
               "skipSumming": [
                 "startTime"
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "urls": [
+                  "https://www.mikescerealshack.co/"
+                ],
+                "tasks": [
+                  {
+                    "urlIndex": 0,
+                    "startTime": 1903.2,
+                    "duration": 172.8,
+                    "other": 2,
+                    "parseHTML": 0.1,
+                    "scriptEvaluation": 150.2,
+                    "styleLayout": 20.5
+                  }
+                ]
+              }
             }
           },
           "no-unload-listeners": {
@@ -18611,7 +18659,30 @@
               ],
               "skipSumming": [
                 "startTime"
-              ]
+              ],
+              "debugData": {
+                "type": "debugdata",
+                "urls": [
+                  "https://www.mikescerealshack.co/_next/static/chunks/framework.9d524150d48315f49e80.js",
+                  "https://www.mikescerealshack.co/_next/static/chunks/main-1f8481d632114a408557.js"
+                ],
+                "tasks": [
+                  {
+                    "urlIndex": 0,
+                    "startTime": 907.7,
+                    "duration": 76,
+                    "other": 76,
+                    "scriptEvaluation": 0
+                  },
+                  {
+                    "urlIndex": 1,
+                    "startTime": 752.7,
+                    "duration": 63,
+                    "other": 63,
+                    "scriptEvaluation": 0
+                  }
+                ]
+              }
             }
           },
           "no-unload-listeners": {

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -2558,7 +2558,36 @@
         ],
         "skipSumming": [
           "startTime"
-        ]
+        ],
+        "debugData": {
+          "type": "debugdata",
+          "urls": [
+            "http://localhost:10200/dobetterweb/dbw_tester.html",
+            "http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js"
+          ],
+          "tasks": [
+            {
+              "urlIndex": 0,
+              "startTime": 6845.8,
+              "duration": 1174.9,
+              "other": 0.8,
+              "parseHTML": 0.6,
+              "scriptEvaluation": 1170.7,
+              "scriptParseCompile": 2.5,
+              "styleLayout": 0.2
+            },
+            {
+              "urlIndex": 1,
+              "startTime": 8044.8,
+              "duration": 145.8,
+              "other": 0.1,
+              "parseHTML": 13.5,
+              "scriptEvaluation": 120.7,
+              "scriptParseCompile": 10.4,
+              "styleLayout": 1.2
+            }
+          ]
+        }
       }
     },
     "no-unload-listeners": {


### PR DESCRIPTION
The `long-tasks` audit lists the 20 longest tasks, attributed to specific URLs when possible. This makes sense in the HTML report, where these 20 are typically representative of the worst behavior, and any more would risk overwhelming any prioritization it provides.

However, when doing analysis using HTTP Archive, you often want _all_ the long tasks, to see where first and third parties are spending time when blocking the main thread. Meanwhile, you often want to see how time was spent during that task (all js? lengthy layout? etc), which today we only provide in aggregate in `mainthread-work-breakdown`, not per task or per URL (`third-party-summary` has yet another summary with slightly different information summed up per third-party URL).

This PR extends the `debugData` associated with the `long-tasks` audit to include more long tasks and include a breakdown of how time was spent during each long task (similar to some of the [breakdown LoAF will provide](https://github.com/w3c/longtasks/blob/main/loaf-explainer.md#how-a-loaf-entry-might-look-like)).

As an example, here's the debug data taken from `sample_v2`:
```js
{
  type: 'debugdata',
  urls: [
    'http://localhost:10200/dobetterweb/dbw_tester.html',
    'http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js',
  ],
  tasks: [
    {
      urlIndex: 0,
      startTime: 6845.8,
      duration: 1174.9,
      other: 0.8,
      parseHTML: 0.6,
      scriptEvaluation: 1170.7,
      scriptParseCompile: 2.5,
      styleLayout: 0.2
    },
    {
      urlIndex: 1,
      startTime: 8044.8,
      duration: 145.8,
      other: 0.1,
      parseHTML: 13.5,
      scriptEvaluation: 120.7,
      scriptParseCompile: 10.4,
      styleLayout: 1.2
    }
  ]
}
```
Often the biggest thing in the LHR is the URLs, so this keeps them in a separate array and has each entry index into it so that URLs are listed at most once.

