### PR TITLE
core(unused-css): exclude header size for estimating wasted bytes

### DIFF
--- a/core/computed/unused-css.js
+++ b/core/computed/unused-css.js
@@ -7,7 +7,7 @@
 import {makeComputedArtifact} from './computed-artifact.js';
 import {NetworkRecords} from './network-records.js';
 import {Util} from '../../shared/util.js';
-import {estimateTransferSize} from '../lib/script-helpers.js';
+import {estimateCompressedContentSize} from '../lib/script-helpers.js';
 
 const PREVIEW_LENGTH = 100;
 
@@ -70,15 +70,15 @@ class UnusedCSS {
       usedUncompressedBytes += usedRule.endOffset - usedRule.startOffset;
     }
 
-    const totalTransferredBytes = estimateTransferSize(
+    const compressedSize = estimateCompressedContentSize(
         stylesheetInfo.networkRecord, totalUncompressedBytes, 'Stylesheet');
     const percentUnused = (totalUncompressedBytes - usedUncompressedBytes) / totalUncompressedBytes;
-    const wastedBytes = Math.round(percentUnused * totalTransferredBytes);
+    const wastedBytes = Math.round(percentUnused * compressedSize);
 
     return {
       wastedBytes,
       wastedPercent: percentUnused * 100,
-      totalBytes: totalTransferredBytes,
+      totalBytes: compressedSize,
     };
   }
 

--- a/core/test/audits/byte-efficiency/unused-css-rules-test.js
+++ b/core/test/audits/byte-efficiency/unused-css-rules-test.js
@@ -106,6 +106,7 @@ describe('Best Practices: unused css rules audit', () => {
           transferSize: 100 * 1024 * 0.5, // compression ratio of 0.5
           resourceSize: 100 * 1024,
           resourceType: 'Document', // this is a document so it'll use the compressionRatio but not the raw size
+          responseHeaders: [{name: 'Content-Encoding'}],
         },
         {
           url: 'file://a.html',

--- a/core/test/audits/largest-contentful-paint-element-test.js
+++ b/core/test/audits/largest-contentful-paint-element-test.js
@@ -23,6 +23,7 @@ function mockNetworkRecords() {
     networkRequestTime: 0,
     networkEndTime: 500,
     timing: {sendEnd: 0, receiveHeadersEnd: 500},
+    responseHeadersTransferSize: 400,
     transferSize: 400,
     url: requestedUrl,
     frameId: 'ROOT_FRAME',

--- a/core/test/audits/prioritize-lcp-image-test.js
+++ b/core/test/audits/prioritize-lcp-image-test.js
@@ -57,6 +57,7 @@ describe('Performance: prioritize-lcp-image audit', () => {
         networkRequestTime: 0,
         networkEndTime: 500,
         timing: {receiveHeadersEnd: 500},
+        responseHeadersTransferSize: 400,
         transferSize: 400,
         url: requestedUrl,
         frameId: 'ROOT_FRAME',
@@ -318,6 +319,7 @@ describe('Performance: prioritize-lcp-image audit', () => {
     // Redirect image request to newly added request.
     const redirectSource = networkRecords.at(-1);
     redirectSource.networkEndTime = 2500;
+    redirectSource.responseHeadersTransferSize = 708;
     redirectSource.transferSize = 708;
     redirectSource.resourceType = undefined;
     networkRecords.push({

--- a/core/test/computed/lcp-image-record-test.js
+++ b/core/test/computed/lcp-image-record-test.js
@@ -32,6 +32,7 @@ function mockNetworkRecords() {
     networkRequestTime: 0,
     networkEndTime: 500,
     timing: {receiveHeadersEnd: 500},
+    responseHeadersTransferSize: 400,
     transferSize: 400,
     url: requestedUrl,
     frameId: 'ROOT_FRAME',

--- a/core/test/computed/metrics/lcp-breakdown-test.js
+++ b/core/test/computed/metrics/lcp-breakdown-test.js
@@ -46,6 +46,7 @@ function mockNetworkRecords() {
     networkRequestTime: 0,
     networkEndTime: 500,
     timing: {sendEnd: 0, receiveHeadersEnd: 500},
+    responseHeadersTransferSize: 400,
     transferSize: 400,
     url: requestedUrl,
     frameId: 'ROOT_FRAME',

--- a/core/test/computed/metrics/time-to-first-byte-test.js
+++ b/core/test/computed/metrics/time-to-first-byte-test.js
@@ -41,6 +41,7 @@ function mockNetworkRecords() {
     networkRequestTime: 0,
     networkEndTime: 300,
     timing: {sendEnd: 0},
+    responseHeadersTransferSize: 300,
     transferSize: 300,
     url: requestedUrl,
     frameId: 'ROOT_FRAME',

--- a/core/test/network-records-to-devtools-log.js
+++ b/core/test/network-records-to-devtools-log.js
@@ -288,8 +288,7 @@ function getResponseReceivedEvent(networkRecord, index, normalizedTiming) {
         connectionId: networkRecord.connectionId || 140,
         fromDiskCache: networkRecord.fromDiskCache || false,
         fromServiceWorker: networkRecord.fetchedViaServiceWorker || false,
-        encodedDataLength:
-          networkRecord.responseHeadersTransferSize || networkRecord.transferSize || 0,
+        encodedDataLength: networkRecord.responseHeadersTransferSize || 0,
         timing: {...normalizedTiming.timing},
         protocol: networkRecord.protocol || 'http/1.1',
       },


### PR DESCRIPTION
following up to https://github.com/GoogleChrome/lighthouse/pull/15640, but doing it for unused-css.