### PR TITLE
core: update residual usages of legacy runner

### DIFF
--- a/core/config/config-helpers.js
+++ b/core/config/config-helpers.js
@@ -20,7 +20,7 @@ import {getModuleDirectory} from '../../esm-utils.js';
 
 const require = createRequire(import.meta.url);
 
-/** @typedef {typeof import('../gather/gatherers/gatherer.js').Gatherer} GathererConstructor */
+/** @typedef {typeof import('../gather/base-gatherer.js').default} GathererConstructor */
 /** @typedef {typeof import('../audits/audit.js')['Audit']} Audit */
 /** @typedef {InstanceType<GathererConstructor>} Gatherer */
 
@@ -160,7 +160,7 @@ function mergeConfigFragmentArrayByKey(baseArray, extensionArray, keyFn) {
  *  - {instance: myGathererInstance}
  *
  * @param {LH.Config.GathererJson} gatherer
- * @return {{instance?: Gatherer, implementation?: GathererConstructor, path?: string}} passes
+ * @return {{instance?: Gatherer, implementation?: GathererConstructor, path?: string}}
  */
 function expandGathererShorthand(gatherer) {
   if (typeof gatherer === 'string') {
@@ -178,7 +178,7 @@ function expandGathererShorthand(gatherer) {
   } else if (typeof gatherer === 'function') {
     // just GathererConstructor
     return {implementation: gatherer};
-  } else if (gatherer && typeof gatherer.beforePass === 'function') {
+  } else if (gatherer && typeof gatherer.getArtifact === 'function') {
     // just GathererInstance
     return {instance: gatherer};
   } else {
@@ -595,13 +595,6 @@ function deepCloneConfigJson(json) {
 
   // Copy arrays that could contain non-serializable properties to allow for programmatic
   // injection of audit and gatherer implementations.
-  if (Array.isArray(cloned.passes) && Array.isArray(json.passes)) {
-    for (let i = 0; i < cloned.passes.length; i++) {
-      const pass = cloned.passes[i];
-      pass.gatherers = (json.passes[i].gatherers || []).map(gatherer => shallowClone(gatherer));
-    }
-  }
-
   if (Array.isArray(json.audits)) {
     cloned.audits = json.audits.map(audit => shallowClone(audit));
   }

--- a/core/config/config-helpers.js
+++ b/core/config/config-helpers.js
@@ -20,7 +20,7 @@ import {getModuleDirectory} from '../../esm-utils.js';
 
 const require = createRequire(import.meta.url);
 
-/** @typedef {typeof import('../gather/base-gatherer.js').default} GathererConstructor */
+/** @typedef {typeof import('../gather/gatherers/gatherer.js').Gatherer} GathererConstructor */
 /** @typedef {typeof import('../audits/audit.js')['Audit']} Audit */
 /** @typedef {InstanceType<GathererConstructor>} Gatherer */
 
@@ -160,7 +160,7 @@ function mergeConfigFragmentArrayByKey(baseArray, extensionArray, keyFn) {
  *  - {instance: myGathererInstance}
  *
  * @param {LH.Config.GathererJson} gatherer
- * @return {{instance?: Gatherer, implementation?: GathererConstructor, path?: string}}
+ * @return {{instance?: Gatherer, implementation?: GathererConstructor, path?: string}} passes
  */
 function expandGathererShorthand(gatherer) {
   if (typeof gatherer === 'string') {
@@ -178,7 +178,7 @@ function expandGathererShorthand(gatherer) {
   } else if (typeof gatherer === 'function') {
     // just GathererConstructor
     return {implementation: gatherer};
-  } else if (gatherer && typeof gatherer.getArtifact === 'function') {
+  } else if (gatherer && typeof gatherer.beforePass === 'function') {
     // just GathererInstance
     return {instance: gatherer};
   } else {
@@ -595,6 +595,13 @@ function deepCloneConfigJson(json) {
 
   // Copy arrays that could contain non-serializable properties to allow for programmatic
   // injection of audit and gatherer implementations.
+  if (Array.isArray(cloned.passes) && Array.isArray(json.passes)) {
+    for (let i = 0; i < cloned.passes.length; i++) {
+      const pass = cloned.passes[i];
+      pass.gatherers = (json.passes[i].gatherers || []).map(gatherer => shallowClone(gatherer));
+    }
+  }
+
   if (Array.isArray(json.audits)) {
     cloned.audits = json.audits.map(audit => shallowClone(audit));
   }

--- a/core/config/filters.js
+++ b/core/config/filters.js
@@ -169,9 +169,9 @@ function filterAuditsByGatherMode(audits, mode) {
 /**
  * Optional `supportedModes` property can explicitly exclude a category even if some audits are available.
  *
- * @param {LH.Config.LegacyResolvedConfig['categories']} categories
+ * @param {LH.Config.ResolvedConfig['categories']} categories
  * @param {LH.Gatherer.GatherMode} mode
- * @return {LH.Config.LegacyResolvedConfig['categories']}
+ * @return {LH.Config.ResolvedConfig['categories']}
  */
 function filterCategoriesByGatherMode(categories, mode) {
   if (!categories) return null;
@@ -186,9 +186,9 @@ function filterCategoriesByGatherMode(categories, mode) {
 /**
  * Filters a categories object and their auditRefs down to the specified category ids.
  *
- * @param {LH.Config.LegacyResolvedConfig['categories']} categories
+ * @param {LH.Config.ResolvedConfig['categories']} categories
  * @param {string[] | null | undefined} onlyCategories
- * @return {LH.Config.LegacyResolvedConfig['categories']}
+ * @return {LH.Config.ResolvedConfig['categories']}
  */
 function filterCategoriesByExplicitFilters(categories, onlyCategories) {
   if (!categories || !onlyCategories) return categories;
@@ -202,7 +202,7 @@ function filterCategoriesByExplicitFilters(categories, onlyCategories) {
  * Logs a warning if any specified onlyCategory is not a known category that can
  * be included.
  *
- * @param {LH.Config.LegacyResolvedConfig['categories']} allCategories
+ * @param {LH.Config.ResolvedConfig['categories']} allCategories
  * @param {string[] | null} onlyCategories
  * @return {void}
  */
@@ -220,9 +220,9 @@ function warnOnUnknownOnlyCategories(allCategories, onlyCategories) {
  * Filters a categories object and their auditRefs down to the set that can be computed using
  * only the specified audits.
  *
- * @param {LH.Config.LegacyResolvedConfig['categories']} categories
+ * @param {LH.Config.ResolvedConfig['categories']} categories
  * @param {Array<LH.Config.AuditDefn>} availableAudits
- * @return {LH.Config.LegacyResolvedConfig['categories']}
+ * @return {LH.Config.ResolvedConfig['categories']}
  */
 function filterCategoriesByAvailableAudits(categories, availableAudits) {
   if (!categories) return categories;

--- a/core/gather/gatherers/seo/font-size.js
+++ b/core/gather/gatherers/seo/font-size.js
@@ -22,7 +22,6 @@ const MINIMAL_LEGIBLE_FONT_SIZE_PX = 12;
 // limit number of protocol calls to make sure that gatherer doesn't take more than 1-2s
 const MAX_NODES_SOURCE_RULE_FETCHED = 50; // number of nodes to fetch the source font-size rule
 
-/** @typedef {import('../../../legacy/gather/driver.js')} Driver */
 /** @typedef {LH.Artifacts.FontSize['analyzedFailingNodesData'][0]} NodeFontData */
 /** @typedef {Map<number, {fontSize: number, textLength: number}>} BackendIdsToFontData */
 

--- a/core/lib/navigation-error.js
+++ b/core/lib/navigation-error.js
@@ -110,7 +110,7 @@ function getNonHtmlError(finalRecord) {
  * Returns an error if the page load should be considered failed, e.g. from a
  * main document request failure, a security issue, etc.
  * @param {LH.LighthouseError|undefined} navigationError
- * @param {{url: string, loadFailureMode: LH.Gatherer.PassContext['passConfig']['loadFailureMode'], networkRecords: Array<LH.Artifacts.NetworkRequest>, warnings: Array<string | LH.IcuMessage>}} context
+ * @param {{url: string, loadFailureMode: LH.Config.SharedPassNavigationJson['loadFailureMode'], networkRecords: Array<LH.Artifacts.NetworkRequest>, warnings: Array<string | LH.IcuMessage>}} context
  * @return {LH.LighthouseError|undefined}
  */
 function getPageLoadError(navigationError, context) {


### PR DESCRIPTION
I did a dry run of removing the legacy runner. These places are using legacy code and/or types but don't need to.
