### PR TITLE
misc: tweak dependabot ecosystem value

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "yarn"
+  - package-ecosystem: "npm"
     directory: '/'
     allow:
       - "production"


### PR DESCRIPTION
I've seen this error on prs: https://github.com/GoogleChrome/lighthouse/pull/14915/checks?check_run_id=17444701281

![image](https://github.com/GoogleChrome/lighthouse/assets/39191/c8bc3cac-fdee-479f-8176-2c1d4c5b39cf)

we should use  'npm': https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem

(also i SWEAR it told me to use yarn a week ago, but w/e)