### PR TITLE
tests: do not allow hashes in mock dt log

### DIFF
--- a/core/test/network-records-to-devtools-log.js
+++ b/core/test/network-records-to-devtools-log.js
@@ -416,6 +416,10 @@ function addRedirectResponseIfNeeded(networkRecords, record) {
 function networkRecordsToDevtoolsLog(networkRecords, options = {}) {
   const devtoolsLog = [];
   networkRecords.forEach((networkRecord, index) => {
+    if (networkRecord.url && new URL(networkRecord.url).hash) {
+      throw new Error(`Network records should not have hashes: ${networkRecord.url}`);
+    }
+
     networkRecord = addRedirectResponseIfNeeded(networkRecords, networkRecord);
 
     const normalizedTiming = getNormalizedRequestTiming(networkRecord);


### PR DESCRIPTION
Our network records will never contain hashes, and so neither should our tests. This tripped me up over in https://github.com/GoogleChrome/lighthouse/pull/14520#discussion_r1019583406