### PR TITLE
cli(sentry): set useful tags from resolved config

### DIFF
--- a/cli/bin.js
+++ b/cli/bin.js
@@ -124,6 +124,7 @@ async function begin() {
     await Sentry.init({
       url: urlUnderTest,
       flags: cliFlags,
+      config,
       environmentData: {
         serverName: 'redacted', // prevent sentry from using hostname
         environment: isDev() ? 'development' : 'production',

--- a/core/lib/sentry.js
+++ b/core/lib/sentry.js
@@ -69,9 +69,7 @@ async function init(opts) {
     /** @type {LH.Config.Settings | LH.CliFlags} */
     let settings = opts.flags;
     try {
-      const gatherMode = /** @type {LH.Gatherer.GatherMode} */ (
-        opts.flags.gatherMode || 'navigation');
-      const {resolvedConfig} = await initializeConfig(gatherMode, opts.config, opts.flags);
+      const {resolvedConfig} = await initializeConfig('navigation', opts.config, opts.flags);
       settings = resolvedConfig.settings;
     } catch {
       // The config failed validation (note - probably, we don't use a specific error type for that).

--- a/core/lib/sentry.js
+++ b/core/lib/sentry.js
@@ -5,6 +5,7 @@
  */
 
 import log from 'lighthouse-logger';
+
 import {initializeConfig} from '../config/config.js';
 
 /** @typedef {import('@sentry/node').Breadcrumb} Breadcrumb */
@@ -16,12 +17,6 @@ const SENTRY_URL = 'https://a6bb0da87ee048cc9ae2a345fc09ab2e:63a7029f46f74265981
 
 // Per-run chance of capturing errors (if enabled).
 const SAMPLE_RATE = 0.01;
-
-/** @type {Array<{pattern: RegExp, rate: number}>} */
-const SAMPLED_ERRORS = [
-  // Error code based sampling. Delete if still unused after 2019-01-01.
-  // e.g.: {pattern: /No.*node with given id/, rate: 0.01},
-];
 
 const noop = () => { };
 
@@ -117,10 +112,6 @@ async function init(opts) {
         if (sentryExceptionCache.has(key)) return;
         sentryExceptionCache.set(key, true);
       }
-
-      // Sample known errors that occur at a high frequency.
-      const sampledErrorMatch = SAMPLED_ERRORS.find(sample => sample.pattern.test(err.message));
-      if (sampledErrorMatch && sampledErrorMatch.rate <= Math.random()) return;
 
       // @ts-expect-error - properties added to protocol method LighthouseErrors.
       if (err.protocolMethod) {

--- a/core/test/lib/sentry-test.js
+++ b/core/test/lib/sentry-test.js
@@ -8,6 +8,7 @@ import jestMock from 'jest-mock';
 import * as td from 'testdouble';
 
 import {Sentry} from '../../lib/sentry.js';
+import defaultConfig from '../../config/default-config.js';
 
 describe('Sentry', () => {
   let sentryNodeMock;
@@ -18,6 +19,7 @@ describe('Sentry', () => {
     await td.replaceEsm('@sentry/node', (sentryNodeMock = {
       init: jestMock.fn().mockReturnValue({install: jestMock.fn()}),
       setExtras: jestMock.fn(),
+      setTags: jestMock.fn(),
       captureException: jestMock.fn(),
       withScope: (fn) => fn({
         setLevel: () => {},
@@ -63,8 +65,13 @@ describe('Sentry', () => {
         url: 'http://example.com',
         flags: {
           enableErrorReporting: true,
-          formFactor: 'desktop',
+          formFactor: 'mobile',
           throttlingMethod: 'devtools',
+        },
+        config: {
+          settings: {
+            channel: 'test',
+          },
         },
         environmentData: {},
       });
@@ -72,9 +79,12 @@ describe('Sentry', () => {
       expect(sentryNodeMock.init).toHaveBeenCalled();
       expect(sentryNodeMock.setExtras).toHaveBeenCalled();
       expect(sentryNodeMock.setExtras.mock.calls[0][0]).toEqual({
-        channel: 'cli',
         url: 'http://example.com',
-        formFactor: 'desktop',
+        ...defaultConfig.settings.throttling,
+      });
+      expect(sentryNodeMock.setTags.mock.calls[0][0]).toEqual({
+        channel: 'test',
+        formFactor: 'mobile',
         throttlingMethod: 'devtools',
       });
     });


### PR DESCRIPTION
1. Set useful things from the provided settings as tags, not extra. Only the form are queryable. Channel, form factor, and throttling method
2. Resolve settings from provided config and flags. This is normally only done inside core, but we repeat the same logic inside lib/sentry.js. If it fails, just ignore and fallback to using the provided flags -- core will handle the failure for us.