### PR TITLE
core: add `clearStorageTypes` option

### DIFF
--- a/core/config/constants.js
+++ b/core/config/constants.js
@@ -106,6 +106,7 @@ const defaultSettings = {
 
   auditMode: false,
   gatherMode: false,
+  clearStorageTypes: ['file_systems', 'shader_cache', 'service_workers', 'cache_storage'],
   disableStorageReset: false,
   debugNavigation: false,
   channel: 'node',

--- a/core/gather/driver/storage.js
+++ b/core/gather/driver/storage.js
@@ -36,9 +36,10 @@ const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 /**
  * @param {LH.Gatherer.ProtocolSession} session
  * @param {string} url
+ * @param {LH.Config.Settings['clearStorageTypes']} clearStorageTypes
  * @return {Promise<LH.IcuMessage[]>}
  */
-async function clearDataForOrigin(session, url) {
+async function clearDataForOrigin(session, url, clearStorageTypes) {
   const status = {msg: 'Cleaning origin data', id: 'lh:storage:clearDataForOrigin'};
   log.time(status);
 
@@ -46,17 +47,7 @@ async function clearDataForOrigin(session, url) {
 
   const origin = new URL(url).origin;
 
-  // Clear some types of storage.
-  // Cookies are not cleared, so the user isn't logged out.
-  // indexeddb, websql, and localstorage are not cleared to prevent loss of potentially important data.
-  //   https://chromedevtools.github.io/debugger-protocol-viewer/tot/Storage/#type-StorageType
-  const typesToClear = [
-    // 'cookies',
-    'file_systems',
-    'shader_cache',
-    'service_workers',
-    'cache_storage',
-  ].join(',');
+  const typesToClear = clearStorageTypes.join(',');
 
   // `Storage.clearDataForOrigin` is one of our PROTOCOL_TIMEOUT culprits and this command is also
   // run in the context of PAGE_HUNG to cleanup. We'll keep the timeout low and just warn if it fails.

--- a/core/gather/navigation-runner.js
+++ b/core/gather/navigation-runner.js
@@ -247,7 +247,12 @@ async function _navigation(navigationContext) {
  */
 async function _cleanup({requestedUrl, driver, resolvedConfig, lhBrowser, lhPage}) {
   const didResetStorage = !resolvedConfig.settings.disableStorageReset && requestedUrl;
-  if (didResetStorage) await storage.clearDataForOrigin(driver.defaultSession, requestedUrl);
+  if (didResetStorage) {
+    await storage.clearDataForOrigin(driver.defaultSession,
+    requestedUrl,
+    resolvedConfig.settings.clearStorageTypes
+    );
+  }
 
   await driver.disconnect();
 

--- a/core/test/fixtures/user-flows/artifacts/step0/artifacts.json
+++ b/core/test/fixtures/user-flows/artifacts/step0/artifacts.json
@@ -495,6 +495,7 @@
     "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
     "auditMode": false,
     "gatherMode": false,
+    "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
     "disableStorageReset": false,
     "debugNavigation": false,
     "channel": "node",

--- a/core/test/fixtures/user-flows/artifacts/step1/artifacts.json
+++ b/core/test/fixtures/user-flows/artifacts/step1/artifacts.json
@@ -287,6 +287,7 @@
     "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
     "auditMode": false,
     "gatherMode": false,
+    "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
     "disableStorageReset": false,
     "debugNavigation": false,
     "channel": "node",

--- a/core/test/fixtures/user-flows/artifacts/step2/artifacts.json
+++ b/core/test/fixtures/user-flows/artifacts/step2/artifacts.json
@@ -207,6 +207,7 @@
     "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
     "auditMode": false,
     "gatherMode": false,
+    "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
     "disableStorageReset": false,
     "debugNavigation": false,
     "channel": "node",

--- a/core/test/fixtures/user-flows/artifacts/step3/artifacts.json
+++ b/core/test/fixtures/user-flows/artifacts/step3/artifacts.json
@@ -479,6 +479,7 @@
     "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
     "auditMode": false,
     "gatherMode": false,
+    "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
     "disableStorageReset": true,
     "debugNavigation": false,
     "channel": "node",

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -3746,6 +3746,12 @@
           "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
           "auditMode": false,
           "gatherMode": false,
+          "clearStorageTypes": [
+            "file_systems",
+            "shader_cache",
+            "service_workers",
+            "cache_storage"
+          ],
           "disableStorageReset": false,
           "debugNavigation": false,
           "channel": "node",
@@ -10671,6 +10677,12 @@
           "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
           "auditMode": false,
           "gatherMode": false,
+          "clearStorageTypes": [
+            "file_systems",
+            "shader_cache",
+            "service_workers",
+            "cache_storage"
+          ],
           "disableStorageReset": false,
           "debugNavigation": false,
           "channel": "node",
@@ -14793,6 +14805,12 @@
           "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
           "auditMode": false,
           "gatherMode": false,
+          "clearStorageTypes": [
+            "file_systems",
+            "shader_cache",
+            "service_workers",
+            "cache_storage"
+          ],
           "disableStorageReset": false,
           "debugNavigation": false,
           "channel": "node",
@@ -21355,6 +21373,12 @@
           "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
           "auditMode": false,
           "gatherMode": false,
+          "clearStorageTypes": [
+            "file_systems",
+            "shader_cache",
+            "service_workers",
+            "cache_storage"
+          ],
           "disableStorageReset": true,
           "debugNavigation": false,
           "channel": "node",

--- a/core/test/gather/driver/prepare-test.js
+++ b/core/test/gather/driver/prepare-test.js
@@ -245,6 +245,19 @@ describe('.prepareTargetForNavigationMode()', () => {
     expect(storageMock.clearBrowserCaches).toHaveBeenCalled();
   });
 
+  it('clears storage types specified by user', async () => {
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+      disableStorageReset: false,
+      clearStorageTypes: ['cookies', 'shared_storage']},
+      url);
+
+    expect(storageMock.clearDataForOrigin).toHaveBeenCalledWith(expect.anything(),
+      url,
+      ['cookies', 'shared_storage']);
+    expect(storageMock.clearBrowserCaches).toHaveBeenCalled();
+  });
+
   it('does not clear storage when globally disabled', async () => {
     await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
       ...constants.defaultSettings,
@@ -275,9 +288,9 @@ describe('.prepareTargetForNavigationMode()', () => {
     }, url);
 
     expect(warnings).toEqual([
-      'This is a storage warning',
       'This is a clear data warning',
       'This is a clear cache warning',
+      'This is a storage warning',
     ]);
   });
 });

--- a/core/test/gather/navigation-runner-test.js
+++ b/core/test/gather/navigation-runner-test.js
@@ -459,6 +459,13 @@ describe('NavigationRunner', () => {
       expect(mocks.storageMock.clearDataForOrigin).toHaveBeenCalled();
     });
 
+    it('should clear storage with user-config clearStorageTypes', async () => {
+      resolvedConfig.settings.disableStorageReset = false;
+      resolvedConfig.settings.clearStorageTypes = ['cookies', 'indexeddb'];
+      await runner._cleanup({requestedUrl, driver, resolvedConfig});
+      expect(mocks.storageMock.clearDataForOrigin).toHaveBeenCalledWith(expect.anything(), 'http://example.com', ['cookies', 'indexeddb']);
+    });
+
     it('should not clear storage when storage reset was disabled', async () => {
       resolvedConfig.settings.disableStorageReset = true;
       await runner._cleanup({requestedUrl, driver, resolvedConfig});

--- a/core/test/results/artifacts/artifacts.json
+++ b/core/test/results/artifacts/artifacts.json
@@ -64,6 +64,7 @@
     "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
     "auditMode": false,
     "gatherMode": "core/test/results/artifacts",
+    "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
     "disableStorageReset": false,
     "debugNavigation": false,
     "channel": "cli",

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -5742,6 +5742,12 @@
     "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Mobile Safari/537.36",
     "auditMode": true,
     "gatherMode": false,
+    "clearStorageTypes": [
+      "file_systems",
+      "shader_cache",
+      "service_workers",
+      "cache_storage"
+    ],
     "disableStorageReset": false,
     "debugNavigation": false,
     "channel": "cli",

--- a/report/test-assets/lhr-3.0.0.json
+++ b/report/test-assets/lhr-3.0.0.json
@@ -1671,6 +1671,7 @@
       },
       "auditMode": false,
       "gatherMode": false,
+      "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
       "disableStorageReset": false,
       "disableDeviceEmulation": false,
       "blockedUrlPatterns": null,

--- a/report/test-assets/lhr-4.3.0.json
+++ b/report/test-assets/lhr-4.3.0.json
@@ -1854,6 +1854,7 @@
         },
         "auditMode": false,
         "gatherMode": false,
+        "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
         "disableStorageReset": false,
         "disableDeviceEmulation": false,
         "emulatedFormFactor": "mobile",

--- a/report/test-assets/lhr-5.0.0.json
+++ b/report/test-assets/lhr-5.0.0.json
@@ -3187,6 +3187,7 @@
         },
         "auditMode": true,
         "gatherMode": false,
+        "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
         "disableStorageReset": false,
         "emulatedFormFactor": "mobile",
         "channel": "cli",

--- a/report/test-assets/lhr-6.0.0.json
+++ b/report/test-assets/lhr-6.0.0.json
@@ -3662,6 +3662,7 @@
         },
         "auditMode": true,
         "gatherMode": false,
