### PR TITLE
tests(dbw): add unload handler deprecation

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -377,6 +377,17 @@ const expectations = {
               },
               subItems: undefined,
             },
+            {
+              _minChromiumVersion: '121',
+              value: 'UnloadHandler',
+              source: {
+                type: 'source-location',
+                url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
+                urlProvider: 'network',
+                line: '>0',
+                column: 9,
+              },
+            },
           ],
         },
       },


### PR DESCRIPTION
Looks like a recently added deprecation:
https://github.com/GoogleChrome/lighthouse/actions/runs/6868498490/job/18679184030?pr=15597

https://developer.chrome.com/articles/deprecating-unload/#:~:text=The%20unload%20event%20will%20be,flags%2F%23deprecate%2Dunload%20flag.