### PR TITLE
tests(smoke): drop legacy support

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -32,27 +32,3 @@ jobs:
 
     # Fail if any changes were written to source files.
     - run: git diff --exit-code
-
-  package-test-legacy:
-    runs-on: ubuntu-latest
-    name: Package Test Legacy Navigation
-    env:
-      FORCE_COLOR: true
-
-    steps:
-    - name: git clone
-      uses: actions/checkout@v2
-
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16.x
-
-    - run: yarn install --frozen-lockfile --network-timeout 1000000
-    - run: yarn build-report
-    - run: sudo apt-get install xvfb
-
-    - run: xvfb-run --auto-servernum bash $GITHUB_WORKSPACE/core/scripts/release/package-test.sh --legacy-navigation
-
-    # Fail if any changes were written to source files.
-    - run: git diff --exit-code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -120,54 +120,6 @@ jobs:
         name: Smokehouse (windows)
         path: .tmp/smokehouse-failures/
 
-  smoke-legacy:
-    strategy:
-      matrix:
-        smoke-test-shard: [1, 2, 3]
-      # e.g. if set 1 fails, continue with set 2 anyway
-      fail-fast: false
-    runs-on: ubuntu-latest
-    env:
-      # The total number of shards. Set dynamically when length of *single* matrix variable is
-      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
-      SHARD_TOTAL: 3
-      FORCE_COLOR: true
-    name: Legacy Navigation ${{ matrix.smoke-test-shard }}/3
-
-    steps:
-    - name: git clone
-      uses: actions/checkout@v2
-
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16.x
-
-    - run: yarn install --frozen-lockfile --network-timeout 1000000
-    - run: yarn build-report
-    - run: yarn reset-link
-
-    - name: Define ToT chrome path
-      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
-
-    - name: Install Chrome ToT
-      working-directory: /home/runner
-      run: bash $GITHUB_WORKSPACE/core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
-
-    - run: sudo apt-get install xvfb
-    - name: yarn smoke --legacy-navigation
-      run: xvfb-run --auto-servernum yarn smoke --debug --legacy-navigation -j=2 --retries=2 --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
-
-    # Fail if any changes were written to source files.
-    - run: git diff --exit-code
-
-    - name: Upload failures
-      if: failure()
-      uses: actions/upload-artifact@v1
-      with:
-        name: Smokehouse (legacy)
-        path: .tmp/smokehouse-failures/
-
   smoke-bundle:
     strategy:
       matrix:
@@ -210,54 +162,6 @@ jobs:
     - run: git diff --exit-code
 
     - name: Upload failures
-      if: failure()
-      uses: actions/upload-artifact@v1
-      with:
-        name: Smokehouse (bundled)
-        path: .tmp/smokehouse-failures/
-
-  smoke-bundle-legacy:
-    strategy:
-      matrix:
-        smoke-test-shard: [1, 2, 3]
-      # e.g. if set 1 fails, continue with set 2 anyway
-      fail-fast: false
-    runs-on: ubuntu-latest
-    env:
-      # The total number of shards. Set dynamically when length of *single* matrix variable is
-      # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
-      SHARD_TOTAL: 3
-      FORCE_COLOR: true
-    name: Bundled Legacy Navigation ${{ matrix.smoke-test-shard }}/3
-
-    steps:
-    - name: git clone
-      uses: actions/checkout@v2
-
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16.x
-
-    - run: yarn install --frozen-lockfile --network-timeout 1000000
-    - run: yarn build-report
-    - run: yarn build-devtools
-
-    - name: Define ToT chrome path
-      run: echo "CHROME_PATH=/home/runner/chrome-linux-tot/chrome" >> $GITHUB_ENV
-
-    - name: Install Chrome ToT
-      working-directory: /home/runner
-      run: bash $GITHUB_WORKSPACE/core/scripts/download-chrome.sh && mv chrome-linux chrome-linux-tot
-
-    - run: sudo apt-get install xvfb
-    - name: yarn test-bundle
-      run: xvfb-run --auto-servernum yarn test-bundle --legacy-navigation --shard=${{ matrix.smoke-test-shard }}/$SHARD_TOTAL
-
-    # Fail if any changes were written to source files.
-    - run: git diff --exit-code
-
-    - name: Upload dist
       if: failure()
       uses: actions/upload-artifact@v1
       with:

