### PR TITLE
docs(plugins): add link to GitHub repo template

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,7 +47,7 @@ To develop a Lighthouse plugin, you'll need to write three things:
 1. A `plugin.js` file to declare your plugin's audits, category name, and scoring.
 1. Custom audit files that will contain the primary logic of the checks you want to perform.
 
-To see a fully functioning example, see our [plugin recipe](./recipes/lighthouse-plugin-example/readme.md).
+To see a fully functioning example, see our [plugin recipe](./recipes/lighthouse-plugin-example/readme.md) or its [GitHub repository template](https://github.com/GoogleChrome/lighthouse-plugin-example).
 
 #### `package.json`
 

--- a/docs/recipes/lighthouse-plugin-example/readme.md
+++ b/docs/recipes/lighthouse-plugin-example/readme.md
@@ -1,5 +1,7 @@
 # Lighthouse plugin recipe
 
+The result of this guide can be found at our [Lighthouse Plugin GitHub repository template](https://github.com/GoogleChrome/lighthouse-plugin-example)
+
 ## Contents
 - `package.json` - declares the plugin's entry point (`plugin.js`)
 - `plugin.js` - instructs Lighthouse to run the plugin's own `preload-as.js` audit; describes the new category and its details for the report


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse-plugin-example is now available as a template.