### PR TITLE
core(installable-manifest): update available installability errors

### DIFF
--- a/core/audits/installable-manifest.js
+++ b/core/audits/installable-manifest.js
@@ -87,7 +87,7 @@ const UIStrings = {
   /** Error message explaining that the web manifest's URL changed while the manifest was being downloaded by the browser. */
   'manifest-location-changed': `Manifest URL changed while the manifest was being fetched.`,
   /** Warning message explaining that the page does not work offline. */
-  // TODO: This error was removed in M118, we can remove this message when it hits stable.
+  // TODO(COMPAT): This error was removed in M118, we can remove this message when it hits stable.
   'warn-not-offline-capable': `Page does not work offline. The page will not be regarded as installable after Chrome 93, stable release August 2021.`,
   /** Error message explaining that Lighthouse failed while checking if the page is installable, and directing the user to try again in a new Chrome. */
   'protocol-timeout': `Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome.`,
@@ -151,17 +151,6 @@ class InstallableManifest extends Audit {
 
       // @ts-expect-error errorIds from protocol should match up against the strings dict
       const matchingString = UIStrings[err.errorId];
-
-      if (err.errorId === 'scheme-not-supported-for-webapk') {
-        // If there was no manifest, then there will be at lest one other installability error.
-        // We can ignore this error if that's the case.
-        const manifestUrl = artifacts.WebAppManifest?.url;
-        if (!manifestUrl) continue;
-
-        const scheme = new URL(manifestUrl).protocol;
-        i18nErrors.push(str_(matchingString, {scheme}));
-        continue;
-      }
 
       // Handle an errorId we don't recognize.
       if (matchingString === undefined) {

--- a/core/audits/installable-manifest.js
+++ b/core/audits/installable-manifest.js
@@ -87,17 +87,12 @@ const UIStrings = {
   /** Error message explaining that the web manifest's URL changed while the manifest was being downloaded by the browser. */
   'manifest-location-changed': `Manifest URL changed while the manifest was being fetched.`,
   /** Warning message explaining that the page does not work offline. */
+  // TODO: This error was removed in M118, we can remove this message when it hits stable.
   'warn-not-offline-capable': `Page does not work offline. The page will not be regarded as installable after Chrome 93, stable release August 2021.`,
   /** Error message explaining that Lighthouse failed while checking if the page is installable, and directing the user to try again in a new Chrome. */
   'protocol-timeout': `Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome.`,
   /** Message logged when the web app has been uninstalled o desktop, signalling that the install banner state is being reset. */
   'pipeline-restarted': 'PWA has been uninstalled and installability checks resetting.',
-  /**
-   * TODO: This error was removed in M114, we can remove this message when it hits stable.
-   * @description Error message explaining that the URL of the manifest uses a scheme that is not supported on Android.
-   * @example {data:} scheme
-   */
-  'scheme-not-supported-for-webapk': 'The manifest URL scheme ({scheme}) is not supported on Android.',
 };
 /* eslint-enable max-len */
 

--- a/core/test/audits/installable-manifest-test.js
+++ b/core/test/audits/installable-manifest-test.js
@@ -195,39 +195,6 @@ describe('PWA: webapp install banner audit', () => {
         assert.strictEqual(result.score, 1);
       });
     });
-
-    it('adds scheme to invalid scheme error message', async () => {
-      const artifacts = generateMockArtifacts();
-      artifacts.WebAppManifest.url = 'data:application/json;base64,AAAAAAAAAA';
-      artifacts.InstallabilityErrors.errors.push({
-        errorId: 'scheme-not-supported-for-webapk',
-        errorArguments: [],
-      });
-      const context = generateMockAuditContext();
-
-      const result = await InstallableManifestAudit.audit(artifacts, context);
-      expect(result.score).toEqual(0);
-      expect(result.details.items[0].reason).toBeDisplayString(
-        'The manifest URL scheme (data:) is not supported on Android.'
-      );
-    });
-
-    it('ignores invalid scheme error if there was no manifest url', async () => {
-      const artifacts = generateMockArtifacts();
-      artifacts.WebAppManifest = undefined;
-      artifacts.InstallabilityErrors.errors.push(
-        {errorId: 'no-manifest', errorArguments: []},
-        {errorId: 'scheme-not-supported-for-webapk', errorArguments: []}
-      );
-      const context = generateMockAuditContext();
-
-      const result = await InstallableManifestAudit.audit(artifacts, context);
-      expect(result.score).toEqual(0);
-      expect(result.details.items).toHaveLength(1);
-      expect(result.details.items[0].reason).toBeDisplayString(
-        'Page has no manifest <link> URL'
-      );
-    });
   });
 
   describe('warnings', () => {

--- a/shared/localization/locales/ar-XB.json
+++ b/shared/localization/locales/ar-XB.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "‏‮The‬‏ ‏‮manifest‬‏ ‏‮URL‬‏ ‏‮scheme‬‏ ({scheme}) ‏‮is‬‏ ‏‮not‬‏ ‏‮supported‬‏ ‏‮on‬‏ ‏‮Android‬‏."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "‏‮Manifest‬‏ ‏‮start‬‏ ‏‮URL‬‏ ‏‮is‬‏ ‏‮not‬‏ ‏‮valid‬‏"
   },

--- a/shared/localization/locales/ar.json
+++ b/shared/localization/locales/ar.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "مخطّط عنوان URL الخاص بملف البيان ({scheme}) غير متاح لنظام التشغيل Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "عنوان URL البداية لملف البيان غير صالح."
   },

