### PR TITLE
core: remove unnecessary references to legacy gatherer

### DIFF
--- a/core/gather/base-gatherer.js
+++ b/core/gather/base-gatherer.js
@@ -9,9 +9,7 @@ import * as LH from '../../types/lh.js';
 /* eslint-disable no-unused-vars */
 
 /**
- * Base class for all gatherers supporting both Fraggle Rock and the legacy flow.
- * Most extending classes should implement the Fraggle Rock API and let this class handle translation.
- * See core/gather/gatherers/gatherer.js for legacy method explanations.
+ * Base class for all gatherers.
  *
  * @implements {LH.Gatherer.GathererInstance}
  * @implements {LH.Gatherer.FRGathererInstance}

--- a/core/test/config/config-helpers-test.js
+++ b/core/test/config/config-helpers-test.js
@@ -21,7 +21,7 @@ import {
   mergeConfigFragmentArrayByKey,
 } from '../../config/config-helpers.js';
 import {Runner} from '../../runner.js';
-import {Gatherer} from '../../gather/gatherers/gatherer.js';
+import Gatherer from '../../gather/base-gatherer.js';
 import ImageElementsGatherer from '../../gather/gatherers/image-elements.js';
 import UserTimingsAudit from '../../audits/user-timings.js';
 import {LH_ROOT} from '../../../root.js';

--- a/core/test/fixtures/valid-custom-gatherer.cjs
+++ b/core/test/fixtures/valid-custom-gatherer.cjs
@@ -4,6 +4,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-module.exports = import('../../gather/gatherers/gatherer.js').then(({Gatherer}) => {
+module.exports = import('../../gather/base-gatherer.js').then(({default: Gatherer}) => {
   return class CustomGatherer extends Gatherer {};
 });

--- a/core/test/fixtures/valid-custom-gatherer.js
+++ b/core/test/fixtures/valid-custom-gatherer.js
@@ -4,7 +4,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-import {Gatherer} from '../../gather/gatherers/gatherer.js';
+import Gatherer from '../../gather/base-gatherer.js';
 
 class CustomGatherer extends Gatherer {}
 


### PR DESCRIPTION
We use the old gatherer class in some config helpers tests. These tests are sticking around after legacy removal and can use the new base gatherer.