### PR TITLE
audit(non-composited-animations): add UIString for custom properties

### DIFF
--- a/core/audits/non-composited-animations.js
+++ b/core/audits/non-composited-animations.js
@@ -32,6 +32,12 @@ const UIStrings = {
     =1 {Unsupported CSS Property: {properties}}
     other {Unsupported CSS Properties: {properties}}
   }`,
+  /**
+   * @description Descriptive reason for why a user-provided animation failed to be optimized by the browser due to the animated custom CSS property not being supported on the compositor. Shown in a table with a list of other potential failure reasons.
+   * @example {--my-custom-property} properties
+   * */
+  unsupportedCustomCSSProperty: 'Custom CSS properties cannot be animated on the compositor: ' +
+  '{properties}',
   /** Descriptive reason for why a user-provided animation failed to be optimized by the browser due to a `transform` property being dependent on the size of the element itself. Shown in a table with a list of other potential failure reasons.  */
   transformDependsBoxSize: 'Transform-related property depends on box size',
   /** Descriptive reason for why a user-provided animation failed to be optimized by the browser due to a `filter` property possibly moving pixels. Shown in a table with a list of other potential failure reasons.  */
@@ -55,6 +61,10 @@ const ACTIONABLE_FAILURE_REASONS = [
   {
     flag: 1 << 13,
     text: UIStrings.unsupportedCSSProperty,
+  },
+  {
+    flag: 1 << 13,
+    text: UIStrings.unsupportedCustomCSSProperty,
   },
   {
     flag: 1 << 11,
@@ -91,9 +101,18 @@ function getActionableFailureReasons(failureCode, unsupportedProperties) {
     .filter(reason => failureCode & reason.flag)
     .map(reason => {
       if (reason.text === UIStrings.unsupportedCSSProperty) {
+        const nonCustomUnSupportedProperties = unsupportedProperties
+        .filter(property => !property.startsWith('--'));
         return str_(reason.text, {
-          propertyCount: unsupportedProperties.length,
-          properties: unsupportedProperties.join(', '),
+          propertyCount: nonCustomUnSupportedProperties.length,
+          properties: nonCustomUnSupportedProperties.join(', '),
+        });
+      }
+      if (reason.text === UIStrings.unsupportedCustomCSSProperty) {
+        const customUnsupportedProperties = unsupportedProperties
+        .filter(property => property.startsWith('--'));
+        return str_(UIStrings.unsupportedCustomCSSProperty, {
+          properties: customUnsupportedProperties.join(', '),
         });
       }
       return str_(reason.text);

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1292,6 +1292,9 @@
   "core/audits/non-composited-animations.js | unsupportedCSSProperty": {
     "message": "{propertyCount, plural,\n    =1 {Unsupported CSS Property: {properties}}\n    other {Unsupported CSS Properties: {properties}}\n  }"
   },
+  "core/audits/non-composited-animations.js | unsupportedCustomCSSProperty": {
+    "message": "Custom CSS properties cannot be animated on the compositor: {properties}"
+  },
   "core/audits/non-composited-animations.js | unsupportedTimingParameters": {
     "message": "Effect has unsupported timing parameters"
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1292,6 +1292,9 @@
   "core/audits/non-composited-animations.js | unsupportedCSSProperty": {
     "message": "{propertyCount, plural,\n    =1 {Ûńŝúp̂ṕôŕt̂éd̂ ĆŜŚ P̂ŕôṕêŕt̂ý: {properties}}\n    other {Ûńŝúp̂ṕôŕt̂éd̂ ĆŜŚ P̂ŕôṕêŕt̂íêś: {properties}}\n  }"
   },
+  "core/audits/non-composited-animations.js | unsupportedCustomCSSProperty": {
+    "message": "Ĉúŝt́ôḿ ĈŚŜ ṕr̂óp̂ér̂t́îéŝ ćâńn̂ót̂ b́ê án̂ím̂át̂éd̂ ón̂ t́ĥé ĉóm̂ṕôśît́ôŕ: {properties}"
+  },
   "core/audits/non-composited-animations.js | unsupportedTimingParameters": {
     "message": "Êf́f̂éĉt́ ĥáŝ ún̂śûṕp̂ór̂t́êd́ t̂ím̂ín̂ǵ p̂ár̂ám̂ét̂ér̂ś"
   },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->
Animating [custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/@property) appear to always end up non-composited (at least outside of CSS painting), and get lumped with all the other non-composited CSS properties found in the trace (don't be surprised like me and note that this happens regardless of what the property is animating, e.g. animating translate through fixed values is usually composited, animating --yheight in translate: 0 var(--yheight) will not be).
<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
Closes #14521