### PR TITLE
core: re-weight best practices

### DIFF
--- a/core/config/default-config.js
+++ b/core/config/default-config.js
@@ -593,7 +593,7 @@ const defaultConfig = {
       supportedModes: ['navigation', 'timespan', 'snapshot'],
       auditRefs: [
         // Trust & Safety
-        {id: 'is-on-https', weight: 1, group: 'best-practices-trust-safety'},
+        {id: 'is-on-https', weight: 5, group: 'best-practices-trust-safety'},
         {id: 'geolocation-on-start', weight: 1, group: 'best-practices-trust-safety'},
         {id: 'notification-on-start', weight: 1, group: 'best-practices-trust-safety'},
         {id: 'csp-xss', weight: 0, group: 'best-practices-trust-safety'},
@@ -608,7 +608,7 @@ const defaultConfig = {
         // General Group
         {id: 'no-unload-listeners', weight: 1, group: 'best-practices-general'},
         {id: 'js-libraries', weight: 0, group: 'best-practices-general'},
-        {id: 'deprecations', weight: 1, group: 'best-practices-general'},
+        {id: 'deprecations', weight: 5, group: 'best-practices-general'},
         {id: 'errors-in-console', weight: 1, group: 'best-practices-general'},
         {id: 'valid-source-maps', weight: 0, group: 'best-practices-general'},
         {id: 'inspector-issues', weight: 1, group: 'best-practices-general'},

--- a/core/config/default-config.js
+++ b/core/config/default-config.js
@@ -598,7 +598,7 @@ const defaultConfig = {
         {id: 'notification-on-start', weight: 1, group: 'best-practices-trust-safety'},
         {id: 'csp-xss', weight: 0, group: 'best-practices-trust-safety'},
         // User Experience
-        {id: 'paste-preventing-inputs', weight: 1, group: 'best-practices-ux'},
+        {id: 'paste-preventing-inputs', weight: 3, group: 'best-practices-ux'},
         {id: 'image-aspect-ratio', weight: 1, group: 'best-practices-ux'},
         {id: 'image-size-responsive', weight: 1, group: 'best-practices-ux'},
         {id: 'preload-fonts', weight: 1, group: 'best-practices-ux'},

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -4372,7 +4372,7 @@
             "auditRefs": [
               {
                 "id": "is-on-https",
-                "weight": 1,
+                "weight": 5,
                 "group": "best-practices-trust-safety"
               },
               {
@@ -4432,7 +4432,7 @@
               },
               {
                 "id": "deprecations",
-                "weight": 1,
+                "weight": 5,
                 "group": "best-practices-general"
               },
               {
@@ -10848,7 +10848,7 @@
             "auditRefs": [
               {
                 "id": "is-on-https",
-                "weight": 1,
+                "weight": 5,
                 "group": "best-practices-trust-safety"
               },
               {
@@ -10873,7 +10873,7 @@
               },
               {
                 "id": "deprecations",
-                "weight": 1,
+                "weight": 5,
                 "group": "best-practices-general"
               },
               {
@@ -10893,7 +10893,7 @@
               }
             ],
             "id": "best-practices",
-            "score": 0.86
+            "score": 0.93
           }
         },
         "categoryGroups": {
@@ -22000,7 +22000,7 @@
             "auditRefs": [
               {
                 "id": "is-on-https",
-                "weight": 1,
+                "weight": 5,
                 "group": "best-practices-trust-safety"
               },
               {
@@ -22060,7 +22060,7 @@
               },
               {
                 "id": "deprecations",
-                "weight": 1,
+                "weight": 5,
                 "group": "best-practices-general"
               },
               {

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -4392,7 +4392,7 @@
               },
               {
                 "id": "paste-preventing-inputs",
-                "weight": 1,
+                "weight": 3,
                 "group": "best-practices-ux"
               },
               {
@@ -15221,7 +15221,7 @@
             "auditRefs": [
               {
                 "id": "paste-preventing-inputs",
-                "weight": 1,
+                "weight": 3,
                 "group": "best-practices-ux"
               },
               {
@@ -15246,7 +15246,7 @@
               }
             ],
             "id": "best-practices",
-            "score": 0.75
+            "score": 0.83
           },
           "seo": {
             "title": "SEO",
@@ -22020,7 +22020,7 @@
               },
               {
                 "id": "paste-preventing-inputs",
-                "weight": 1,
+                "weight": 3,
                 "group": "best-practices-ux"
               },
               {

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -6469,7 +6469,7 @@
       "auditRefs": [
         {
           "id": "is-on-https",
-          "weight": 1,
+          "weight": 5,
           "group": "best-practices-trust-safety"
         },
         {
@@ -6529,7 +6529,7 @@
         },
         {
           "id": "deprecations",
-          "weight": 1,
+          "weight": 5,
           "group": "best-practices-general"
         },
         {
@@ -6549,7 +6549,7 @@
         }
       ],
       "id": "best-practices",
-      "score": 0.33
+      "score": 0.2
     },
     "seo": {
       "title": "SEO",

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -6489,7 +6489,7 @@
         },
         {
           "id": "paste-preventing-inputs",
-          "weight": 1,
+          "weight": 3,
           "group": "best-practices-ux"
         },
         {
@@ -6549,7 +6549,7 @@
         }
       ],
       "id": "best-practices",
-      "score": 0.2
+      "score": 0.18
     },
     "seo": {
       "title": "SEO",

--- a/report/test/generator/report-generator-test.js
+++ b/report/test/generator/report-generator-test.js
@@ -108,7 +108,7 @@ describe('ReportGenerator', () => {
 category,score
 \\"performance\\",\\"0.28\\"
 \\"accessibility\\",\\"0.81\\"
-\\"best-practices\\",\\"0.2\\"
+\\"best-practices\\",\\"0.18\\"
 \\"seo\\",\\"0.67\\"
 \\"pwa\\",\\"0.38\\"
 

--- a/report/test/generator/report-generator-test.js
+++ b/report/test/generator/report-generator-test.js
@@ -108,7 +108,7 @@ describe('ReportGenerator', () => {
 category,score
 \\"performance\\",\\"0.28\\"
 \\"accessibility\\",\\"0.81\\"
-\\"best-practices\\",\\"0.33\\"
+\\"best-practices\\",\\"0.2\\"
 \\"seo\\",\\"0.67\\"
 \\"pwa\\",\\"0.38\\"
 


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/lighthouse/issues/15163

Happy to discuss these weightings. Main goal was to ensure best practices is not green (i.e. <90) if deprecations fail. I also felt that the https audit was important enough in this regard.

Others that could maybe increase weighting IMO:
- `errors-in-console`
- `inspector-issues`
- `no-unload-listeners`