### PR TITLE
tests(unit): retry failures and upload failure artifacts

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -84,6 +84,13 @@ jobs:
     - name: yarn test-viewer
       run: yarn build-viewer && xvfb-run --auto-servernum bash $GITHUB_WORKSPACE/.github/scripts/test-retry.sh yarn test-viewer
 
+    - name: Upload failures
+      if: failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: Unit (ubuntu; node ${{ matrix.node }})
+        path: .tmp/unit-failures/
+
   # For windows, just test the potentially platform-specific code.
   unit-windows:
     runs-on: windows-latest

--- a/core/test/scenarios/api-test-pptr.js
+++ b/core/test/scenarios/api-test-pptr.js
@@ -75,6 +75,7 @@ describe('Individual modes API', function() {
       if (!result) throw new Error('Lighthouse failed to produce a result');
 
       const {lhr, artifacts} = result;
+      state.saveTrace(artifacts.Trace);
       expect(artifacts.URL).toEqual({
         finalDisplayedUrl: `${state.serverBaseUrl}/onclick.html#done`,
       });
@@ -133,6 +134,8 @@ describe('Individual modes API', function() {
 
       if (!result) throw new Error('Lighthouse failed to produce a result');
 
+      state.saveTrace(result.artifacts.Trace);
+
       expect(result.artifacts.URL).toEqual({
         finalDisplayedUrl: `${serverBaseUrl}/onclick.html#done`,
       });
@@ -164,6 +167,8 @@ describe('Individual modes API', function() {
       const result = await run.endTimespan();
 
       if (!result) throw new Error('Lighthouse failed to produce a result');
+
+      state.saveTrace(result.artifacts.Trace);
 
       const networkRequestsDetails = /** @type {LH.Audit.Details.Table} */ (
         result.lhr.audits['network-requests'].details);
@@ -222,6 +227,7 @@ Array [
       if (!result) throw new Error('Lighthouse failed to produce a result');
 
       const {lhr, artifacts} = result;
+      state.saveTrace(artifacts.Trace);
       expect(artifacts.URL).toEqual({
         requestedUrl: url,
         mainDocumentUrl: url,
@@ -263,6 +269,7 @@ Array [
       expect(requestor).toHaveBeenCalled();
 
       const {lhr, artifacts} = result;
+      state.saveTrace(artifacts.Trace);
       expect(lhr.requestedUrl).toEqual(requestedUrl);
       expect(lhr.finalDisplayedUrl).toEqual(mainDocumentUrl);
       expect(artifacts.URL).toEqual({

--- a/core/test/scenarios/pptr-test-utils.js
+++ b/core/test/scenarios/pptr-test-utils.js
@@ -77,6 +77,7 @@ function createTestState() {
 
       beforeEach(async () => {
         trace = undefined;
+        console.log('########');
         this.page = await this.browser.newPage();
       });
 

--- a/core/test/scenarios/start-end-navigation-test-pptr.js
+++ b/core/test/scenarios/start-end-navigation-test-pptr.js
@@ -37,6 +37,8 @@ describe('Start/End navigation', function() {
     const lhr = flowResult.steps[0].lhr;
     const artifacts = flowArtifacts.gatherSteps[0].artifacts;
 
+    state.saveTrace(artifacts.Trace);
+
     expect(artifacts.URL).toEqual({
       requestedUrl: `${state.serverBaseUrl}/?redirect=/index.html`,
       mainDocumentUrl: `${state.serverBaseUrl}/index.html`,

--- a/core/test/scripts/run-mocha-tests.js
+++ b/core/test/scripts/run-mocha-tests.js
@@ -146,6 +146,9 @@ const rawArgv = y
     'require': {
       type: 'string',
     },
+    'retries': {
+      type: 'number',
+    },
   })
   .wrap(y.terminalWidth())
   .argv;
@@ -259,6 +262,7 @@ function exit({numberFailures, numberMochaInvocations}) {
  * @property {boolean} bail
  * @property {boolean} parallel
  * @property {string | undefined} require
+ * @property {number | undefined} retries
  */
 
 /**
@@ -281,6 +285,7 @@ async function runMocha(tests, mochaArgs, invocationNumber) {
       // TODO: not working
       // parallel: tests.length > 1 && mochaArgs.parallel,
       parallel: false,
+      retries: mochaArgs.retries,
     });
 
     // @ts-expect-error - not in types.
@@ -325,6 +330,7 @@ async function main() {
     bail: argv.bail,
     parallel: argv.parallel,
     require: argv.require,
+    retries: argv.retries,
   };
 
   mochaGlobalSetup();

--- a/core/test/scripts/run-mocha-tests.js
+++ b/core/test/scripts/run-mocha-tests.js
@@ -148,6 +148,11 @@ const rawArgv = y
     },
     'retries': {
       type: 'number',
+      default: process.env.CI ? 5 : undefined,
+    },
+    'forbidOnly': {
+      type: 'boolean',
+      default: Boolean(process.env.CI),
     },
   })
   .wrap(y.terminalWidth())
@@ -260,6 +265,7 @@ function exit({numberFailures, numberMochaInvocations}) {
  * @typedef OurMochaArgs
  * @property {RegExp | string | undefined} grep
  * @property {boolean} bail
+ * @property {boolean} forbidOnly
  * @property {boolean} parallel
  * @property {string | undefined} require
  * @property {number | undefined} retries
@@ -282,6 +288,7 @@ async function runMocha(tests, mochaArgs, invocationNumber) {
       timeout: 20_000,
       bail: mochaArgs.bail,
       grep: mochaArgs.grep,
+      forbidOnly: mochaArgs.forbidOnly,
       // TODO: not working
       // parallel: tests.length > 1 && mochaArgs.parallel,
       parallel: false,
@@ -331,6 +338,7 @@ async function main() {
     parallel: argv.parallel,
     require: argv.require,
     retries: argv.retries,
+    forbidOnly: argv.forbidOnly,
   };
 
   mochaGlobalSetup();

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "unit-viewer": "yarn mocha --testMatch viewer/**/*-test.js",
     "unit-flow": "bash flow-report/test/run-flow-report-tests.sh",
     "unit": "yarn unit-flow && yarn mocha",
-    "unit:ci": "NODE_OPTIONS=--max-old-space-size=8192 npm run unit --forbid-only",
+    "unit:ci": "NODE_OPTIONS=--max-old-space-size=8192 npm run unit --forbid-only --retries=5",
     "core-unit": "yarn unit-core",
     "cli-unit": "yarn unit-cli",
     "viewer-unit": "yarn unit-viewer",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "unit-viewer": "yarn mocha --testMatch viewer/**/*-test.js",
     "unit-flow": "bash flow-report/test/run-flow-report-tests.sh",
     "unit": "yarn unit-flow && yarn mocha",
-    "unit:ci": "NODE_OPTIONS=--max-old-space-size=8192 npm run unit --forbid-only --retries=5",
+    "unit:ci": "NODE_OPTIONS=--max-old-space-size=8192 npm run unit",
     "core-unit": "yarn unit-core",
     "cli-unit": "yarn unit-cli",
     "viewer-unit": "yarn unit-viewer",


### PR DESCRIPTION
Unit failures are only happening in CI, failure artifacts might give us more insight. Retry unit tests 5 times to unblock CI.

CI failures added to backlog: https://github.com/GoogleChrome/lighthouse/issues/15382