--- a/shared/localization/locales/bg.json
+++ b/shared/localization/locales/bg.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Схемата ({scheme}) на URL адреса на манифеста не се поддържа под Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "URL адресът за стартиране в манифеста не е валиден"
   },

--- a/shared/localization/locales/ca.json
+++ b/shared/localization/locales/ca.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "L'esquema d'URL del manifest ({scheme}) no s'admet a Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "L'URL d'inici del manifest no és vàlid"
   },

--- a/shared/localization/locales/cs.json
+++ b/shared/localization/locales/cs.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Schéma adresy URL manifestu ({scheme}) není v systému Android podporováno."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Počáteční URL (start_url) v manifestu není platná"
   },

--- a/shared/localization/locales/da.json
+++ b/shared/localization/locales/da.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Manifestets webadresseskema ({scheme}) understøttes ikke i Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Manifestets startwebadresse er ikke gyldig"
   },

--- a/shared/localization/locales/de.json
+++ b/shared/localization/locales/de.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Das Manifest-URL-Schema ({scheme}) wird unter Android nicht unterstützt."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Start-URL des Manifests ist nicht gültig"
   },

--- a/shared/localization/locales/el.json
+++ b/shared/localization/locales/el.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Το URL μανιφέστου ({scheme}) δεν υποστηρίζεται στο Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Το URL έναρξης μανιφέστου δεν είναι έγκυρο"
   },

--- a/shared/localization/locales/en-GB.json
+++ b/shared/localization/locales/en-GB.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "The manifest URL scheme ({scheme}) is not supported on Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Manifest start URL is not valid"
   },

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "The manifest URL scheme ({scheme}) is not supported on Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Manifest start URL is not valid"
   },

--- a/shared/localization/locales/en-XA.json
+++ b/shared/localization/locales/en-XA.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "[Ţĥé måñîƒéšţ ÛŔĻ šçĥémé (ᐅ{scheme}ᐊ) îš ñöţ šûþþöŕţéð öñ Åñðŕöîð. one two three four five six seven eight nine ten eleven twelve]"
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "[Måñîƒéšţ šţåŕţ ÛŔĻ îš ñöţ våļîð one two three four five six seven]"
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "L̂íĝh́t̂h́ôúŝé ĉóûĺd̂ ńôt́ d̂ét̂ér̂ḿîńê íf̂ t́ĥé p̂áĝé îś îńŝt́âĺl̂áb̂ĺê. Ṕl̂éâśê t́r̂ý ŵít̂h́ â ńêẃêŕ v̂ér̂śîón̂ óf̂ Ćĥŕôḿê."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "T̂h́ê ḿâńîf́êśt̂ ÚR̂Ĺ ŝćĥém̂é ({scheme}) îś n̂ót̂ śûṕp̂ór̂t́êd́ ôń Âńd̂ŕôíd̂."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "M̂án̂íf̂éŝt́ ŝt́âŕt̂ ÚR̂Ĺ îś n̂ót̂ v́âĺîd́"
   },

--- a/shared/localization/locales/es-419.json
+++ b/shared/localization/locales/es-419.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "El esquema de URL del manifiesto ({scheme}) no es compatible en Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "La URL de inicio del manifiesto no es válida"
   },

--- a/shared/localization/locales/es.json
+++ b/shared/localization/locales/es.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "El esquema de URL del archivo de manifiesto ({scheme}) no es compatible con Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "La URL de inicio del archivo de manifiesto no es válida"
   },

