### PR TITLE
core(response-compresson): throw on unexpected error

### DIFF
--- a/core/test/gather/gatherers/dobetterweb/response-compression-test.js
+++ b/core/test/gather/gatherers/dobetterweb/response-compression-test.js
@@ -145,12 +145,19 @@ describe('Optimized responses', () => {
     expect(artifact[0].gzipSize).toEqual(26);
   });
 
-  it('recovers from driver errors', async () => {
-    mocks.networkMock.fetchResponseBodyFromCache.mockRejectedValue(new Error('Failed'));
+  it('recovers from cache ejection errors', async () => {
+    mocks.networkMock.fetchResponseBodyFromCache.mockRejectedValue(
+      new Error('No resource with given identifier found'));
     const artifact = await gatherer.getCompressibleRecords(context, networkRecords);
     expect(artifact).toHaveLength(2);
     expect(artifact[0].resourceSize).toEqual(6);
     expect(artifact[0].gzipSize).toBeUndefined();
+  });
+
+  it('does not suppress other errors', async () => {
+    mocks.networkMock.fetchResponseBodyFromCache.mockRejectedValue(new Error('Failed'));
+    await expect(gatherer.getCompressibleRecords(context, networkRecords))
+      .rejects.toThrow();
   });
 
   it('ignores responses from installed Chrome extensions', async () => {


### PR DESCRIPTION
(land #15258 first)

All the errors for this artifact that I saw are from cache ejections. We should throw on anything else.

This was a problem for me because the bundler changes were erroring on some real problem, which was hidden from me.