### PR TITLE
tests: call toString for errors from bundled worker

### DIFF
--- a/cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -39,7 +39,7 @@ if (!isMainThread && parentPort) {
       parentPort?.postMessage({type: 'result', value});
     } catch (err) {
       console.error(err);
-      parentPort?.postMessage({type: 'error', value: err});
+      parentPort?.postMessage({type: 'error', value: err.toString()});
     }
   })();
 }


### PR DESCRIPTION
Error objects can't be sent from a worker, so all we get is `{}` printed on errors.