--- a/shared/localization/locales/fi.json
+++ b/shared/localization/locales/fi.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Manifestin URL-kaava ({scheme}) ei ole Androidin tukema."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Manifestin aloitus-URL ei kelpaa"
   },

--- a/shared/localization/locales/fil.json
+++ b/shared/localization/locales/fil.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Hindi sinusuportahan sa Android ang scheme ng URL ng manifest ({scheme})."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Hindi valid ang start URL ng manifest"
   },

--- a/shared/localization/locales/fr.json
+++ b/shared/localization/locales/fr.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Le schéma d'URL du fichier manifeste ({scheme}) n'est pas compatible avec Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "L'URL de démarrage du fichier manifeste n'est pas valide"
   },

--- a/shared/localization/locales/he.json
+++ b/shared/localization/locales/he.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "הסכימה של כתובת ה-URL של המניפסט ({scheme}) אינה נתמכת ב-Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "כתובת ה-URL להתחלה של המניפסט לא חוקית"
   },

--- a/shared/localization/locales/hi.json
+++ b/shared/localization/locales/hi.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "मेनिफ़ेस्ट का यूआरएल जिस स्कीम ({scheme}) का इस्तेमाल करता है वह Android पर काम नहीं करती."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "दिया गया मेनिफ़ेस्ट स्टार्ट यूआरएल मान्य नहीं है"
   },

--- a/shared/localization/locales/hr.json
+++ b/shared/localization/locales/hr.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Shema URL-a manifesta ({scheme}) nije podržana na Androidu."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Početni URL manifesta nije važeći"
   },

--- a/shared/localization/locales/hu.json
+++ b/shared/localization/locales/hu.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "A manifest URL-sémája ({scheme}) nem támogatott Androidon."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "A manifest kezdési URL-je érvénytelen"
   },

--- a/shared/localization/locales/id.json
+++ b/shared/localization/locales/id.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Skema URL manifes ({scheme}) tidak didukung di Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "URL mulai manifes tidak valid"
   },

--- a/shared/localization/locales/it.json
+++ b/shared/localization/locales/it.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Lo schema dell'URL del file manifest ({scheme}) non è supportato su Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "L'URL di avvio del file manifest non è valido"
   },

--- a/shared/localization/locales/ja.json
+++ b/shared/localization/locales/ja.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "マニフェスト URL スキーム（{scheme}）は Android ではサポートされていません。"
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "マニフェストの開始 URL が無効です"
   },

--- a/shared/localization/locales/ko.json
+++ b/shared/localization/locales/ko.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Android에서 지원되지 않는 매니페스트 URL 스키마({scheme})입니다."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "잘못된 매니페스트 시작 URL입니다."
   },

--- a/shared/localization/locales/lt.json
+++ b/shared/localization/locales/lt.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Aprašo URL schema ({scheme}) nepalaikoma sistemoje „Android“."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Aprašo pradžios URL netinkamas"
   },

--- a/shared/localization/locales/lv.json
+++ b/shared/localization/locales/lv.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Manifesta URL shēma ({scheme}) netiek atbalstīta operētājsistēmā Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Manifesta sākuma URL nav derīgs"
   },

--- a/shared/localization/locales/nl.json
+++ b/shared/localization/locales/nl.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Het URL-schema van het manifest ({scheme}) wordt niet ondersteund op Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "De start-URL voor het manifest is ongeldig"
   },

--- a/shared/localization/locales/no.json
+++ b/shared/localization/locales/no.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Protokollen for manifestets nettadresse ({scheme}) støttes ikke i Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Start-nettadressen til manifestet er ikke gyldig"
   },

--- a/shared/localization/locales/pl.json
+++ b/shared/localization/locales/pl.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Schemat adresu URL pliku manifestu ({scheme}) nie jest obsługiwany na urządzeniach z Androidem."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "URL początkowy pliku manifestu jest nieprawidłowy"
   },

--- a/shared/localization/locales/pt-PT.json
+++ b/shared/localization/locales/pt-PT.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "O esquema do URL do manifesto ({scheme}) não é suportado no Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "O URL de início do manifesto não é válido."
   },

--- a/shared/localization/locales/pt.json
+++ b/shared/localization/locales/pt.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "O Android não tem suporte ao esquema de URL do manifesto ({scheme})."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "O URL de início do manifesto não é válido"
   },

--- a/shared/localization/locales/ro.json
+++ b/shared/localization/locales/ro.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Schema adresei URL a manifestului ({scheme}) nu este acceptată pe Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Adresa URL inițială a manifestului nu este validă"
   },

