### PR TITLE
tests(devtools): remove unused test options

### DIFF
--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -40,10 +40,9 @@ async function setup() {
  * CHROME_PATH determines which Chrome is used–otherwise the default is puppeteer's chrome binary.
  * @param {string} url
  * @param {LH.Config=} config
- * @param {{isDebug?: boolean}=} testRunnerOptions
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
-async function runLighthouse(url, config, testRunnerOptions = {}) {
+async function runLighthouse(url, config) {
   const chromeFlags = [
     `--custom-devtools-frontend=file://${devtoolsDir}/out/LighthouseIntegration/gen/front_end`,
   ];


### PR DESCRIPTION
There was a linter error caused when we removed the 2 usages of this variable in 2 separate PRs. We didn't rebase after merging the first one so this slipped through.