### PR TITLE
core(tags-blocking-first-paint): ignore malformed link tags

### DIFF
--- a/cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -45,6 +45,9 @@
 <!-- Alternate stylesheets should not show in TagsBlockingFirstPaint artifact -->
 <link rel="alternate stylesheet" href="./empty.css">
 
+<!-- Malformed links should not show in TagsBlockingFirstPaint artifact -->
+<link rel="stylesheet" href="">
+
 <!-- FAIL: block rendering -->
 <script src="./dbw_tester.js" id="dbw-tester-script"></script>
 

--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -123,6 +123,15 @@ const expectations = {
       },
       {
         rel: 'stylesheet',
+        href: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+        hrefRaw: '',
+        hreflang: '',
+        as: '',
+        crossOrigin: null,
+        source: 'head',
+      },
+      {
+        rel: 'stylesheet',
         href: 'http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200',
         hrefRaw: './dbw_tester.css?scriptActivated&delay=200',
         hreflang: '',

--- a/core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
+++ b/core/gather/gatherers/dobetterweb/tags-blocking-first-paint.js
@@ -62,6 +62,11 @@ async function collectTagsThatBlockFirstPaint() {
     /** @type {Array<LinkTag>} */
     const linkTags = [...document.querySelectorAll('link')]
       .filter(linkTag => {
+        // Ignore malformed links with no href (e.g. `<link rel="stylesheet" href="">`)
+        // The resolved `linkTag.href` will be the main document, but the main document
+        // should never be render blocking.
+        if (!linkTag.getAttribute('href')) return false;
+
         // Filter stylesheet/HTML imports that block rendering.
         // https://www.igvita.com/2012/06/14/debunking-responsive-css-performance-myths/
         // https://www.w3.org/TR/html-imports/#dfn-import-async-attribute


### PR DESCRIPTION
This was one of the errors caught be sentry. A malformed link tag on https://www.iguaracu.pr.gov.br/index.php?mod=466&idConcurso=9 caused the main document request to be marked as render blocking. This is because an empty `href` attribute on a link tag gets resolved to the main document URL on `el.href`.

Since these malformed links do not actually request anything, they should not be considered render blocking.