### PR TITLE
core(trace-elements): remove element score field

### DIFF
--- a/cli/test/smokehouse/test-definitions/perf-trace-elements.js
+++ b/cli/test/smokehouse/test-definitions/perf-trace-elements.js
@@ -95,7 +95,6 @@ const expectations = {
             height: 37,
           },
         },
-        score: '0.035 +/- 0.01',
       },
       {
         traceEventType: 'layout-shift',
@@ -111,7 +110,6 @@ const expectations = {
             height: 18,
           },
         },
-        score: '0.017 +/- 0.01',
       },
       {
         traceEventType: 'animation',
@@ -176,9 +174,39 @@ const expectations = {
         score: null,
         displayValue: '2 elements found',
         details: {
-          items: {
-            length: 2,
-          },
+          items: [
+            {
+              node: {
+                selector: 'body > h1',
+                nodeLabel: 'Please don\'t move me',
+                snippet: '<h1>',
+                boundingRect: {
+                  top: 465,
+                  bottom: 502,
+                  left: 8,
+                  right: 404,
+                  width: 396,
+                  height: 37,
+                },
+              },
+              score: '0.035 +/- 0.01',
+            },
+            {
+              node: {
+                nodeLabel: 'Sorry!',
+                snippet: '<div style="height: 18px;">',
+                boundingRect: {
+                  top: 426,
+                  bottom: 444,
+                  left: 8,
+                  right: 404,
+                  width: 396,
+                  height: 18,
+                },
+              },
+              score: '0.017 +/- 0.01',
+            },
+          ],
         },
       },
       'long-tasks': {

--- a/core/audits/layout-shift-elements.js
+++ b/core/audits/layout-shift-elements.js
@@ -43,12 +43,12 @@ class LayoutShiftElements extends Audit {
     const {cumulativeLayoutShift: clsSavings, impactByNodeId} =
       await CumulativeLayoutShiftComputed.request(artifacts.traces[Audit.DEFAULT_PASS], context);
 
-    /** @type {Array<{node: LH.Audit.Details.ItemValue, score?: number}>} */
+    /** @type {Array<{node: LH.Audit.Details.ItemValue, score: number}>} */
     const clsElementData = artifacts.TraceElements
       .filter(element => element.traceEventType === 'layout-shift')
       .map(element => ({
         node: Audit.makeNodeItem(element.node),
-        score: element.score,
+        score: impactByNodeId.get(element.nodeId) || 0,
       }));
 
     if (clsElementData.length < impactByNodeId.size) {

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -24,7 +24,7 @@ import {Responsiveness} from '../../computed/metrics/responsiveness.js';
 import {CumulativeLayoutShift} from '../../computed/metrics/cumulative-layout-shift.js';
 import {ExecutionContext} from '../driver/execution-context.js';
 
-/** @typedef {{nodeId: number, score?: number, animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[], type?: string}} TraceElementData */
+/** @typedef {{nodeId: number, animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[], type?: string}} TraceElementData */
 
 const MAX_LAYOUT_SHIFT_ELEMENTS = 15;
 
@@ -76,12 +76,7 @@ class TraceElements extends BaseGatherer {
     return [...impactByNodeId.entries()]
       .sort((a, b) => b[1] - a[1])
       .slice(0, MAX_LAYOUT_SHIFT_ELEMENTS)
-      .map(([nodeId, clsContribution]) => {
-        return {
-          nodeId: nodeId,
-          score: clsContribution,
-        };
-      });
+      .map(([nodeId]) => ({nodeId}));
   }
 
   /**
@@ -261,7 +256,6 @@ class TraceElements extends BaseGatherer {
           traceElements.push({
             traceEventType,
             ...response.result.value,
-            score: backendNodeData[i].score,
             animations: backendNodeData[i].animations,
             nodeId: backendNodeId,
             type: backendNodeData[i].type,

--- a/core/test/gather/gatherers/trace-elements-test.js
+++ b/core/test/gather/gatherers/trace-elements-test.js
@@ -73,15 +73,6 @@ function makeLCPTraceEvent(nodeId) {
 }
 
 describe('Trace Elements gatherer - GetTopLayoutShiftElements', () => {
-  /**
-   * @param {Array<{nodeId: number, score: number}>} shiftScores
-   */
-  function sumScores(shiftScores) {
-    let sum = 0;
-    shiftScores.forEach(shift => sum += shift.score);
-    return sum;
-  }
-
   it('returns layout shift data sorted by impact area', async () => {
     const trace = createTestTrace({});
     trace.traceEvents.push(
@@ -102,11 +93,9 @@ describe('Trace Elements gatherer - GetTopLayoutShiftElements', () => {
     const result =
       await TraceElementsGatherer.getTopLayoutShiftElements(trace, {computedCache: new Map()});
     expect(result).toEqual([
-      {nodeId: 25, score: 0.6},
-      {nodeId: 60, score: 0.4},
+      {nodeId: 25}, // score: 0.6
+      {nodeId: 60}, // score: 0.4
     ]);
-    const total = sumScores(result);
-    expect(total).toBeCloseTo(1.0);
   });
 
   it('returns only the top 15 values', async () => {
@@ -167,24 +156,22 @@ describe('Trace Elements gatherer - GetTopLayoutShiftElements', () => {
     const result =
       await TraceElementsGatherer.getTopLayoutShiftElements(trace, {computedCache: new Map()});
     expect(result).toEqual([
-      {nodeId: 3, score: 1.0},
-      {nodeId: 1, score: 0.5},
-      {nodeId: 2, score: 0.5},
-      {nodeId: 6, score: 0.25},
-      {nodeId: 7, score: 0.25},
-      {nodeId: 4, score: 0.125},
-      {nodeId: 5, score: 0.125},
-      {nodeId: 8, score: 0.1},
-      {nodeId: 9, score: 0.1},
-      {nodeId: 10, score: 0.1},
-      {nodeId: 11, score: 0.1},
-      {nodeId: 12, score: 0.1},
-      {nodeId: 13, score: 0.1},
-      {nodeId: 14, score: 0.1},
-      {nodeId: 15, score: 0.1},
+      {nodeId: 3}, // score: 1.0
+      {nodeId: 1}, // score: 0.5
+      {nodeId: 2}, // score: 0.5
+      {nodeId: 6}, // score: 0.25
+      {nodeId: 7}, // score: 0.25
+      {nodeId: 4}, // score: 0.125
+      {nodeId: 5}, // score: 0.125
+      {nodeId: 8}, // score: 0.1
+      {nodeId: 9}, // score: 0.1
+      {nodeId: 10}, // score: 0.1
+      {nodeId: 11}, // score: 0.1
+      {nodeId: 12}, // score: 0.1
+      {nodeId: 13}, // score: 0.1
+      {nodeId: 14}, // score: 0.1
+      {nodeId: 15}, // score: 0.1
     ]);
-    const total = sumScores(result);
-    expect(total).toBeCloseTo(3.55);
   });
 });
 
@@ -379,7 +366,6 @@ describe('Trace Elements gatherer - Animated Elements', () => {
       },
       {
         ...layoutShiftNodeData,
-        score: 0.5, // the other CLS node contributed an additional 0.5, but it was 'no node found'
         nodeId: 4,
       },
       {

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -560,9 +560,8 @@ declare module Artifacts {
 
   interface TraceElement {
     traceEventType: 'largest-contentful-paint'|'layout-shift'|'animation'|'responsiveness';
-    score?: number;
     node: NodeDetails;
-    nodeId?: number;
+    nodeId: number;
     animations?: {name?: string, failureReasonsMask?: number, unsupportedProperties?: string[]}[];
     type?: string;
   }


### PR DESCRIPTION
Follow up to https://github.com/GoogleChrome/lighthouse/pull/15593

With `impactByNodeId` on the CLS computed artifact, we don't need the trace elements `score` field anymore.
