### PR TITLE
tests(devtools): extend protocol timeout for load

### DIFF
--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -307,6 +307,7 @@ async function testUrlFromDevtools(url, options = {}) {
   const browser = await puppeteer.connect({
     browserURL: `http://127.0.0.1:${chrome.port}`,
     defaultViewport: null,
+    protocolTimeout: 300_000, // 5 min
   });
 
   /** @type {puppeteer.CDPSession|undefined} */


### PR DESCRIPTION
Related https://github.com/GoogleChrome/lighthouse/issues/14083

Protocol timeouts are happening a lot DT smokes for oopifs:
https://github.com/GoogleChrome/lighthouse/actions/runs/6579880151/attempts/2?pr=15554

The root cause is that Lighthouse never sees network quiet, and so Lighthouse waits for `maxWaitForLoad` before continuing.

The problem is that [`oopif-requests` defines `maxWaitForLoad`](https://github.com/GoogleChrome/lighthouse/blob/main/cli/test/smokehouse/test-definitions/oopif-requests.js#L28) to be longer the same a the [default puppeteer timeout of 180s](https://pptr.dev/api/puppeteer.browserconnectoptions/#properties). If Lighthouse spends 180s just waiting for load then the entire run is guaranteed to take longer than 180s. This PR extends the puppeteer timeout to 5 min to accommodate the possibility of `oopif-requests` hitting it's `maxWaitForLoad`.
