### PR TITLE
tests: lower bootup-time threshold in api-test-pptr.js

### DIFF
--- a/core/test/scenarios/api-test-pptr.js
+++ b/core/test/scenarios/api-test-pptr.js
@@ -70,7 +70,7 @@ describe('Individual modes API', function() {
           audits: [
             {path: 'bootup-time', options: {thresholdInMs: 10}},
           ],
-        }
+        },
       });
 
       await setupTestPage();


### PR DESCRIPTION
I was getting values slightly less than 50ms (the default threshold) when running this test locally, which fails one of the snapshots in this test (made bootup-time count as n/a). so I configured a lower threshold for the test.