### PR TITLE
tests: remove usages of legacy driver

### DIFF
--- a/core/test/gather/driver/navigation-test.js
+++ b/core/test/gather/driver/navigation-test.js
@@ -6,13 +6,10 @@
 
 import {createMockDriver} from '../mock-driver.js';
 import {
-  mockCommands,
   makePromiseInspectable,
   flushAllTimersAndMicrotasks,
   timers,
 } from '../../test-utils.js';
-
-const {createMockOnceFn} = mockCommands;
 
 // Some imports needs to be done dynamically, so that their dependencies will be mocked.
 // https://github.com/GoogleChrome/lighthouse/blob/main/docs/hacking-tips.md#mocking-modules-with-testdouble
@@ -41,7 +38,7 @@ describe('.gotoURL', () => {
   });
 
   it('will track redirects through gotoURL load with warning', async () => {
-    mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
 
     const url = 'http://example.com';
 
@@ -93,7 +90,7 @@ describe('.gotoURL', () => {
   });
 
   it('backfills requestedUrl when using a callback requestor', async () => {
-    mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
 
     const requestor = () => Promise.resolve();
 
@@ -112,7 +109,7 @@ describe('.gotoURL', () => {
   });
 
   it('throws if no navigations found using a callback requestor', async () => {
-    mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
 
     const requestor = () => Promise.resolve();
 
@@ -131,7 +128,7 @@ describe('.gotoURL', () => {
   });
 
   it('does not add warnings when URLs are equal', async () => {
-    mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
 
     const url = 'https://www.example.com';
 
@@ -147,7 +144,7 @@ describe('.gotoURL', () => {
   });
 
   it('waits for Page.frameNavigated', async () => {
-    mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
 
     const url = 'https://www.example.com';
 
@@ -165,7 +162,7 @@ describe('.gotoURL', () => {
   });
 
   it('waits for page load', async () => {
-    mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
 
     const url = 'https://www.example.com';
 
@@ -194,7 +191,7 @@ describe('.gotoURL', () => {
   });
 
   it('waits for page FCP', async () => {
-    mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
 
     const url = 'https://www.example.com';
 
@@ -228,7 +225,7 @@ describe('.gotoURL', () => {
   });
 
   it('throws when asked to wait for FCP without waiting for load', async () => {
-    mockDriver.defaultSession.on = mockDriver.defaultSession.once = createMockOnceFn();
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
 
     const url = 'https://www.example.com';
 

--- a/core/test/gather/driver/wait-for-condition-test.js
+++ b/core/test/gather/driver/wait-for-condition-test.js
@@ -8,16 +8,13 @@ import log from 'lighthouse-logger';
 
 import * as wait from '../../../gather/driver/wait-for-condition.js';
 import {
-  mockCommands,
   makePromiseInspectable,
   flushAllTimersAndMicrotasks,
   createDecomposedPromise,
   fnAny,
   timers,
 } from '../../test-utils.js';
-
-const {createMockOnceFn} = mockCommands;
-
+import {createMockSession} from '../mock-driver.js';
 
 function createMockWaitForFn() {
   const {promise, resolve, reject} = createDecomposedPromise();
@@ -256,18 +253,11 @@ describe('waitForFcp()', () => {
   let session;
 
   beforeEach(() => {
-    session = {
-      on: fnAny(),
-      once: fnAny(),
-      off: fnAny(),
-      sendCommand: fnAny(),
-    };
+    session = createMockSession();
   });
 
 
   it('should not resolve until FCP fires', async () => {
-    session.on = session.once = createMockOnceFn();
-
     const waitPromise = makePromiseInspectable(wait.waitForFcp(session, 0, 60 * 1000).promise);
     const listener = session.on.findListener('Page.lifecycleEvent');
 
@@ -285,8 +275,6 @@ describe('waitForFcp()', () => {
   });
 
   it('should wait for pauseAfterFcpMs after FCP', async () => {
-    session.on = session.once = createMockOnceFn();
-
     const waitPromise = makePromiseInspectable(wait.waitForFcp(session, 5000, 60 * 1000).promise);
     const listener = session.on.findListener('Page.lifecycleEvent');
 
@@ -305,8 +293,6 @@ describe('waitForFcp()', () => {
   });
 
   it('should timeout', async () => {
-    session.on = session.once = createMockOnceFn();
-
     const waitPromise = makePromiseInspectable(wait.waitForFcp(session, 0, 5000).promise);
 
     await flushAllTimersAndMicrotasks();
@@ -319,9 +305,6 @@ describe('waitForFcp()', () => {
   });
 
   it('should be cancellable', async () => {
-    session.on = session.once = createMockOnceFn();
-    session.off = fnAny();
-
     const {promise: rawPromise, cancel} = wait.waitForFcp(session, 0, 5000);
     const waitPromise = makePromiseInspectable(rawPromise);
 

--- a/core/test/gather/gatherers/global-listeners-test.js
+++ b/core/test/gather/gatherers/global-listeners-test.js
@@ -5,9 +5,7 @@
  */
 
 import GlobalListenerGatherer from '../../../gather/gatherers/global-listeners.js';
-import {createMockSendCommandFn} from '../mock-commands.js';
-import {Connection} from '../../../legacy/gather/connections/connection.js';
-import {Driver} from '../../../legacy/gather/driver.js';
+import {createMockDriver} from '../mock-driver.js';
 
 describe('Global Listener Gatherer', () => {
   it('remove duplicate listeners from artifacts', async () => {
@@ -39,19 +37,16 @@ describe('Global Listener Gatherer', () => {
       },
     ];
 
-    const sendCommandMock = createMockSendCommandFn()
-        .mockResponse('Runtime.evaluate', {result: {objectId: 10}})
-        .mockResponse('DOMDebugger.getEventListeners', {listeners: mockListeners.slice(0)});
-
     const expectedOutput = [
       mockListeners[0],
       mockListeners[2],
       mockListeners[3],
     ];
 
-    const connectionStub = new Connection();
-    connectionStub.sendCommand = sendCommandMock;
-    const driver = new Driver(connectionStub);
+    const driver = createMockDriver();
+    driver._session.sendCommand
+      .mockResponse('Runtime.evaluate', {result: {objectId: 10}})
+      .mockResponse('DOMDebugger.getEventListeners', {listeners: mockListeners.slice(0)});
 
     const globalListeners = await globalListenerGatherer.getArtifact({driver});
     return expect(globalListeners).toMatchObject(expectedOutput);

--- a/core/test/gather/gatherers/js-usage-test.js
+++ b/core/test/gather/gatherers/js-usage-test.js
@@ -4,11 +4,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {Driver} from '../../../legacy/gather/driver.js';
-import {Connection} from '../../../legacy/gather/connections/connection.js';
 import JsUsage from '../../../gather/gatherers/js-usage.js';
-import {createMockSendCommandFn, createMockOnFn} from '../mock-commands.js';
-import {createMockContext} from '../../gather/mock-driver.js';
+import {createMockContext, createMockDriver} from '../../gather/mock-driver.js';
 import {flushAllTimersAndMicrotasks, timers} from '../../test-utils.js';
 
 describe('JsUsage gatherer', () => {
@@ -22,19 +19,13 @@ describe('JsUsage gatherer', () => {
    * @return {Promise<LH.Artifacts['JsUsage']>}
    */
   async function runJsUsage({coverage}) {
-    const onMock = createMockOnFn();
-    const sendCommandMock = createMockSendCommandFn()
+    const driver = createMockDriver();
+    driver._session.sendCommand
       .mockResponse('Profiler.enable', {})
       .mockResponse('Profiler.disable', {})
       .mockResponse('Profiler.startPreciseCoverage', {})
       .mockResponse('Profiler.takePreciseCoverage', {result: coverage})
       .mockResponse('Profiler.stopPreciseCoverage', {});
-
-    const connectionStub = new Connection();
-    connectionStub.sendCommand = sendCommandMock;
-    connectionStub.on = onMock;
-
-    const driver = new Driver(connectionStub);
 
     const gatherer = new JsUsage();
     await gatherer.startInstrumentation({driver});

--- a/core/test/gather/mock-driver.js
+++ b/core/test/gather/mock-driver.js
@@ -27,6 +27,8 @@ function createMockSession() {
     setTargetInfo: fnAny(),
     sendCommand: createMockSendCommandFn({useSessionId: false}),
     setNextProtocolTimeout: fnAny(),
+    hasNextProtocolTimeout: fnAny(),
+    getNextProtocolTimeout: fnAny(),
     once: createMockOnceFn(),
     on: createMockOnFn(),
     off: fnAny(),
@@ -36,7 +38,6 @@ function createMockSession() {
 
     /** @return {LH.Gatherer.FRProtocolSession} */
     asSession() {
-      // @ts-expect-error - We'll rely on the tests passing to know this matches.
       return this;
     },
   };
@@ -135,6 +136,7 @@ function createMockExecutionContext() {
 function createMockTargetManager(session) {
   return {
     rootSession: () => session,
+    mainFrameExecutionContexts: () => [{uniqueId: 'EXECUTION_CTX_ID'}],
     enable: fnAny(),
     disable: fnAny(),
     on: createMockOnFn(),
@@ -164,6 +166,9 @@ function createMockDriver() {
     disconnect: fnAny(),
     executionContext: context.asExecutionContext(),
     targetManager: targetManager.asTargetManager(),
+    fetcher: {
+      fetchResource: fnAny(),
+    },
 
     /** @return {Driver} */
     asDriver() {


### PR DESCRIPTION
Follow up to https://github.com/GoogleChrome/lighthouse/pull/15047

Missed a few usages of legacy driver/connection in tests. This PR also reduces our usage of `mockCommands` directly, instead deferring to the mock `sendCommand`/`on`/`once` functions created on the mock session and mock driver.

#15060 
