### PR TITLE
tests(devtools): ensure Lighthouse starts in smoke tests

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -168,7 +168,7 @@ jobs:
     - run: mkdir latest-run
       working-directory: ${{ github.workspace }}/lighthouse
     - name: yarn smoke --runner devtools
-      run: xvfb-run --auto-servernum yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }} --jobs=3 --retries=2
+      run: xvfb-run --auto-servernum yarn smoke --runner devtools --shard=${{ matrix.smoke-test-shard }}/${{ strategy.job-total }} --jobs=3 --retries=2 --debug
       working-directory: ${{ github.workspace }}/lighthouse
 
     - name: Upload failures

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -2,7 +2,7 @@ name: DevTools
 
 on:
   push:
-    branches: [main]
+    # branches: [main]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 env:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -2,7 +2,7 @@ name: DevTools
 
 on:
   push:
-    # branches: [main]
+    branches: [main]
   pull_request: # run on all PRs, not just PRs to a particular branch
 
 env:

--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -50,7 +50,7 @@ async function runLighthouse(url, config, options) {
   const {lhr, artifacts, logs} = await testUrlFromDevtools(url, {
     config,
     chromeFlags,
-    printScreenshotOnTimeout: options?.isDebug,
+    includedScreenshotInError: options?.isDebug,
   });
 
   const log = logs.join('') + '\n';

--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -40,15 +40,17 @@ async function setup() {
  * CHROME_PATH determines which Chrome is used–otherwise the default is puppeteer's chrome binary.
  * @param {string} url
  * @param {LH.Config=} config
+ * @param {{isDebug?: boolean}=} options
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
-async function runLighthouse(url, config) {
+async function runLighthouse(url, config, options) {
   const chromeFlags = [
     `--custom-devtools-frontend=file://${devtoolsDir}/out/LighthouseIntegration/gen/front_end`,
   ];
   const {lhr, artifacts, logs} = await testUrlFromDevtools(url, {
     config,
     chromeFlags,
+    printConsole: options?.isDebug,
   });
 
   const log = logs.join('') + '\n';

--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -50,7 +50,7 @@ async function runLighthouse(url, config, options) {
   const {lhr, artifacts, logs} = await testUrlFromDevtools(url, {
     config,
     chromeFlags,
-    printConsole: options?.isDebug,
+    printScreenshotOnTimeout: options?.isDebug,
   });
 
   const log = logs.join('') + '\n';

--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -50,7 +50,7 @@ async function runLighthouse(url, config, options) {
   const {lhr, artifacts, logs} = await testUrlFromDevtools(url, {
     config,
     chromeFlags,
-    includedScreenshotInError: options?.isDebug,
+    detailedError: options?.isDebug,
   });
 
   const log = logs.join('') + '\n';

--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -40,17 +40,15 @@ async function setup() {
  * CHROME_PATH determines which Chrome is used–otherwise the default is puppeteer's chrome binary.
  * @param {string} url
  * @param {LH.Config=} config
- * @param {{isDebug?: boolean}=} options
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, log: string}>}
  */
-async function runLighthouse(url, config, options) {
+async function runLighthouse(url, config) {
   const chromeFlags = [
     `--custom-devtools-frontend=file://${devtoolsDir}/out/LighthouseIntegration/gen/front_end`,
   ];
   const {lhr, artifacts, logs} = await testUrlFromDevtools(url, {
     config,
     chromeFlags,
-    detailedError: options?.isDebug,
   });
 
   const log = logs.join('') + '\n';

--- a/cli/test/smokehouse/smokehouse.js
+++ b/cli/test/smokehouse/smokehouse.js
@@ -12,8 +12,6 @@
 
 /* eslint-disable no-console */
 
-/** @typedef {import('./lib/child-process-error.js').ChildProcessError} ChildProcessError */
-
 /**
  * @typedef Run
  * @property {string[] | undefined} networkRequests
@@ -39,6 +37,7 @@ import {runLighthouse as cliLighthouseRunner} from './lighthouse-runners/cli.js'
 import {getAssertionReport} from './report-assert.js';
 import {LocalConsole} from './lib/local-console.js';
 import {ConcurrentMapper} from './lib/concurrent-mapper.js';
+import {ChildProcessError} from './lib/child-process-error.js';
 
 // The number of concurrent (`!runSerially`) tests to run if `jobs` isn't set.
 const DEFAULT_CONCURRENT_RUNS = 5;
@@ -239,11 +238,18 @@ async function runSmokeTest(smokeTestDefn, testOptions) {
  * @param {ChildProcessError|Error} err
  */
 function logChildProcessError(localConsole, err) {
-  if ('stdout' in err && 'stderr' in err) {
+  if (err instanceof ChildProcessError) {
     localConsole.adoptStdStrings(err);
   }
 
   localConsole.log(log.redify(err.stack || err.message));
+  if (err.cause) {
+    if (err.cause instanceof Error) {
+      localConsole.log(log.redify(`[cause] ${err.cause.stack || err.cause.message}`));
+    } else {
+      localConsole.log(log.redify(`[cause] ${err.cause}`));
+    }
+  }
 }
 
 /**

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -217,6 +217,9 @@ async function runLighthouse() {
     );
   });
 
+  // In CI there ins't a 100% guarantee that clicking the start button once
+  // will start the run.
+  // Therefore, keep clicking the button until we detect that the run started.
   const intervalHandle = setInterval(() => {
     const button = panel.contentElement.querySelector('button');
     button.click();

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -329,13 +329,9 @@ async function testUrlFromDevtools(url, options = {}) {
     const result = await evaluateInSession(inspectorSession, runLighthouse, [addSniffer]);
 
     return {...result, logs};
-  } catch (err) {
-    if (options.printConsole) {
-      console.log('Inspector Console:');
-      console.log(logs.join('') + '\n');
-    }
-    throw err;
   } finally {
+    console.log('Inspector Console:');
+    console.log(logs.join('') + '\n');
     await browser.close();
   }
 }

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -217,8 +217,7 @@ async function runLighthouse() {
     );
   });
 
-  // In CI there ins't a 100% guarantee that clicking the start button once
-  // will start the run.
+  // In CI clicking the start button just once is flaky and can cause a timeout.
   // Therefore, keep clicking the button until we detect that the run started.
   const intervalHandle = setInterval(() => {
     const button = panel.contentElement.querySelector('button');
@@ -297,7 +296,7 @@ function dismissDialog(dialog) {
 
 /**
  * @param {string} url
- * @param {{config?: LH.Config, chromeFlags?: string[], includedScreenshotInError?: boolean}} [options]
+ * @param {{config?: LH.Config, chromeFlags?: string[], detailedError?: boolean}} [options]
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, logs: string[]}>}
  */
 async function testUrlFromDevtools(url, options = {}) {
@@ -343,7 +342,7 @@ async function testUrlFromDevtools(url, options = {}) {
 
     return {...result, logs};
   } catch (err) {
-    if (options.includedScreenshotInError && inspectorSession) {
+    if (options.detailedError && inspectorSession) {
       const {data} = await inspectorSession.send('Page.captureScreenshot', {format: 'webp'});
       const image = `data:image/webp;base64,${data}`;
       throw new Error(

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -330,7 +330,7 @@ async function testUrlFromDevtools(url, options = {}) {
 
     return {...result, logs};
   } finally {
-    console.log('Inspector Console:');
+    console.log(`Inspector Console of DT on ${url}:`);
     console.log(logs.join('') + '\n');
     await browser.close();
   }

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -326,7 +326,15 @@ async function testUrlFromDevtools(url, options = {}) {
       await installCustomLighthouseConfig(inspectorSession, config);
     }
 
-    const result = await evaluateInSession(inspectorSession, runLighthouse, [addSniffer]);
+    const result = await evaluateInSession(inspectorSession, runLighthouse, [addSniffer])
+      .catch(async err => {
+        if (/protocolTimeout/.test(err)) {
+          console.log('Lighthouse timed out, inspector screenshot:');
+          const {data} = await inspectorSession.send('Page.captureScreenshot');
+          console.log(`data:image/png;base64,${data}`);
+        }
+        throw err;
+      });
 
     return {...result, logs};
   } finally {

--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -296,7 +296,7 @@ function dismissDialog(dialog) {
 
 /**
  * @param {string} url
- * @param {{config?: LH.Config, chromeFlags?: string[], detailedError?: boolean}} [options]
+ * @param {{config?: LH.Config, chromeFlags?: string[]}} [options]
  * @return {Promise<{lhr: LH.Result, artifacts: LH.Artifacts, logs: string[]}>}
  */
 async function testUrlFromDevtools(url, options = {}) {
@@ -342,7 +342,7 @@ async function testUrlFromDevtools(url, options = {}) {
 
     return {...result, logs};
   } catch (err) {
-    if (options.detailedError && inspectorSession) {
+    if (inspectorSession) {
       const {data} = await inspectorSession.send('Page.captureScreenshot', {format: 'webp'});
       const image = `data:image/webp;base64,${data}`;
       throw new Error(


### PR DESCRIPTION
A lot of our flaky DevTools smoke failures are timeouts on the protocol command that waits for Lighthouse to finish ([example](https://github.com/GoogleChrome/lighthouse/actions/runs/6190447931/job/16806797771?pr=15201)). After some investigation, I discovered that the Lighthouse run never actually starts in these cases. For whatever reason, clicking the start button just once isn't 100% reliable.

This PR adds a loop that clicks the start button every 100ms until we detect the run has started via JS sniffer.

I also added some code that lets us view a screenshot of the DT frontend when a timeout occurs. This screenshot diagnostic is already used in DT e2e tests, and was super helpful for debugging this problem.
