### PR TITLE
core(source-maps): support BOM markers and CORB prefix

### DIFF
--- a/core/computed/js-bundles.js
+++ b/core/computed/js-bundles.js
@@ -99,7 +99,7 @@ class JSBundles {
 
       const compiledUrl = SourceMap.scriptUrl || 'compiled.js';
       const mapUrl = SourceMap.sourceMapUrl || 'compiled.js.map';
-      const map = new SDK.TextSourceMap(compiledUrl, mapUrl, rawMap);
+      const map = new SDK.SourceMap(compiledUrl, mapUrl, rawMap);
 
       const sizes = computeGeneratedFileSizes(map, script.length || 0, script.content || '');
 

--- a/core/gather/gatherers/source-maps.js
+++ b/core/gather/gatherers/source-maps.js
@@ -4,6 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+import SDK from '../../lib/cdt/SDK.js';
 import FRGatherer from '../base-gatherer.js';
 
 /**
@@ -32,7 +33,7 @@ class SourceMaps extends FRGatherer {
     if (response.content === null) {
       throw new Error(`Failed fetching source map (${response.status})`);
     }
-    return JSON.parse(response.content);
+    return SDK.SourceMap.parseSourceMap(response.content);
   }
 
   /**
@@ -41,7 +42,7 @@ class SourceMaps extends FRGatherer {
    */
   parseSourceMapFromDataUrl(sourceMapURL) {
     const buffer = Buffer.from(sourceMapURL.split(',')[1], 'base64');
-    return JSON.parse(buffer.toString());
+    return SDK.SourceMap.parseSourceMap(buffer.toString());
   }
 
   /**

--- a/core/lib/cdt/SDK.js
+++ b/core/lib/cdt/SDK.js
@@ -5,12 +5,12 @@
  */
 
 const SDK = {
-  TextSourceMap: require('./generated/SourceMap.js'),
+  SourceMap: require('./generated/SourceMap.js'),
 };
 
 // Add `lastColumnNumber` to mappings. This will eventually be added to CDT.
 // @ts-expect-error
-SDK.TextSourceMap.prototype.computeLastGeneratedColumns = function() {
+SDK.SourceMap.prototype.computeLastGeneratedColumns = function() {
   const mappings = this.mappings();
   if (mappings.length && mappings[0].lastColumnNumber !== undefined) return;
 

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -11,7 +11,7 @@ import {Simulator} from '../core/lib/dependency-graph/simulator/simulator.js';
 import {LighthouseError} from '../core/lib/lh-error.js';
 import {NetworkRequest as _NetworkRequest} from '../core/lib/network-request.js';
 import speedline from 'speedline-core';
-import * as TextSourceMap from '../core/lib/cdt/generated/SourceMap.js';
+import * as CDTSourceMap from '../core/lib/cdt/generated/SourceMap.js';
 import {ArbitraryEqualityMap} from '../core/lib/arbitrary-equality-map.js';
 import type { TaskNode as _TaskNode } from '../core/lib/tracehouse/main-thread-tasks.js';
 import AuditDetails from './lhr/audit-details.js'
@@ -388,7 +388,7 @@ declare module Artifacts {
   interface Bundle {
     rawMap: RawSourceMap;
     script: Artifacts.Script;
-    map: TextSourceMap;
+    map: CDTSourceMap;
     sizes: {
       // TODO(cjamcl): Rename to `sources`.
       files: Record<string, number>;


### PR DESCRIPTION
Plus a driveby rename of TextSourceMap -> SourceMap, to match the original code.