### PR TITLE
Option to disable blocked url patterns

### DIFF
--- a/core/gather/driver/prepare.js
+++ b/core/gather/driver/prepare.js
@@ -126,10 +126,12 @@ async function prepareThrottlingAndNetwork(session, settings, options) {
   // Set request blocking before any network activity.
   // No "clearing" is done at the end of the recording since Network.setBlockedURLs([]) will unset all if
   // neccessary at the beginning of the next section.
-  const blockedUrls = (options.blockedUrlPatterns || []).concat(
-    settings.blockedUrlPatterns || []
-  );
-  await session.sendCommand('Network.setBlockedURLs', {urls: blockedUrls});
+  if (settings.blockedUrlPatterns !== false) {
+    const blockedUrls = (options.blockedUrlPatterns || []).concat(
+      settings.blockedUrlPatterns || []
+    );
+    await session.sendCommand('Network.setBlockedURLs', {urls: blockedUrls});
+  }
 
   const headers = settings.extraHeaders;
   if (headers) await session.sendCommand('Network.setExtraHTTPHeaders', {headers});

--- a/types/lhr/settings.d.ts
+++ b/types/lhr/settings.d.ts
@@ -60,7 +60,7 @@ export type ScreenEmulationSettings = {
   /** The maximum amount of time to wait for a page to load, in ms. */
   maxWaitForLoad?: number;
   /** List of URL patterns to block. */
-  blockedUrlPatterns?: string[] | null;
+  blockedUrlPatterns?: string[] | null | false;
   /** Comma-delimited list of trace categories to include. */
   additionalTraceCategories?: string | null;
   /** Flag indicating the run should only audit. */


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**

This PR allow to set the setting blockedUrlPatterns to `false` to entirely disable the call to `Network.setBlockedUrlPatterns'. 

By default, if the setting is unspecified, the call will still be made with an empty array (current behavior). This is useful in the case of an external tool controlling the browser and handing it out to Lighthouse, because Lighthouse will reset any blocked URL pattern configured by the external tool which is not desirable in this case.


**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
