### PR TITLE
core(network-request): loosen lightrider timing checksum

### DIFF
--- a/core/test/lib/network-request-test.js
+++ b/core/test/lib/network-request-test.js
@@ -183,11 +183,25 @@ describe('NetworkRequest', () => {
       expect(record.lrStatistics).toStrictEqual(undefined);
     });
 
-    it('does nothing if header timings do not add up', () => {
+    it('accepts if header timings only kinda do not add up', () => {
       const req = getRequest();
       const tcpHeader = req.responseHeaders[1];
       expect(tcpHeader.name).toStrictEqual(NetworkRequest.HEADER_TCP);
       tcpHeader.value = '5001';
+
+      const devtoolsLog = networkRecordsToDevtoolsLog([req]);
+      global.isLightrider = true;
+      const record = NetworkRecorder.recordsFromLogs(devtoolsLog)[0];
+
+      expect(record).toMatchObject(req);
+      expect(record.lrStatistics).not.toStrictEqual(undefined);
+    });
+
+    it('does nothing if header timings _really_ do not add up', () => {
+      const req = getRequest();
+      const tcpHeader = req.responseHeaders[1];
+      expect(tcpHeader.name).toStrictEqual(NetworkRequest.HEADER_TCP);
+      tcpHeader.value = '8000';
 
       const devtoolsLog = networkRecordsToDevtoolsLog([req]);
       global.isLightrider = true;


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/issues/15075 came back because we still sometimes have no timings, because of the checksum with used to verify the data as reasonable. While comments in the proto do suggest they should be equal, in practice we saw up to a 5ms difference.

Let's not drop everything when they don't match. Instead, reset the total time to be the sum of the components. Perhaps the stages internally are being done in parallel somehow, or they is some rounding issue, or the boundaries between these stages accidentally have gaps. Whatever the reason, we can afford to be somewhat lenient here.

b/283153039