--- a/shared/localization/locales/ru.json
+++ b/shared/localization/locales/ru.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Android не поддерживает схему URL манифеста ({scheme})."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Недействительный URL стартовой страницы манифеста."
   },

--- a/shared/localization/locales/sk.json
+++ b/shared/localization/locales/sk.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Schéma webovej adresy manifestu ({scheme}) nie je v Androide podporovaná."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Začiatočná webová adresa manifestu nie je platná"
   },

--- a/shared/localization/locales/sl.json
+++ b/shared/localization/locales/sl.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Shema URL-ja v manifestu ({scheme}) ni podprta v sistemu Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Začetni URL manifesta ni veljaven"
   },

--- a/shared/localization/locales/sr-Latn.json
+++ b/shared/localization/locales/sr-Latn.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Šema URL-a manifesta ({scheme}) nije podržana na Android-u."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Početni URL manifesta nije važeći"
   },

--- a/shared/localization/locales/sr.json
+++ b/shared/localization/locales/sr.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Шема URL-а манифеста ({scheme}) није подржана на Android-у."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Почетни URL манифеста није важећи"
   },

--- a/shared/localization/locales/sv.json
+++ b/shared/localization/locales/sv.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Manifestets webbadresschema ({scheme}) stöds inte på Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Startwebbadressen i manifestet är ogiltig"
   },

--- a/shared/localization/locales/ta.json
+++ b/shared/localization/locales/ta.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Androidல் மெனிஃபெஸ்ட் URL ஸ்கீம் ({scheme}) ஆதரிக்கப்படவில்லை."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "மெனிஃபெஸ்ட் ஸ்டார்ட் URL தவறானது"
   },

--- a/shared/localization/locales/te.json
+++ b/shared/localization/locales/te.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "మ్యానిఫెస్ట్ URL స్కీమ్ ({scheme})కు Androidలో సపోర్ట్ లేదు."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "మ్యానిఫెస్ట్ ప్రారంభ URL చెల్లదు"
   },

--- a/shared/localization/locales/th.json
+++ b/shared/localization/locales/th.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "รูปแบบ URL ของไฟล์ Manifest ({scheme}) ใช้ไม่ได้ใน Android"
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "URL เริ่มต้นของไฟล์ Manifest ไม่ถูกต้อง"
   },

--- a/shared/localization/locales/tr.json
+++ b/shared/localization/locales/tr.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Manifest dosyasının URL şeması ({scheme}) Android'de desteklenmiyor."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Manifest başlangıç URL'si geçerli değil"
   },

--- a/shared/localization/locales/uk.json
+++ b/shared/localization/locales/uk.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Схема URL-адреси маніфесту ({scheme}) не підтримується на Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "Початкова URL-адреса в маніфесті недійсна"
   },

--- a/shared/localization/locales/vi.json
+++ b/shared/localization/locales/vi.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Lược đồ URL kê khai ({scheme}) không được hỗ trợ trên Android."
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "URL bắt đầu của tệp kê khai là không hợp lệ"
   },

--- a/shared/localization/locales/zh-HK.json
+++ b/shared/localization/locales/zh-HK.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Android 不支援資訊清單網址配置 ({scheme})。"
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "資訊清單起始網址無效"
   },

--- a/shared/localization/locales/zh-TW.json
+++ b/shared/localization/locales/zh-TW.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "Android 不支援資訊清單網址架構 ({scheme})。"
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "資訊清單開始網址無效"
   },

--- a/shared/localization/locales/zh.json
+++ b/shared/localization/locales/zh.json
@@ -1085,9 +1085,6 @@
   "core/audits/installable-manifest.js | protocol-timeout": {
     "message": "Lighthouse could not determine if the page is installable. Please try with a newer version of Chrome."
   },
-  "core/audits/installable-manifest.js | scheme-not-supported-for-webapk": {
-    "message": "清单网址的架构 ({scheme}) 在 Android 设备上不受支持。"
-  },
   "core/audits/installable-manifest.js | start-url-not-valid": {
     "message": "清单起始网址无效"
   },

--- a/third-party/chromium-synchronization/installability-errors-test.js
+++ b/third-party/chromium-synchronization/installability-errors-test.js
@@ -66,7 +66,6 @@ Array [
   "prefer-related-applications-only-beta-stable",
   "start-url-not-valid",
   "url-not-supported-for-webapk",
-  "warn-not-offline-capable",
 ]
 `);
   });


### PR DESCRIPTION
`warn-not-offline-capable` was dropped in ToT. This PR also removes `scheme-not-supported-for-webapk` from our end because that change has hit stable.