### PR TITLE
misc: have dependabot check github actions deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "yarn"
+    directory: '/'
     allow:
       - "production"
     schedule:
@@ -8,3 +9,8 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+  - package-ecosystem: 'github-actions' # Necessary to update action hash
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2


### PR DESCRIPTION
fixing that occasional error in the dependabot action.  it needed "directory"


i also added a thing to give us PRs when our gh actions deps  are outdated