### PR TITLE
misc: add dependabot.yml

### DIFF
--- a/core/scripts/legacy-javascript/package.json
+++ b/core/scripts/legacy-javascript/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "type": "module",
-  "dependencies": {
+  "devDependencies": {
     "@babel/cli": "^7.20.7",
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",

--- a/core/scripts/legacy-javascript/package.json
+++ b/core/scripts/legacy-javascript/package.json
@@ -8,5 +8,6 @@
     "browserify": "^16.5.0",
     "glob": "^7.1.6",
     "terser": "^5.16.1"
-  }
+  },
+  "dependencies": {}
 }

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "yarn"
+    allow:
+      - "production"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -7,3 +7,4 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

There is no way to exclude certain subfolders (like legacy-javascript package.json). See https://github.com/dependabot/dependabot-core/issues/4364 . But we could at least move all those deps into devDeps which should exclude them from updates.