### PR TITLE
misc: relax node 18 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "smokehouse": "./cli/test/smokehouse/frontends/smokehouse-bin.js"
   },
   "engines": {
-    "node": ">=18.16"
+    "node": ">=18.13"
   },
   "scripts": {
     "prepack": "yarn build-report --standalone --flow --esm && yarn build-types",


### PR DESCRIPTION
#15290 touched this last

but my cloudtop runs 18.13.0 right now and can't upgrade farther.

fixing this is one of the things that will get the autoroll back again