+        "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
         "disableStorageReset": false,
         "emulatedFormFactor": "mobile",
         "internalDisableDeviceScreenEmulation": false,

--- a/report/test-assets/lhr-8.5.0.json
+++ b/report/test-assets/lhr-8.5.0.json
@@ -4557,6 +4557,7 @@
         "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 7.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4590.2 Mobile Safari/537.36 Chrome-Lighthouse",
         "auditMode": false,
         "gatherMode": false,
+        "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
         "disableStorageReset": false,
         "debugNavigation": false,
         "channel": "devtools",

--- a/treemap/app/debug.json
+++ b/treemap/app/debug.json
@@ -19398,6 +19398,7 @@
       "emulatedUserAgent": "Mozilla/5.0 (Linux; Android 7.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4695.0 Mobile Safari/537.36 Chrome-Lighthouse",
       "auditMode": true,
       "gatherMode": false,
+      "clearStorageTypes": ["file_systems", "shader_cache", "service_workers", "cache_storage"],
       "disableStorageReset": false,
       "debugNavigation": false,
       "channel": "cli",

--- a/types/lhr/settings.d.ts
+++ b/types/lhr/settings.d.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type {Protocol as Crdp} from 'devtools-protocol/types/protocol.js';
+
 import Budget from './budget.js';
 
 export type Locale = 'en-US'|'en'|'en-AU'|'en-GB'|'en-IE'|'en-SG'|'en-ZA'|'en-IN'|'ar-XB'|'ar'|'bg'|'ca'|'cs'|'da'|'de'|'el'|'en-XA'|'en-XL'|'es'|'es-419'|'es-AR'|'es-BO'|'es-BR'|'es-BZ'|'es-CL'|'es-CO'|'es-CR'|'es-CU'|'es-DO'|'es-EC'|'es-GT'|'es-HN'|'es-MX'|'es-NI'|'es-PA'|'es-PE'|'es-PR'|'es-PY'|'es-SV'|'es-US'|'es-UY'|'es-VE'|'fi'|'fil'|'fr'|'he'|'hi'|'hr'|'hu'|'gsw'|'id'|'in'|'it'|'iw'|'ja'|'ko'|'lt'|'lv'|'mo'|'nl'|'nb'|'no'|'pl'|'pt'|'pt-PT'|'ro'|'ru'|'sk'|'sl'|'sr'|'sr-Latn'|'sv'|'ta'|'te'|'th'|'tl'|'tr'|'uk'|'vi'|'zh'|'zh-HK'|'zh-TW';
@@ -69,6 +71,14 @@ export type ScreenEmulationSettings = {
   gatherMode?: boolean | string;
   /** Flag indicating that the browser storage should not be reset for the audit. */
   disableStorageReset?: boolean;
+  /**
+   * Flag indicating which kinds of browser storage should be reset for the audit.
+   * Cookies are not cleared by default, so the user isn't logged out.
+   * indexeddb, websql, and localstorage are not cleared by default to prevent
+   * loss of potentially important data.
+   * https://chromedevtools.github.io/debugger-protocol-viewer/tot/Storage/#type-StorageType
+   */
+  clearStorageTypes?: Crdp.Storage.StorageType[];
   /** Flag indicating that Lighthouse should pause after page load to wait for the user's permission to continue the audit. */
   debugNavigation?: boolean;
   /** If set to true, will skip the initial navigation to about:blank. */


### PR DESCRIPTION
**Summary**
This commit adds a new option to the config to allow users to specify which storage types to clear when resetting storage for a URL. This is useful for testing scenarios where you want to clear all storage except for a specific type.

Test plan:
- Added a few unit tests to make sure the option works as expected

**Related Issues/PRs**

closes #15506