### PR TITLE
docs(readme): fix chrome-launcher import example

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -10,7 +10,7 @@ assumes you've installed Lighthouse as a dependency (`yarn add --dev lighthouse`
 ```js
 import fs from 'fs';
 import lighthouse from 'lighthouse';
-import chromeLauncher from 'chrome-launcher';
+import * as chromeLauncher from 'chrome-launcher';
 
 const chrome = await chromeLauncher.launch({chromeFlags: ['--headless']});
 const options = {logLevel: 'info', output: 'html', onlyCategories: ['performance'], port: chrome.port};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
This PR fixes the chrome-launcher import in the first example of `docs/README.md`
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
This is a bugfix.
<!-- Describe the need for this change -->
The module `chrome-launcher` doesn't appear to have a default export. You can test this on a blank node project by:

- Running `npm i chrome-launcher`
- Adding `"type": "module"` to package.json file.
- Writing `import chromeLauncher from 'chrome-launcher';` on an index.js file.
- Running `node index.js`
<!-- Link any documentation or information that would help understand this change -->


**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
