### PR TITLE
misc(ci): use commit sha for markdown action

### DIFF
--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@a996638015fbc9ef96beef1a41bbad7df8e06154
         # checks all markdown files from /docs including all subfolders
         with:
           use-quiet-mode: 'yes'
@@ -17,7 +17,7 @@ jobs:
           config-file: '.github/workflows/markdown.links.config.json'
           folder-path: 'docs/'
       - uses: actions/checkout@v3
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@a996638015fbc9ef96beef1a41bbad7df8e06154
         # checks all markdown files from root but ignores subfolders
         with:
           use-quiet-mode: 'yes'


### PR DESCRIPTION
This is our only non-GitHub GHA action that wasn't pinned to a hash.