### PR TITLE
core(duplicated-javascript): use valid granularity

### DIFF
--- a/core/audits/byte-efficiency/duplicated-javascript.js
+++ b/core/audits/byte-efficiency/duplicated-javascript.js
@@ -229,8 +229,8 @@ class DuplicatedJavascript extends ByteEfficiencyAudit {
     const headings = [
       /* eslint-disable max-len */
       {key: 'source', valueType: 'code', subItemsHeading: {key: 'url', valueType: 'url'}, label: str_(i18n.UIStrings.columnSource)},
-      {key: null, valueType: 'bytes', subItemsHeading: {key: 'sourceTransferBytes'}, granularity: 0.05, label: str_(i18n.UIStrings.columnTransferSize)},
-      {key: 'wastedBytes', valueType: 'bytes', granularity: 0.05, label: str_(i18n.UIStrings.columnWastedBytes)},
+      {key: null, valueType: 'bytes', subItemsHeading: {key: 'sourceTransferBytes'}, granularity: 10, label: str_(i18n.UIStrings.columnTransferSize)},
+      {key: 'wastedBytes', valueType: 'bytes', granularity: 10, label: str_(i18n.UIStrings.columnWastedBytes)},
       /* eslint-enable max-len */
     ];
 


### PR DESCRIPTION
This was originally introduced at 0.05, which did...something in our old formatter. Since #13839 this value has been warning in the report and falling back to 1.

Instead, let's round to nearest tens.