### PR TITLE
report: use normal gauge if performance score is null

### DIFF
--- a/report/renderer/performance-category-renderer.js
+++ b/report/renderer/performance-category-renderer.js
@@ -302,7 +302,8 @@ export class PerformanceCategoryRenderer extends CategoryRenderer {
       element.append(groupEl);
     }
 
-    if (!options || options?.gatherMode === 'navigation') {
+    const isNavigationMode = !options || options?.gatherMode === 'navigation';
+    if (isNavigationMode && category.score !== null) {
       const el = createGauge(this.dom);
       updateGauge(this.dom, el, category);
       this.dom.find('.lh-score__gauge', element).replaceWith(el);


### PR DESCRIPTION
Fixes https://github.com/GoogleChrome/lighthouse/issues/15551

We could implement a `null` case within the explodey gauge, but then we would need a fancy way of displaying an erroneous metric arc which I don't think is worth it. Just showing a normal gauge that already handles this case should be fine.