### PR TITLE
misc(logger): add types, remove cjs

### DIFF
--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -127,7 +127,7 @@ class Log {
   }
 
   /**
-   * @param {{msg: string, id: string, args: any[]}} status
+   * @param {{msg: string, id: string, args?: any[]}} status
    * @param {string} level
    */
   static time({msg, id, args = []}, level = 'log') {
@@ -136,7 +136,7 @@ class Log {
   }
 
   /**
-   * @param {{msg: string, id: string, args: any[]}} status
+   * @param {{msg: string, id: string, args?: any[]}} status
    * @param {string} level
    */
   static timeEnd({msg, id, args = []}, level = 'verbose') {

--- a/lighthouse-logger/index.js
+++ b/lighthouse-logger/index.js
@@ -61,6 +61,9 @@ class Log {
     log(...argsArray);
   }
 
+  /**
+   * @param {string} title
+   */
   static loggerfn(title) {
     title = `LH:${title}`;
     let log = loggersByTitle[title];
@@ -123,30 +126,54 @@ class Log {
     return level_ === 'verbose';
   }
 
+  /**
+   * @param {{msg: string, id: string, args: any[]}} status
+   * @param {string} level
+   */
   static time({msg, id, args = []}, level = 'log') {
     marky.mark(id);
     Log[level]('status', msg, ...args);
   }
 
+  /**
+   * @param {{msg: string, id: string, args: any[]}} status
+   * @param {string} level
+   */
   static timeEnd({msg, id, args = []}, level = 'verbose') {
     Log[level]('statusEnd', msg, ...args);
     marky.stop(id);
   }
 
+  /**
+   * @param {string} title
+   * @param {...any} args
+   */
   static log(title, ...args) {
     Log.events.issueStatus(title, args);
     return Log._logToStdErr(title, args);
   }
 
+  /**
+   * @param {string} title
+   * @param {...any} args
+   */
   static warn(title, ...args) {
     Log.events.issueWarning(title, args);
     return Log._logToStdErr(`${title}:warn`, args);
   }
 
+  /**
+   * @param {string} title
+   * @param {...any} args
+   */
   static error(title, ...args) {
     return Log._logToStdErr(`${title}:error`, args);
   }
 
+  /**
+   * @param {string} title
+   * @param {...any} args
+   */
   static verbose(title, ...args) {
     Log.events.issueStatus(title, args);
     return Log._logToStdErr(`${title}:verbose`, args);
@@ -236,11 +263,19 @@ class Log {
 }
 
 Log.events = new Emitter();
+
+/**
+ * @return {PerformanceEntry[]}
+ */
 Log.takeTimeEntries = () => {
   const entries = marky.getEntries();
   marky.clear();
   return entries;
 };
+
+/**
+ * @return {PerformanceEntry[]}
+ */
 Log.getTimeEntries = () => marky.getEntries();
 
 export default Log;

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -3,6 +3,10 @@
   "name": "lighthouse-logger",
   "version": "2.0.0",
   "license": "Apache-2.0",
+  "scripts": {
+    "prepack": "yarn build-types",
+    "build-types": "npx tsc index.js --allowJs --emitDeclarationOnly --declaration"
+  },
   "dependencies": {
     "debug": "^2.6.9",
     "marky": "^1.2.2"

--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -1,17 +1,8 @@
 {
   "type": "module",
   "name": "lighthouse-logger",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "license": "Apache-2.0",
-  "main": "./dist/index.cjs",
-  "exports": {
-    "require": "./dist/index.cjs",
-    "import": "./index.js"
-  },
-  "scripts": {
-    "prepack": "yarn build-cjs",
-    "build-cjs": "npx rollup --format=cjs --file=dist/index.cjs -- index.js"
-  },
   "dependencies": {
     "debug": "^2.6.9",
     "marky": "^1.2.2"


### PR DESCRIPTION
We could keep CJS support with rollup the way it currently is. Unfortunately, esbuild doesn't handle the default export the way we want and requires a [workaround with a wrapper file](https://github.com/evanw/esbuild/issues/532#issuecomment-1019392638).

This PR also adds type compilation so we don't need to add an extra `lighthouse-logger.d.ts` in the main Lighthouse repo and also chrome launcher.

#14909 