--- a/cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -136,11 +136,6 @@ async function begin() {
         default: false,
         describe: 'Save test artifacts and output verbose logs',
       },
-      'legacy-navigation': {
-        type: 'boolean',
-        default: false,
-        describe: 'Use the legacy navigation runner',
-      },
       'jobs': {
         type: 'number',
         alias: 'j',
@@ -218,7 +213,6 @@ async function begin() {
       jobs,
       retries,
       isDebug: argv.debug,
-      useLegacyNavigation: argv.legacyNavigation,
       lighthouseRunner: runLighthouse,
       takeNetworkRequestUrls,
       setup,

--- a/cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/cli/test/smokehouse/lighthouse-runners/cli.js
@@ -28,7 +28,7 @@ const execFileAsync = promisify(execFile);
  * Launch Chrome and do a full Lighthouse run via the Lighthouse CLI.
  * @param {string} url
  * @param {LH.Config=} config
- * @param {{isDebug?: boolean, useFraggleRock?: boolean}=} testRunnerOptions
+ * @param {{isDebug?: boolean}=} testRunnerOptions
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
 async function runLighthouse(url, config, testRunnerOptions = {}) {
@@ -46,11 +46,11 @@ async function runLighthouse(url, config, testRunnerOptions = {}) {
  * @param {string} url
  * @param {string} tmpPath
  * @param {LH.Config=} config
- * @param {{isDebug?: boolean, useLegacyNavigation?: boolean}=} options
+ * @param {{isDebug?: boolean}=} options
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
 async function internalRun(url, tmpPath, config, options) {
-  const {isDebug = false, useLegacyNavigation = false} = options || {};
+  const {isDebug = false} = options || {};
   const localConsole = new LocalConsole();
 
   const outputPath = `${tmpPath}/smokehouse.report.json`;
@@ -66,10 +66,6 @@ async function internalRun(url, tmpPath, config, options) {
     '--port=0',
     '--quiet',
   ];
-
-  if (useLegacyNavigation) {
-    args.push('--legacy-navigation');
-  }
 
   // Config can be optionally provided.
   if (config) {

--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -42,7 +42,7 @@ async function setup() {
  * CHROME_PATH determines which Chrome is used–otherwise the default is puppeteer's chrome binary.
  * @param {string} url
  * @param {LH.Config=} config
- * @param {{isDebug?: boolean, useLegacyNavigation?: boolean}=} testRunnerOptions
+ * @param {{isDebug?: boolean}=} testRunnerOptions
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
 async function runLighthouse(url, config, testRunnerOptions = {}) {
@@ -52,7 +52,6 @@ async function runLighthouse(url, config, testRunnerOptions = {}) {
   const {lhr, artifacts, logs} = await testUrlFromDevtools(url, {
     config,
     chromeFlags,
-    useLegacyNavigation: testRunnerOptions.useLegacyNavigation,
   });
 
   if (testRunnerOptions.isDebug) {

--- a/cli/test/smokehouse/readme.md
+++ b/cli/test/smokehouse/readme.md
@@ -118,8 +118,6 @@ All pruning checks:
 
 - `_minChromiumVersion`
 - `_maxChromiumVersion`
-- `_legacyOnly`
-- `_fraggleRockOnly`
 - `_runner` (set to same value provided to CLI --runner flag, ex: `'devtools'`)
 - `_excludeRunner` (set to same value provided to CLI --runner flag, ex: `'devtools'`)
 

--- a/cli/test/smokehouse/report-assert.js
+++ b/cli/test/smokehouse/report-assert.js
@@ -237,11 +237,9 @@ function makeComparison(name, actualResult, expectedResult) {
  * @param {LocalConsole} localConsole
  * @param {LH.Result} lhr
  * @param {Smokehouse.ExpectedRunnerResult} expected
- * @param {{runner?: string, useLegacyNavigation?: boolean}=} reportOptions
+ * @param {{runner?: string}=} reportOptions
  */
 function pruneExpectations(localConsole, lhr, expected, reportOptions) {
-  const isLegacyNavigation = reportOptions?.useLegacyNavigation;
-
   /**
    * Lazily compute the Chrome version because some reports are explicitly asserting error conditions.
    * @returns {string}
@@ -295,19 +293,6 @@ function pruneExpectations(localConsole, lhr, expected, reportOptions) {
           `Actual Chromium version: ${getChromeVersionString()}`,
         ].join(' '));
         remove(key);
-      } else if (value._legacyOnly && !isLegacyNavigation) {
-        localConsole.log([
-          `[${key}] marked legacy only but run is Fraggle Rock, pruning expectation:`,
-          JSON.stringify(value, null, 2),
-        ].join(' '));
-        remove(key);
-      } else if (value._fraggleRockOnly && isLegacyNavigation) {
-        localConsole.log([
-          `[${key}] marked Fraggle Rock only but run is legacy, pruning expectation:`,
-          JSON.stringify(value, null, 2),
-          `Actual channel: ${lhr.configSettings.channel}`,
-        ].join(' '));
-        remove(key);
       } else if (value._runner && reportOptions?.runner !== value._runner) {
         localConsole.log([
           `[${key}] is only for runner ${value._runner}, pruning expectation:`,
@@ -325,8 +310,6 @@ function pruneExpectations(localConsole, lhr, expected, reportOptions) {
       }
     }
 
-    delete obj._legacyOnly;
-    delete obj._fraggleRockOnly;
     delete obj._skipInBundled;
     delete obj._minChromiumVersion;
     delete obj._maxChromiumVersion;
@@ -483,7 +466,7 @@ function reportAssertion(localConsole, assertion) {
  * summary. Returns count of passed and failed tests.
  * @param {{lhr: LH.Result, artifacts: LH.Artifacts, networkRequests?: string[]}} actual
  * @param {Smokehouse.ExpectedRunnerResult} expected
- * @param {{runner?: string, isDebug?: boolean, useLegacyNavigation?: boolean}=} reportOptions
+ * @param {{runner?: string, isDebug?: boolean}=} reportOptions
  * @return {{passed: number, failed: number, log: string}}
  */
 function getAssertionReport(actual, expected, reportOptions = {}) {

--- a/cli/test/smokehouse/test-definitions/errors-expired-ssl.js
+++ b/cli/test/smokehouse/test-definitions/errors-expired-ssl.js
@@ -33,10 +33,10 @@ const expectations = {
     requestedUrl: 'https://expired.badssl.com',
     finalDisplayedUrl: /(expired.badssl.com|chrome-error)/,
     runtimeError: {code: 'INSECURE_DOCUMENT_REQUEST'},
-    runWarnings: Object.defineProperty([
-      /expired.badssl.*redirected to chrome-error:/, // This warning was not provided in legacy reports.
+    runWarnings: [
+      /expired.badssl.*redirected to chrome-error:/,
       'The URL you have provided does not have a valid security certificate. net::ERR_CERT_DATE_INVALID',
-    ], '_fraggleRockOnly', {value: true, enumerable: true}),
+    ],
     audits: {
       'first-contentful-paint': {
         scoreDisplayMode: 'error',
@@ -47,12 +47,10 @@ const expectations = {
   artifacts: {
     PageLoadError: {code: 'INSECURE_DOCUMENT_REQUEST'},
     devtoolsLogs: {
-      'pageLoadError-defaultPass': {...NONEMPTY_ARRAY, _legacyOnly: true},
-      'pageLoadError-default': {...NONEMPTY_ARRAY, _fraggleRockOnly: true},
+      'pageLoadError-default': {...NONEMPTY_ARRAY},
     },
     traces: {
-      'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY, _legacyOnly: true},
-      'pageLoadError-default': {traceEvents: NONEMPTY_ARRAY, _fraggleRockOnly: true},
+      'pageLoadError-default': {traceEvents: NONEMPTY_ARRAY},
     },
   },
 };

--- a/cli/test/smokehouse/test-definitions/errors-infinite-loop.js
+++ b/cli/test/smokehouse/test-definitions/errors-infinite-loop.js
@@ -44,12 +44,10 @@ const expectations = {
   artifacts: {
     PageLoadError: {code: 'PAGE_HUNG'},
     devtoolsLogs: {
-      'pageLoadError-defaultPass': {...NONEMPTY_ARRAY, _legacyOnly: true},
-      'pageLoadError-default': {...NONEMPTY_ARRAY, _fraggleRockOnly: true},
+      'pageLoadError-default': {...NONEMPTY_ARRAY},
     },
     traces: {
-      'pageLoadError-defaultPass': {traceEvents: NONEMPTY_ARRAY, _legacyOnly: true},
-      'pageLoadError-default': {traceEvents: NONEMPTY_ARRAY, _fraggleRockOnly: true},
+      'pageLoadError-default': {traceEvents: NONEMPTY_ARRAY},
     },
   },
 };

--- a/cli/test/smokehouse/test-definitions/oopif-scripts.js
+++ b/cli/test/smokehouse/test-definitions/oopif-scripts.js
@@ -61,14 +61,8 @@ const expectations = {
               {url: 'http://localhost:10503/simple-script.js', resourceType: 'Fetch'},
               {url: 'http://localhost:10200/simple-worker.js'},
               {url: 'http://localhost:10503/simple-worker.js'},
-              // These requests are emitted in workers so Lighthouse doesn't capture them.
+              // Several requests are emitted in workers but Lighthouse doesn't capture them.
               // https://github.com/GoogleChrome/lighthouse/issues/14211
-              // {url: 'http://localhost:10200/simple-worker.mjs'},
-              // {url: 'http://localhost:10503/simple-worker.mjs'},
-              // {url: 'http://localhost:10200/simple-script.js?esm', resourceType: 'Script'},
-              // {url: 'http://localhost:10503/simple-script.js?esm', resourceType: 'Script'},
-              // {url: 'http://localhost:10200/simple-script.js?importScripts', resourceType: 'Other'},
-              // {url: 'http://localhost:10503/simple-script.js?importScripts', resourceType: 'Other'},
             ],
             // Ensure the above is exhaustive (except for favicon, which won't be fetched in devtools/LR).
             _excludes: [

--- a/cli/test/smokehouse/test-definitions/oopif-scripts.js
+++ b/cli/test/smokehouse/test-definitions/oopif-scripts.js
@@ -62,14 +62,13 @@ const expectations = {
               {url: 'http://localhost:10200/simple-worker.js'},
               {url: 'http://localhost:10503/simple-worker.js'},
               // These requests are emitted in workers so Lighthouse doesn't capture them.
-              // For some reason, legacy navigations in DevTools still pick them up.
               // https://github.com/GoogleChrome/lighthouse/issues/14211
-              {_legacyOnly: true, _runner: 'devtools', url: 'http://localhost:10200/simple-worker.mjs'},
-              {_legacyOnly: true, _runner: 'devtools', url: 'http://localhost:10503/simple-worker.mjs'},
-              {_legacyOnly: true, _runner: 'devtools', url: 'http://localhost:10200/simple-script.js?esm', resourceType: 'Script'},
-              {_legacyOnly: true, _runner: 'devtools', url: 'http://localhost:10503/simple-script.js?esm', resourceType: 'Script'},
-              {_legacyOnly: true, _runner: 'devtools', url: 'http://localhost:10200/simple-script.js?importScripts', resourceType: 'Other'},
-              {_legacyOnly: true, _runner: 'devtools', url: 'http://localhost:10503/simple-script.js?importScripts', resourceType: 'Other'},
+              // {url: 'http://localhost:10200/simple-worker.mjs'},
+              // {url: 'http://localhost:10503/simple-worker.mjs'},
+              // {url: 'http://localhost:10200/simple-script.js?esm', resourceType: 'Script'},
+              // {url: 'http://localhost:10503/simple-script.js?esm', resourceType: 'Script'},
+              // {url: 'http://localhost:10200/simple-script.js?importScripts', resourceType: 'Other'},
+              // {url: 'http://localhost:10503/simple-script.js?importScripts', resourceType: 'Other'},
             ],
             // Ensure the above is exhaustive (except for favicon, which won't be fetched in devtools/LR).
             _excludes: [

--- a/clients/devtools/devtools-entry.js
+++ b/clients/devtools/devtools-entry.js
@@ -140,6 +140,4 @@ if (typeof self !== 'undefined') {
   // For the bundle smoke test.
   // @ts-expect-error
   global.runBundledLighthouse = lighthouse;
-  // @ts-expect-error
-  global.runBundledLighthouseLegacyNavigation = legacyNavigation;
 }

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -230,16 +230,6 @@ function enableDevToolsThrottling() {
   toolbarRoot.querySelector('option[value="devtools"]').selected = true;
   toolbarRoot.querySelector('select').dispatchEvent(new Event('change'));
 }
-
-function disableLegacyNavigation() {
-  // @ts-expect-error global
-  const panel = UI.panels.lighthouse || UI.panels.audits;
-  const toolbarRoot = panel.contentElement.querySelector('.lighthouse-settings-pane .toolbar').shadowRoot;
-  const checkboxRoot = toolbarRoot.querySelector('span[is="dt-checkbox"]').shadowRoot;
-  const checkboxEl = checkboxRoot.querySelector('input');
-  checkboxEl.checked = false;
-  checkboxEl.dispatchEvent(new Event('change'));
-}
 /* eslint-enable */
 
 /**
@@ -296,11 +286,11 @@ function dismissDialog(dialog) {
 
 /**
  * @param {string} url
- * @param {{config?: LH.Config, chromeFlags?: string[], useLegacyNavigation?: boolean}} [options]
+ * @param {{config?: LH.Config, chromeFlags?: string[]}} [options]
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, logs: string[]}>}
  */
 async function testUrlFromDevtools(url, options = {}) {
-  const {config, chromeFlags, useLegacyNavigation} = options;
+  const {config, chromeFlags} = options;
 
   const browser = await puppeteer.launch({
     executablePath: getChromePath(),
@@ -329,10 +319,6 @@ async function testUrlFromDevtools(url, options = {}) {
     await waitForFunction(inspectorSession, waitForLighthouseReady);
 
     page.off('dialog', dismissDialog);
-
-    if (!useLegacyNavigation) {
-      await evaluateInSession(inspectorSession, disableLegacyNavigation);
-    }
 
     if (config) {
       await installCustomLighthouseConfig(inspectorSession, config);

--- a/types/internal/smokehouse.d.ts
+++ b/types/internal/smokehouse.d.ts
@@ -53,13 +53,11 @@ declare global {
       {expectations: Smokehouse.ExpectedRunnerResult | Array<Smokehouse.ExpectedRunnerResult>}
 
     export type LighthouseRunner =
-      {runnerName?: string} & ((url: string, config?: Config, runnerOptions?: {isDebug?: boolean; useLegacyNavigation?: boolean}) => Promise<{lhr: LHResult, artifacts: Artifacts, log: string}>);
+      {runnerName?: string} & ((url: string, config?: Config, runnerOptions?: {isDebug?: boolean}) => Promise<{lhr: LHResult, artifacts: Artifacts, log: string}>);
 
     export interface SmokehouseOptions {
       /** If true, performs extra logging from the test runs. */
       isDebug?: boolean;
-      /** If true, use the legacy navigation runner. */
-      useLegacyNavigation?: boolean;
       /** Manually set the number of jobs to run at once. `1` runs all tests serially. */
       jobs?: number;
       /** The number of times to retry failing tests before accepting. Defaults to 0. */


### PR DESCRIPTION
Part of #15060

I wouldn't consider this breaking unless we're concerned about downstream consumers of smokehouse. Regardless, I expect the next release to be breaking.