### PR TITLE
tests(ci): resume using ToT chrome

### DIFF
--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -31,7 +31,7 @@ case "${unameOut}" in
 esac
 
 # Only set this to true when actual ToT is broken and we can't fix it yet.
-should_hardcode_ci=true
+should_hardcode_ci=false
 
 if [[ "${CI:-}" ]] && [ "$should_hardcode_ci" == true ]; then
   rev=1228630


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=1506768 is now resolved, so we can go back to using latest ToT.