### PR TITLE
core(network-recorder): set target type of unfinished request

### DIFF
--- a/core/lib/network-recorder.js
+++ b/core/lib/network-recorder.js
@@ -80,6 +80,7 @@ class NetworkRecorder extends RequestEventEmitter {
       const request = new NetworkRequest();
       request.onRequestWillBeSent(data);
       request.sessionId = event.sessionId;
+      request.sessionTargetType = event.targetType;
       this.onRequestStarted(request);
       log.verbose('network', `request will be sent to ${request.url}`);
       return;

--- a/core/test/lib/network-recorder-test.js
+++ b/core/test/lib/network-recorder-test.js
@@ -195,6 +195,19 @@ describe('network recorder', function() {
     ]);
   });
 
+  it('should set sessionId and sessionTargetType of from just request event', () => {
+    const devtoolsLogs = networkRecordsToDevtoolsLog([
+      {url: 'http://iframe.com', sessionId: 'session2', sessionTargetType: 'iframe'},
+    ]);
+    const requestWillBeSentLog =
+      devtoolsLogs.filter(entry => entry.method === 'Network.requestWillBeSent');
+
+    const records = NetworkRecorder.recordsFromLogs(requestWillBeSentLog);
+    expect(records).toMatchObject([
+      {url: 'http://iframe.com', sessionTargetType: 'iframe', sessionId: 'session2'},
+    ]);
+  });
+
   it('should handle prefetch requests', () => {
     const records = NetworkRecorder.recordsFromLogs(prefetchedScriptDevtoolsLog);
     expect(records).toHaveLength(5);


### PR DESCRIPTION
Investigated some flaky `oopif-requests` failures:
https://github.com/GoogleChrome/lighthouse/actions/runs/5489241604/jobs/10003149170?pr=15231

If a request only has a `Network.requestWillBeSent` event we will still create a request for it, but we were not setting the `sessionTargetType` for that initial request.
