### PR TITLE
core(main-resource): find last matching document request

### DIFF
--- a/cli/test/fixtures/redirects-refresh.html
+++ b/cli/test/fixtures/redirects-refresh.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+  <h1>This page refreshes itself one time.</h1>
+  <script>
+    if (performance.navigation.type !== performance.navigation.TYPE_RELOAD) {
+      console.log('Not refreshed!');
+      window.location.reload();
+    } else {
+      console.log('Refreshed!');
+    }
+  </script>
+</body>
+</html>

--- a/cli/test/smokehouse/config/exclusions.js
+++ b/cli/test/smokehouse/config/exclusions.js
@@ -20,6 +20,7 @@ const exclusions = {
     'redirects-client-paint-server', 'redirects-multiple-server',
     'redirects-single-server', 'redirects-single-client',
     'redirects-history-push-state', 'redirects-scripts',
+    'redirects-refresh',
     // Disabled because these tests use settings that cannot be fully configured in
     // DevTools (e.g. throttling method "provided").
     'metrics-tricky-tti', 'metrics-tricky-tti-late-fcp', 'screenshot',

--- a/cli/test/smokehouse/core-tests.js
+++ b/cli/test/smokehouse/core-tests.js
@@ -53,6 +53,7 @@ import pwaSvgomg from './test-definitions/pwa-svgomg.js';
 import redirectsClientPaintServer from './test-definitions/redirects-client-paint-server.js';
 import redirectsHistoryPushState from './test-definitions/redirects-history-push-state.js';
 import redirectsMultipleServer from './test-definitions/redirects-multiple-server.js';
+import redirectsRefresh from './test-definitions/redirects-refresh.js';
 import redirectsScripts from './test-definitions/redirects-scripts.js';
 import redirectsSelf from './test-definitions/redirects-self.js';
 import redirectsSingleClient from './test-definitions/redirects-single-client.js';
@@ -116,6 +117,7 @@ const smokeTests = [
   redirectsClientPaintServer,
   redirectsHistoryPushState,
   redirectsMultipleServer,
+  redirectsRefresh,
   redirectsScripts,
   redirectsSelf,
   redirectsSingleClient,

--- a/cli/test/smokehouse/test-definitions/redirects-refresh.js
+++ b/cli/test/smokehouse/test-definitions/redirects-refresh.js
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright 2022 The Lighthouse Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const expectations = {
+  artifacts: {
+    MainDocumentContent: /This page refreshes itself one time/,
+    URL: {
+      requestedUrl: 'http://localhost:10200/redirects-refresh.html',
+      mainDocumentUrl: 'http://localhost:10200/redirects-refresh.html',
+      finalDisplayedUrl: 'http://localhost:10200/redirects-refresh.html',
+    },
+  },
+  lhr: {
+    requestedUrl: 'http://localhost:10200/redirects-refresh.html',
+    finalDisplayedUrl: 'http://localhost:10200/redirects-refresh.html',
+    audits: {},
+  },
+};
+
+export default {
+  id: 'redirects-refresh',
+  expectations,
+};
+

--- a/core/computed/main-resource.js
+++ b/core/computed/main-resource.js
@@ -22,7 +22,7 @@ class MainResource {
     const {mainDocumentUrl} = data.URL;
     if (!mainDocumentUrl) throw new Error('mainDocumentUrl must exist to get the main resource');
     const requests = await NetworkRecords.request(data.devtoolsLog, context);
-    const mainResource = NetworkAnalyzer.findResourceForUrl(requests, mainDocumentUrl);
+    const mainResource = NetworkAnalyzer.findLastResourceForUrl(requests, mainDocumentUrl);
     if (!mainResource) {
       throw new Error('Unable to identify the main resource');
     }

--- a/core/computed/main-resource.js
+++ b/core/computed/main-resource.js
@@ -22,7 +22,7 @@ class MainResource {
     const {mainDocumentUrl} = data.URL;
     if (!mainDocumentUrl) throw new Error('mainDocumentUrl must exist to get the main resource');
     const requests = await NetworkRecords.request(data.devtoolsLog, context);
-    const mainResource = NetworkAnalyzer.findLastResourceForUrl(requests, mainDocumentUrl);
+    const mainResource = NetworkAnalyzer.findLastDocumentForUrl(requests, mainDocumentUrl);
     if (!mainResource) {
       throw new Error('Unable to identify the main resource');
     }

--- a/core/computed/page-dependency-graph.js
+++ b/core/computed/page-dependency-graph.js
@@ -413,7 +413,7 @@ class PageDependencyGraph {
     if (!rootNode) throw new Error('rootNode not found');
 
     const mainDocumentRequest =
-      NetworkAnalyzer.findLastResourceForUrl(networkRecords, mainDocumentUrl);
+      NetworkAnalyzer.findLastDocumentForUrl(networkRecords, mainDocumentUrl);
     if (!mainDocumentRequest) throw new Error('mainDocumentRequest not found');
     const mainDocumentNode = networkNodeOutput.idToNodeMap.get(mainDocumentRequest.requestId);
     if (!mainDocumentNode) throw new Error('mainDocumentNode not found');

--- a/core/computed/page-dependency-graph.js
+++ b/core/computed/page-dependency-graph.js
@@ -412,7 +412,8 @@ class PageDependencyGraph {
     const rootNode = networkNodeOutput.idToNodeMap.get(rootRequest.requestId);
     if (!rootNode) throw new Error('rootNode not found');
 
-    const mainDocumentRequest = NetworkAnalyzer.findResourceForUrl(networkRecords, mainDocumentUrl);
+    const mainDocumentRequest =
+      NetworkAnalyzer.findLastResourceForUrl(networkRecords, mainDocumentUrl);
     if (!mainDocumentRequest) throw new Error('mainDocumentRequest not found');
     const mainDocumentNode = networkNodeOutput.idToNodeMap.get(mainDocumentRequest.requestId);
     if (!mainDocumentNode) throw new Error('mainDocumentNode not found');

--- a/core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/core/lib/dependency-graph/simulator/network-analyzer.js
@@ -511,9 +511,10 @@ class NetworkAnalyzer {
    * @param {string} resourceUrl
    * @return {LH.Artifacts.NetworkRequest|undefined}
    */
-  static findLastResourceForUrl(records, resourceUrl) {
+  static findLastDocumentForUrl(records, resourceUrl) {
     // equalWithExcludedFragments is expensive, so check that the resourceUrl starts with the request url first
     const matchingRequests = records.filter(request =>
+      request.resourceType === 'Document' &&
       resourceUrl.startsWith(request.url) &&
       UrlUtils.equalWithExcludedFragments(request.url, resourceUrl)
     );
@@ -522,7 +523,7 @@ class NetworkAnalyzer {
 
   /**
    * Resolves redirect chain given a main document.
-   * See: {@link NetworkAnalyzer.findLastResourceForUrl}) for how to retrieve main document.
+   * See: {@link NetworkAnalyzer.findLastDocumentForUrl}) for how to retrieve main document.
    *
    * @param {LH.Artifacts.NetworkRequest} request
    * @return {LH.Artifacts.NetworkRequest}

--- a/core/lib/dependency-graph/simulator/network-analyzer.js
+++ b/core/lib/dependency-graph/simulator/network-analyzer.js
@@ -507,8 +507,22 @@ class NetworkAnalyzer {
   }
 
   /**
+   * @param {Array<LH.Artifacts.NetworkRequest>} records
+   * @param {string} resourceUrl
+   * @return {LH.Artifacts.NetworkRequest|undefined}
+   */
+  static findLastResourceForUrl(records, resourceUrl) {
+    // equalWithExcludedFragments is expensive, so check that the resourceUrl starts with the request url first
+    const matchingRequests = records.filter(request =>
+      resourceUrl.startsWith(request.url) &&
+      UrlUtils.equalWithExcludedFragments(request.url, resourceUrl)
+    );
+    return matchingRequests[matchingRequests.length - 1];
+  }
+
+  /**
    * Resolves redirect chain given a main document.
-   * See: {@link NetworkAnalyzer.findResourceForUrl}) for how to retrieve main document.
+   * See: {@link NetworkAnalyzer.findLastResourceForUrl}) for how to retrieve main document.
    *
    * @param {LH.Artifacts.NetworkRequest} request
    * @return {LH.Artifacts.NetworkRequest}

--- a/core/lib/navigation-error.js
+++ b/core/lib/navigation-error.js
@@ -119,7 +119,7 @@ function getNonHtmlError(finalRecord) {
 function getPageLoadError(navigationError, context) {
   const {url, loadFailureMode, networkRecords} = context;
   /** @type {LH.Artifacts.NetworkRequest|undefined} */
-  let mainRecord = NetworkAnalyzer.findLastDocumentForUrl(networkRecords, url);
+  let mainRecord = NetworkAnalyzer.findResourceForUrl(networkRecords, url);
 
   // If the url doesn't give us a network request, it's possible we landed on a chrome-error:// page
   // In this case, just get the first document request.

--- a/core/lib/navigation-error.js
+++ b/core/lib/navigation-error.js
@@ -119,7 +119,7 @@ function getNonHtmlError(finalRecord) {
 function getPageLoadError(navigationError, context) {
   const {url, loadFailureMode, networkRecords} = context;
   /** @type {LH.Artifacts.NetworkRequest|undefined} */
-  let mainRecord = NetworkAnalyzer.findLastResourceForUrl(networkRecords, url);
+  let mainRecord = NetworkAnalyzer.findLastDocumentForUrl(networkRecords, url);
 
   // If the url doesn't give us a network request, it's possible we landed on a chrome-error:// page
   // In this case, just get the first document request.

--- a/core/lib/navigation-error.js
+++ b/core/lib/navigation-error.js
@@ -119,7 +119,7 @@ function getNonHtmlError(finalRecord) {
 function getPageLoadError(navigationError, context) {
   const {url, loadFailureMode, networkRecords} = context;
   /** @type {LH.Artifacts.NetworkRequest|undefined} */
-  let mainRecord = NetworkAnalyzer.findResourceForUrl(networkRecords, url);
+  let mainRecord = NetworkAnalyzer.findLastResourceForUrl(networkRecords, url);
 
   // If the url doesn't give us a network request, it's possible we landed on a chrome-error:// page
   // In this case, just get the first document request.


### PR DESCRIPTION
Noticed this on https://umich.edu

If a page does a JS refresh then we will use the wrong network request as the main resource because we match on url. We should be looking for the last request.
