### PR TITLE
core(viewport-meta): include initial-scale value condition

### DIFF
--- a/core/computed/viewport-meta.js
+++ b/core/computed/viewport-meta.js
@@ -36,12 +36,16 @@ class ViewportMeta {
 
     const viewportProps = parsedProps.validProperties;
     const initialScale = viewportProps['initial-scale'];
-    if (initialScale && initialScale < 1) {
-      return {
-        hasViewportTag: true,
-        isMobileOptimized: false,
-        parserWarnings: warnings,
-      };
+    if (initialScale !== undefined) {
+      if (typeof initialScale === 'number') {
+        if (initialScale < 1) {
+          return {
+            hasViewportTag: true,
+            isMobileOptimized: false,
+            parserWarnings: warnings,
+          };
+        }
+      }
     }
 
     const isMobileOptimized = Boolean(viewportProps.width || initialScale);

--- a/core/computed/viewport-meta.js
+++ b/core/computed/viewport-meta.js
@@ -35,17 +35,14 @@ class ViewportMeta {
     }
 
     const viewportProps = parsedProps.validProperties;
-    const initialScale = viewportProps['initial-scale'];
-    if (initialScale !== undefined) {
-      if (typeof initialScale === 'number') {
-        if (initialScale < 1) {
-          return {
-            hasViewportTag: true,
-            isMobileOptimized: false,
-            parserWarnings: warnings,
-          };
-        }
-      }
+    const initialScale = Number(viewportProps['initial-scale']);
+
+    if (!isNaN(initialScale) && initialScale < 1) {
+      return {
+        hasViewportTag: true,
+        isMobileOptimized: false,
+        parserWarnings: warnings,
+      };
     }
 
     const isMobileOptimized = Boolean(viewportProps.width || initialScale);

--- a/core/computed/viewport-meta.js
+++ b/core/computed/viewport-meta.js
@@ -35,7 +35,16 @@ class ViewportMeta {
     }
 
     const viewportProps = parsedProps.validProperties;
-    const isMobileOptimized = Boolean(viewportProps.width || viewportProps['initial-scale']);
+    const initialScale = viewportProps['initial-scale'];
+    if (initialScale && initialScale < 1) {
+      return {
+        hasViewportTag: true,
+        isMobileOptimized: false,
+        parserWarnings: warnings,
+      };
+    }
+
+    const isMobileOptimized = Boolean(viewportProps.width || initialScale);
 
     return {
       hasViewportTag: true,

--- a/core/test/computed/viewport-meta-test.js
+++ b/core/test/computed/viewport-meta-test.js
@@ -52,8 +52,8 @@ describe('ViewportMeta computed artifact', () => {
     assert.equal(parserWarnings[1], 'Invalid values found: {"initial-scale":"microscopic"}');
   });
 
-  it('is not mobile optimized when a viewport contains an initial-scale value lower than 1',
-  async () => {
+  // eslint-disable-next-line max-len
+  it('is not mobile optimized when a viewport contains an initial-scale value lower than 1', async () => {
     const viewport = 'width=device-width, initial-scale=0.9';
     const {isMobileOptimized} =
       await ViewportMeta.compute_(makeMetaElements(viewport));

--- a/core/test/computed/viewport-meta-test.js
+++ b/core/test/computed/viewport-meta-test.js
@@ -52,6 +52,14 @@ describe('ViewportMeta computed artifact', () => {
     assert.equal(parserWarnings[1], 'Invalid values found: {"initial-scale":"microscopic"}');
   });
 
+  it('is not mobile optimized when a viewport contains an initial-scale value lower than 1',
+  async () => {
+    const viewport = 'width=device-width, initial-scale=0.9';
+    const {isMobileOptimized} =
+      await ViewportMeta.compute_(makeMetaElements(viewport));
+    assert.equal(isMobileOptimized, false);
+  });
+
   it('is mobile optimized when a valid viewport is provided', async () => {
     const viewports = [
       'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1',


### PR DESCRIPTION
Fail audit if the viewport's `initial-scale` value is less than 1.

fixes #15266
