### PR TITLE
v11.2.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,75 @@
+Thanks to our new contributors 👽🐷🐰🐯🐻! 
+
+ <a name="11.2.0"></a>
+# 11.2.0 (2023-10-09)
+[Full Changelog](https://github.com/GoogleChrome/lighthouse/compare/v11.1.0...v11.2.0)
+
+~~ TODO: https://chromiumdash.appspot.com/schedule ~~
+We expect this release to ship in the DevTools of [Chrome XX](https://chromiumdash.appspot.com/schedule), and to PageSpeed Insights within 2 weeks.
+
+## Notable Changes
+~~ TODO: Move notable changes here ~~
+
+
+## Core
+
+* align performance audit score with metric savings ([#15447](https://github.com/GoogleChrome/lighthouse/pull/15447))
+* asset-saver: fix handling of undefined trace ([#15451](https://github.com/GoogleChrome/lighthouse/pull/15451))
+* csp: use monospace for technical terms in strings ([#15511](https://github.com/GoogleChrome/lighthouse/pull/15511))
+* driver: attach to worker targets ([#14212](https://github.com/GoogleChrome/lighthouse/pull/14212))
+* inspector-issues: add `propertyRuleIssue` ([#15491](https://github.com/GoogleChrome/lighthouse/pull/15491))
+* installable-manifest: use monospace for technical terms in strings ([#15513](https://github.com/GoogleChrome/lighthouse/pull/15513))
+* long-tasks: compute TBT impact ([#15197](https://github.com/GoogleChrome/lighthouse/pull/15197))
+* mainthread-work-breakdown: add TBT savings ([#15201](https://github.com/GoogleChrome/lighthouse/pull/15201))
+* tags-blocking-first-paint: ignore malformed link tags ([#15489](https://github.com/GoogleChrome/lighthouse/pull/15489))
+
+## CLI
+
+* sentry: set useful tags from resolved config ([#15485](https://github.com/GoogleChrome/lighthouse/pull/15485))
+
+## Report
+
+* sort performance audits based on impact ([#15445](https://github.com/GoogleChrome/lighthouse/pull/15445))
+* add explodey gauge for performance category ([#15396](https://github.com/GoogleChrome/lighthouse/pull/15396))
+* redefine gauge percentage positioning ([#15486](https://github.com/GoogleChrome/lighthouse/pull/15486))
+
+## Deps
+
+* upgrade puppeteer to v21.3.6 ([#15490](https://github.com/GoogleChrome/lighthouse/pull/15490))
+* pin puppeteer version ([#15458](https://github.com/GoogleChrome/lighthouse/pull/15458))
+* upgrade `axe-core` to 4.8.1 ([#15446](https://github.com/GoogleChrome/lighthouse/pull/15446))
+* chrome-launcher: upgrade to 1.1.0 ([#15517](https://github.com/GoogleChrome/lighthouse/pull/15517))
+
+## Clients
+
+* viewer: fix preload links ([#15515](https://github.com/GoogleChrome/lighthouse/pull/15515))
+
+## I18n
+
+* upgrade to latest icu formatter ([#13834](https://github.com/GoogleChrome/lighthouse/pull/13834))
+
+## Docs
+
+* plugins: minor corrections ([#15449](https://github.com/GoogleChrome/lighthouse/pull/15449))
+* readme: edit description of the PageVitals tool ([#15395](https://github.com/GoogleChrome/lighthouse/pull/15395))
+
+## Tests
+
+* use new headless for puppeteer tests ([#15374](https://github.com/GoogleChrome/lighthouse/pull/15374))
+* dbw: increase wasted ms threshold ([#15483](https://github.com/GoogleChrome/lighthouse/pull/15483))
+* devtools: remove usage of frontend globals ([#15518](https://github.com/GoogleChrome/lighthouse/pull/15518))
+* devtools: ensure Lighthouse starts in smoke tests ([#15459](https://github.com/GoogleChrome/lighthouse/pull/15459))
+* devtools: fix viewport in smoke tests ([#15454](https://github.com/GoogleChrome/lighthouse/pull/15454))
+* devtools: sync e2e ([#15444](https://github.com/GoogleChrome/lighthouse/pull/15444))
+
+## Misc
+
+* tweak dependabot ecosystem value ([#15521](https://github.com/GoogleChrome/lighthouse/pull/15521))
+* have dependabot check github actions deps ([#15496](https://github.com/GoogleChrome/lighthouse/pull/15496))
+* adopt minimal license headers ([#15456](https://github.com/GoogleChrome/lighthouse/pull/15456))
+* bot: delete stale git bot rules ([#14915](https://github.com/GoogleChrome/lighthouse/pull/14915))
+* ci: use commit sha for markdown action ([#15493](https://github.com/GoogleChrome/lighthouse/pull/15493))
+
 <a name="11.1.0"></a>
 # 11.1.0 (2023-09-06)
 [Full Changelog](https://github.com/GoogleChrome/lighthouse/compare/v11.0.0...v11.1.0)

--- a/changelog.md
+++ b/changelog.md
@@ -1,19 +1,19 @@
-Thanks to our new contributors 👽🐷🐰🐯🐻! 
-
- <a name="11.2.0"></a>
+<a name="11.2.0"></a>
 # 11.2.0 (2023-10-09)
 [Full Changelog](https://github.com/GoogleChrome/lighthouse/compare/v11.1.0...v11.2.0)
 
-~~ TODO: https://chromiumdash.appspot.com/schedule ~~
-We expect this release to ship in the DevTools of [Chrome XX](https://chromiumdash.appspot.com/schedule), and to PageSpeed Insights within 2 weeks.
+We expect this release to ship in the DevTools of [Chrome 120](https://chromiumdash.appspot.com/schedule), and to PageSpeed Insights within 2 weeks.
 
 ## Notable Changes
-~~ TODO: Move notable changes here ~~
 
+This update includes an overhaul to the performance category. Performance insights are now scored and prioritized based on their estimated impact to the performance metrics. Additionally, the performance score gauge includes more detailed information about how each metric affects the score.
+
+* core: align performance audit score with metric savings ([#15447](https://github.com/GoogleChrome/lighthouse/pull/15447))
+* report: sort performance audits based on impact ([#15445](https://github.com/GoogleChrome/lighthouse/pull/15445))
+* report: add explodey gauge for performance category ([#15396](https://github.com/GoogleChrome/lighthouse/pull/15396))
 
 ## Core
 
-* align performance audit score with metric savings ([#15447](https://github.com/GoogleChrome/lighthouse/pull/15447))
 * asset-saver: fix handling of undefined trace ([#15451](https://github.com/GoogleChrome/lighthouse/pull/15451))
 * csp: use monospace for technical terms in strings ([#15511](https://github.com/GoogleChrome/lighthouse/pull/15511))
 * driver: attach to worker targets ([#14212](https://github.com/GoogleChrome/lighthouse/pull/14212))
@@ -29,8 +29,6 @@ We expect this release to ship in the DevTools of [Chrome XX](https://chromiumda
 
 ## Report
 
-* sort performance audits based on impact ([#15445](https://github.com/GoogleChrome/lighthouse/pull/15445))
-* add explodey gauge for performance category ([#15396](https://github.com/GoogleChrome/lighthouse/pull/15396))
 * redefine gauge percentage positioning ([#15486](https://github.com/GoogleChrome/lighthouse/pull/15486))
 
 ## Deps

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -2,7 +2,7 @@
   "steps": [
     {
       "lhr": {
-        "lighthouseVersion": "11.1.0",
+        "lighthouseVersion": "11.2.0",
         "requestedUrl": "https://www.mikescerealshack.co/",
         "mainDocumentUrl": "https://www.mikescerealshack.co/",
         "finalDisplayedUrl": "https://www.mikescerealshack.co/",
@@ -8429,7 +8429,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "11.1.0",
+        "lighthouseVersion": "11.2.0",
         "finalDisplayedUrl": "https://www.mikescerealshack.co/search?q=call+of+duty",
         "fetchTime": "2023-01-13T23:27:51.982Z",
         "gatherMode": "timespan",
@@ -12401,7 +12401,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "11.1.0",
+        "lighthouseVersion": "11.2.0",
         "finalDisplayedUrl": "https://www.mikescerealshack.co/search?q=call+of+duty",
         "fetchTime": "2023-01-13T23:28:01.888Z",
         "gatherMode": "snapshot",
@@ -17620,7 +17620,7 @@
     },
     {
       "lhr": {
-        "lighthouseVersion": "11.1.0",
+        "lighthouseVersion": "11.2.0",
         "requestedUrl": "https://www.mikescerealshack.co/corrections",
         "mainDocumentUrl": "https://www.mikescerealshack.co/corrections",
         "finalDisplayedUrl": "https://www.mikescerealshack.co/corrections",

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -1,5 +1,5 @@
 {
-  "lighthouseVersion": "11.1.0",
+  "lighthouseVersion": "11.2.0",
   "requestedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "mainDocumentUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",
   "finalDisplayedUrl": "http://localhost:10200/dobetterweb/dbw_tester.html",

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -61,10 +61,10 @@ A Lighthouse plugin is just a node module with a name that starts with `lighthou
   "type": "module",
   "main": "plugin.js",
   "peerDependencies": {
-    "lighthouse": "^11.1.0"
+    "lighthouse": "^11.2.0"
   },
   "devDependencies": {
-    "lighthouse": "^11.1.0"
+    "lighthouse": "^11.2.0"
   }
 }
 ```

--- a/docs/recipes/lighthouse-plugin-example/package.json
+++ b/docs/recipes/lighthouse-plugin-example/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "./plugin.js",
   "peerDependencies": {
-    "lighthouse": "^11.1.0"
+    "lighthouse": "^11.2.0"
   },
   "devDependencies": {
     "lighthouse": "^8.6.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lighthouse",
   "type": "module",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "Automated auditing, performance metrics, and best practices for the web.",
   "main": "./core/index.js",
   "bin": {

--- a/third-party/devtools-tests/e2e/lighthouse/navigation_test.ts
+++ b/third-party/devtools-tests/e2e/lighthouse/navigation_test.ts
@@ -102,7 +102,7 @@ describe('Navigation', async function() {
     // 1 navigation after auditing to reset state
     assert.strictEqual(numNavigations, 6);
 
-    assert.strictEqual(lhr.lighthouseVersion, '11.1.0');
+    assert.strictEqual(lhr.lighthouseVersion, '11.2.0');
     assert.match(lhr.finalUrl, /^https:\/\/localhost:[0-9]+\/test\/e2e\/resources\/lighthouse\/hello.html/);
 
     assert.strictEqual(lhr.configSettings.throttlingMethod, 'simulate');


### PR DESCRIPTION
Holding off on https://github.com/GoogleChrome/lighthouse/pull/15520 until more strings are translated.

Added a descriptive callout for the performance category changes.