### PR TITLE
core(bootup-time): exclude _lighthouse-eval.js

### DIFF
--- a/core/audits/bootup-time.js
+++ b/core/audits/bootup-time.js
@@ -109,6 +109,9 @@ class BootupTime extends Audit {
       settings.throttling.cpuSlowdownMultiplier : 1;
 
     const executionTimings = getExecutionTimingsByURL(tasks, networkRecords);
+    // Exclude our own tasks.
+    executionTimings.delete('_lighthouse-eval.js');
+
     const tbtImpact = await this.getTbtImpact(artifacts, context);
 
     let hadExcessiveChromeExtension = false;


### PR DESCRIPTION
Fixes issue reported [here](https://stackoverflow.com/questions/77556834/lighthouse-eval-js-is-listed-as-a-javascript-issue).