### PR TITLE
docs: remove references to `devtoolsLogs` and `traces`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ A PR adding or changing a gatherer almost always needs to include the following:
    yarn update:sample-artifacts ScriptElements
    ```
 
-   This command works for updating `yarn update:sample-artifacts devtoolsLogs` or `traces` as well, but the resulting `sample_v2.json` churn may be extensive and you might be better off editing manually.
+   This command works for updating `yarn update:sample-artifacts DevtoolsLog` or `Trace` as well, but the resulting `sample_v2.json` churn may be extensive and you might be better off editing manually.
 
 1. Run `yarn update:sample-json` to update the [sample Lighthouse result JSON](core/test/results/sample_v2.json) kept in the repo for testing. This will also pull any strings needed for localization into the correct files.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -210,10 +210,10 @@ The primary objective of the audit function is to return a `score` from `0` to `
 
 The following artifacts are available for use in the audits of Lighthouse plugins. For more detailed information on their usage and purpose, see the [type information](https://github.com/GoogleChrome/lighthouse/blob/623b789497f6c87f85d366b4038deae5dc701c90/types/artifacts.d.ts#L20-L70).
 
-- `devtoolsLogs`
+- `DevtoolsLog`
 - `fetchTime`
 - `settings`
-- `traces`
+- `Trace`
 - `BenchmarkIndex`
 - `ConsoleMessages`
 - `HostUserAgent`
@@ -235,7 +235,7 @@ If you're interested in other page information not mentioned here, please file a
 
 #### Using Network Requests
 
-You might have noticed that a simple array of network requests is missing from the list above. The source information for network requests made by the page is actually contained in the `devtoolsLogs` artifact, which contains all the of DevTools Protocol traffic recorded during page load. The network request objects are derived from this message log at audit time.
+You might have noticed that a simple array of network requests is missing from the list above. The source information for network requests made by the page is actually contained in the `DevtoolsLog` artifact, which contains all the of DevTools Protocol traffic recorded during page load. The network request objects are derived from this message log at audit time.
 
 See below for an example of an audit that processes network requests.
 
@@ -249,14 +249,14 @@ class HeaderPoliceAudit {
       title: 'All headers stripped of debug data',
       failureTitle: 'Headers contained debug data',
       description: 'Pages should mask debug data in production.',
-      requiredArtifacts: ['devtoolsLogs'],
+      requiredArtifacts: ['DevtoolsLog'],
     };
   }
 
   static async audit(artifacts, context) {
     // Lighthouse loads the page multiple times: while offline, without javascript, etc.
     // Use the devtools log from the default pass of the page.
-    const devtoolsLog = artifacts.devtoolsLogs[Audit.DEFAULT_PASS];
+    const devtoolsLog = artifacts.DevtoolsLog;
     // Request the network records from the devtools log.
     // The `context` argument is passed in to allow Lighthouse to cache the result and not re-compute the network requests for every audit that needs them.
     const requests = await NetworkRecords.request(devtoolsLog, context);

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -130,7 +130,7 @@ $ lighthouse --port=9222 --screenEmulation.disabled --throttling.cpuSlowdownMult
 
 ## Lighthouse as trace processor
 
-Lighthouse can be used to analyze trace and performance data collected from other tools (like WebPageTest and ChromeDriver). The `traces` and `devtoolsLogs` artifact items can be provided using a string for the absolute path on disk if they're saved with `.trace.json` and `.devtoolslog.json` file extensions, respectively. The `devtoolsLogs` array is captured from the `Network` and `Page` domains (a la ChromeDriver's [enableNetwork and enablePage options](https://sites.google.com/a/chromium.org/chromedriver/capabilities#TOC-perfLoggingPrefs-object)).
+Lighthouse can be used to analyze trace and performance data collected from other tools (like WebPageTest and ChromeDriver). The `Trace` and `DevtoolsLog` artifact items can be provided using a string for the absolute path on disk if they're saved with `.trace.json` and `.devtoolslog.json` file extensions, respectively. The `DevtoolsLog` array is captured from the `Network` and `Page` domains (a la ChromeDriver's [enableNetwork and enablePage options](https://sites.google.com/a/chromium.org/chromedriver/capabilities#TOC-perfLoggingPrefs-object)).
 
 As an example, here's a trace-only run that reports on user timings and critical request chains:
 


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/issues/15306
