### PR TITLE
misc(treemap): reduce granularity for byte values

### DIFF
--- a/report/renderer/i18n-formatter.js
+++ b/report/renderer/i18n-formatter.js
@@ -141,7 +141,7 @@ export class I18nFormatter {
    *                              If undefined, the number will be displayed in full.
    * @return {string}
    */
-  formatBytesWithBestUnit(size, granularity = undefined) {
+  formatBytesWithBestUnit(size, granularity = 0.1) {
     if (size >= MiB) return this.formatBytesToMiB(size, granularity);
     if (size >= KiB) return this.formatBytesToKiB(size, granularity);
     return this._formatNumberWithGranularity(size, granularity, {


### PR DESCRIPTION
We were showing way too much granularity here

<img width="787" alt="image" src="https://github.com/GoogleChrome/lighthouse/assets/4071474/676e56d6-431c-49d7-a882-b9644e769f38">


let's reduce it to just tenths of whatever byte unit being used