### PR TITLE
core(source-maps): use `Scripts` as a dependency

### DIFF
--- a/core/gather/gatherers/scripts.js
+++ b/core/gather/gatherers/scripts.js
@@ -48,7 +48,7 @@ function isLighthouseRuntimeEvaluateScript(script) {
  * @fileoverview Gets JavaScript file contents.
  */
 class Scripts extends BaseGatherer {
-  static symbol = Symbol('DevtoolsLog');
+  static symbol = Symbol('Scripts');
 
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {

--- a/core/gather/gatherers/scripts.js
+++ b/core/gather/gatherers/scripts.js
@@ -48,8 +48,11 @@ function isLighthouseRuntimeEvaluateScript(script) {
  * @fileoverview Gets JavaScript file contents.
  */
 class Scripts extends BaseGatherer {
+  static symbol = Symbol('DevtoolsLog');
+
   /** @type {LH.Gatherer.GathererMeta} */
   meta = {
+    symbol: Scripts.symbol,
     supportedModes: ['timespan', 'navigation'],
   };
 
@@ -90,11 +93,6 @@ class Scripts extends BaseGatherer {
     const formFactor = context.baseArtifacts.HostFormFactor;
 
     session.off('Debugger.scriptParsed', this.onScriptParsed);
-
-    // Without this line the Debugger domain will be off in FR runner,
-    // because only the legacy gatherer has special handling for multiple,
-    // overlapped enabled/disable calls.
-    await session.sendCommand('Debugger.enable');
 
     // If run on a mobile device, be sensitive to memory limitations and only
     // request one at a time.

--- a/core/test/gather/gatherers/source-maps-test.js
+++ b/core/test/gather/gatherers/source-maps-test.js
@@ -5,7 +5,6 @@
  */
 
 import SourceMaps from '../../../gather/gatherers/source-maps.js';
-import {flushAllTimersAndMicrotasks, timers} from '../../test-utils.js';
 import {createMockDriver} from '../mock-driver.js';
 
 const mapJson = JSON.stringify({
@@ -18,43 +17,39 @@ const mapJson = JSON.stringify({
 });
 
 describe('SourceMaps gatherer', () => {
-  before(() => timers.useFakeTimers());
-  after(() => timers.dispose());
-
   /**
-   * `scriptParsedEvent` mocks the `sourceMapURL` and `url` seen from the protocol.
+   * `script` mocks the `sourceMapURL` and `url` seen from the protocol.
    * `map` mocks the (JSON) of the source maps that `Runtime.evaluate` returns.
    * `resolvedSourceMapUrl` is used to assert that the SourceMaps gatherer is using the expected
    *                        url to fetch the source map.
    * `fetchError` mocks an error that happens in the page. Only fetch error message make sense.
-   * @param {Array<{scriptParsedEvent: LH.Crdp.Debugger.ScriptParsedEvent, map: string, status?: number, resolvedSourceMapUrl?: string, fetchError: string}>} mapsAndEvents
+   * @param {Array<{script: LH.Artifacts.Script, map: string, status?: number, resolvedSourceMapUrl?: string, fetchError: string}>} mapsAndScripts
    * @return {Promise<LH.Artifacts['SourceMaps']>}
    */
-  async function runSourceMaps(mapsAndEvents) {
+  async function runSourceMaps(mapsAndScripts) {
     // pre-condition: should only define map or fetchError, not both.
-    for (const {map, fetchError} of mapsAndEvents) {
+    for (const {map, fetchError} of mapsAndScripts) {
       if (map && fetchError) {
         throw new Error('should only define map or fetchError, not both.');
       }
     }
 
     const driver = createMockDriver();
-    driver._session.sendCommand
-      .mockResponse('Debugger.enable', {})
-      .mockResponse('Debugger.disable', {})
-      .mockResponse('Network.enable', {});
 
-    for (const mapAndEvents of mapsAndEvents) {
+    const Scripts = [];
+
+    for (const mapAndScript of mapsAndScripts) {
       const {
-        scriptParsedEvent,
+        script,
         map,
         status = null,
         resolvedSourceMapUrl,
         fetchError,
-      } = mapAndEvents;
-      driver._session.on.mockEvent('Debugger.scriptParsed', scriptParsedEvent);
+      } = mapAndScript;
 
-      if (scriptParsedEvent.sourceMapURL.startsWith('data:')) {
+      Scripts.push(script);
+
+      if (script.sourceMapURL.startsWith('data:')) {
         // Only the source maps that need to be fetched use the `fetchMock` code path.
         continue;
       }
@@ -74,17 +69,7 @@ describe('SourceMaps gatherer', () => {
     }
 
     const sourceMaps = new SourceMaps();
-
-    await sourceMaps.startInstrumentation({driver});
-    await sourceMaps.startSensitiveInstrumentation({driver});
-
-    // Needed for protocol events to emit.
-    await flushAllTimersAndMicrotasks(1);
-
-    await sourceMaps.stopSensitiveInstrumentation({driver});
-    await sourceMaps.stopInstrumentation({driver});
-
-    return sourceMaps.getArtifact({driver});
+    return sourceMaps.getArtifact({driver, dependencies: {Scripts}});
   }
 
   function makeJsonDataUrl(data) {
@@ -94,8 +79,8 @@ describe('SourceMaps gatherer', () => {
   it('ignores script with no source map url', async () => {
     const artifact = await runSourceMaps([
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/script.js',
+        script: {
+          name: 'http://www.example.com/script.js',
           sourceMapURL: '',
         },
         map: null,
@@ -107,8 +92,8 @@ describe('SourceMaps gatherer', () => {
   it('fetches map for script with source map url', async () => {
     const mapsAndEvents = [
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/bundle.js',
+        script: {
+          name: 'http://www.example.com/bundle.js',
           sourceMapURL: 'http://www.example.com/bundle.js.map',
         },
         map: mapJson,
@@ -118,8 +103,8 @@ describe('SourceMaps gatherer', () => {
     const artifact = await runSourceMaps(mapsAndEvents);
     expect(artifact).toEqual([
       {
-        scriptUrl: mapsAndEvents[0].scriptParsedEvent.url,
-        sourceMapUrl: mapsAndEvents[0].scriptParsedEvent.sourceMapURL,
+        scriptUrl: mapsAndEvents[0].script.name,
+        sourceMapUrl: mapsAndEvents[0].script.sourceMapURL,
         map: JSON.parse(mapsAndEvents[0].map),
       },
     ]);
@@ -128,24 +113,24 @@ describe('SourceMaps gatherer', () => {
   it('fetches map for script with relative source map url', async () => {
     const mapsAndEvents = [
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/path/bundle.js',
+        script: {
+          name: 'http://www.example.com/path/bundle.js',
           sourceMapURL: 'bundle.js.map',
         },
         map: mapJson,
         resolvedSourceMapUrl: 'http://www.example.com/path/bundle.js.map',
       },
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/path/bundle.js',
+        script: {
+          name: 'http://www.example.com/path/bundle.js',
           sourceMapURL: '../bundle.js.map',
         },
         map: mapJson,
         resolvedSourceMapUrl: 'http://www.example.com/bundle.js.map',
       },
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/path/bundle.js',
+        script: {
+          name: 'http://www.example.com/path/bundle.js',
           sourceMapURL: 'http://www.example-2.com/path/bundle.js',
         },
         map: mapJson,
@@ -155,18 +140,18 @@ describe('SourceMaps gatherer', () => {
     const artifacts = await runSourceMaps(mapsAndEvents);
     expect(artifacts).toEqual([
       {
-        scriptUrl: mapsAndEvents[0].scriptParsedEvent.url,
+        scriptUrl: mapsAndEvents[0].script.name,
         sourceMapUrl: 'http://www.example.com/path/bundle.js.map',
         map: JSON.parse(mapsAndEvents[0].map),
       },
       {
-        scriptUrl: mapsAndEvents[1].scriptParsedEvent.url,
+        scriptUrl: mapsAndEvents[1].script.name,
         sourceMapUrl: 'http://www.example.com/bundle.js.map',
         map: JSON.parse(mapsAndEvents[1].map),
       },
       {
-        scriptUrl: mapsAndEvents[2].scriptParsedEvent.url,
-        sourceMapUrl: mapsAndEvents[2].scriptParsedEvent.sourceMapURL,
+        scriptUrl: mapsAndEvents[2].script.name,
+        sourceMapUrl: mapsAndEvents[2].script.sourceMapURL,
         map: JSON.parse(mapsAndEvents[2].map),
       },
     ]);
@@ -175,8 +160,8 @@ describe('SourceMaps gatherer', () => {
   it('throws an error message when fetching map returns bad status code', async () => {
     const mapsAndEvents = [
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/bundle.js',
+        script: {
+          name: 'http://www.example.com/bundle.js',
           sourceMapURL: 'http://www.example.com/bundle.js.map',
         },
         status: 404,
@@ -186,8 +171,8 @@ describe('SourceMaps gatherer', () => {
     const artifact = await runSourceMaps(mapsAndEvents);
     expect(artifact).toEqual([
       {
-        scriptUrl: mapsAndEvents[0].scriptParsedEvent.url,
-        sourceMapUrl: mapsAndEvents[0].scriptParsedEvent.sourceMapURL,
+        scriptUrl: mapsAndEvents[0].script.name,
+        sourceMapUrl: mapsAndEvents[0].script.sourceMapURL,
         errorMessage: 'Error: Failed fetching source map (404)',
         map: undefined,
       },
@@ -197,8 +182,8 @@ describe('SourceMaps gatherer', () => {
   it('generates an error message when fetching map fails', async () => {
     const mapsAndEvents = [
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/bundle.js',
+        script: {
+          name: 'http://www.example.com/bundle.js',
           sourceMapURL: 'http://www.example.com/bundle.js.map',
         },
         fetchError: 'Failed fetching source map',
@@ -207,8 +192,8 @@ describe('SourceMaps gatherer', () => {
     const artifact = await runSourceMaps(mapsAndEvents);
     expect(artifact).toEqual([
       {
-        scriptUrl: mapsAndEvents[0].scriptParsedEvent.url,
-        sourceMapUrl: mapsAndEvents[0].scriptParsedEvent.sourceMapURL,
+        scriptUrl: mapsAndEvents[0].script.name,
+        sourceMapUrl: mapsAndEvents[0].script.sourceMapURL,
         errorMessage: 'Error: Failed fetching source map',
         map: undefined,
       },
@@ -218,8 +203,8 @@ describe('SourceMaps gatherer', () => {
   it('generates an error message when map url cannot be resolved', async () => {
     const mapsAndEvents = [
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/bundle.js',
+        script: {
+          name: 'http://www.example.com/bundle.js',
           sourceMapURL: 'http://',
         },
       },
@@ -227,7 +212,7 @@ describe('SourceMaps gatherer', () => {
     const artifact = await runSourceMaps(mapsAndEvents);
     expect(artifact).toEqual([
       {
-        scriptUrl: mapsAndEvents[0].scriptParsedEvent.url,
+        scriptUrl: mapsAndEvents[0].script.name,
         sourceMapUrl: undefined,
         errorMessage: 'Could not resolve map url: http://',
         map: undefined,
@@ -238,15 +223,15 @@ describe('SourceMaps gatherer', () => {
   it('generates an error message when parsing map fails', async () => {
     const mapsAndEvents = [
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/bundle.js',
+        script: {
+          name: 'http://www.example.com/bundle.js',
           sourceMapURL: 'http://www.example.com/bundle.js.map',
         },
         map: '{{}',
       },
       {
-        scriptParsedEvent: {
-          url: 'http://www.example.com/bundle-2.js',
+        script: {
+          name: 'http://www.example.com/bundle-2.js',
           sourceMapURL: makeJsonDataUrl('{};'),
         },
       },
@@ -254,13 +239,13 @@ describe('SourceMaps gatherer', () => {
     const artifact = await runSourceMaps(mapsAndEvents);
     expect(artifact).toEqual([
       {
-        scriptUrl: mapsAndEvents[0].scriptParsedEvent.url,
-        sourceMapUrl: mapsAndEvents[0].scriptParsedEvent.sourceMapURL,
+        scriptUrl: mapsAndEvents[0].script.name,
+        sourceMapUrl: mapsAndEvents[0].script.sourceMapURL,
         errorMessage: 'SyntaxError: Unexpected token { in JSON at position 1',
         map: undefined,
       },
       {
-        scriptUrl: mapsAndEvents[1].scriptParsedEvent.url,
+        scriptUrl: mapsAndEvents[1].script.name,
         sourceMapUrl: undefined,
         errorMessage: 'SyntaxError: Unexpected token ; in JSON at position 2',
         map: undefined,


### PR DESCRIPTION
Now that legacy runner is removed, it is possible to use artifacts *other* than DT log and trace as dependencies for other gatherers.

This PR uses `Scripts` as a dependency for `SourceMaps` so we don't have to collect 2 sets of script attached events and the calls to `Debugger.enable`/`Dubugger.disable` won't clobber each other.
