### PR TITLE
clients(devtools): default to ignore fatal errors 

### DIFF
--- a/clients/devtools/devtools-entry.js
+++ b/clients/devtools/devtools-entry.js
@@ -38,6 +38,7 @@ function createConfig(categoryIDs, device) {
     // In DevTools, emulation is applied _before_ Lighthouse starts (to deal with viewport emulation bugs). go/xcnjf
     // As a result, we don't double-apply viewport emulation.
     screenEmulation: {disabled: true},
+    ignoreStatusCode: true,
   };
   if (device === 'desktop') {
     settings.throttling = constants.throttling.desktopDense4G;


### PR DESCRIPTION
Follow up to using new flag from #15494

This enables the flag to ignore fatal error status codes on Devtools by default.