### PR TITLE
core(layout-shift-elements): mention windowing in description

### DIFF
--- a/core/audits/layout-shift-elements.js
+++ b/core/audits/layout-shift-elements.js
@@ -9,10 +9,10 @@ import {CumulativeLayoutShift as CumulativeLayoutShiftComputed} from '../compute
 import CumulativeLayoutShift from './metrics/cumulative-layout-shift.js';
 
 const UIStrings = {
-  /** Descriptive title of a diagnostic audit that provides up to the top elements affected by layout shifts. */
+  /** Descriptive title of a diagnostic audit that provides the top elements affected by layout shifts. */
   title: 'Avoid large layout shifts',
-  /** Description of a diagnostic audit that provides up to the top elements affected by layout shifts. The last sentence starting with 'Learn' becomes link text to additional documentation. */
-  description: 'These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)',
+  /** Description of a diagnostic audit that provides the top elements affected by layout shifts. "windowing" means the metric value is calculated using the subset of events in a small window of time during the run. "normalization" is a good substitute for "windowing". The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  description: 'These DOM elements were most affected by layout shifts. Some layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)',
   /**  Label for a column in a data table; entries in this column will be the amount that the corresponding element affected by layout shifts. */
   columnContribution: 'Layout shift impact',
 };

--- a/core/audits/layout-shift-elements.js
+++ b/core/audits/layout-shift-elements.js
@@ -9,12 +9,12 @@ import {CumulativeLayoutShift as CumulativeLayoutShiftComputed} from '../compute
 import CumulativeLayoutShift from './metrics/cumulative-layout-shift.js';
 
 const UIStrings = {
-  /** Descriptive title of a diagnostic audit that provides up to the top five elements contributing to Cumulative Layout Shift. */
+  /** Descriptive title of a diagnostic audit that provides up to the top elements affected by layout shifts. */
   title: 'Avoid large layout shifts',
-  /** Description of a diagnostic audit that provides up to the top five elements contributing to Cumulative Layout Shift. The last sentence starting with 'Learn' becomes link text to additional documentation. */
-  description: 'These DOM elements contribute most to the CLS of the page. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)',
-  /**  Label for a column in a data table; entries in this column will be the amount that the corresponding element contributes to the total CLS metric score. */
-  columnContribution: 'CLS Contribution',
+  /** Description of a diagnostic audit that provides up to the top elements affected by layout shifts. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  description: 'These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)',
+  /**  Label for a column in a data table; entries in this column will be the amount that the corresponding element affected by layout shifts. */
+  columnContribution: 'Layout shift impact',
 };
 
 const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
@@ -52,14 +52,18 @@ class LayoutShiftElements extends Audit {
       }));
 
     if (clsElementData.length < impactByNodeId.size) {
-      const elementDataImpact = clsElementData.reduce((sum, {score}) => sum += score || 0, 0);
-      const remainingImpact = Math.max(clsSavings - elementDataImpact, 0);
+      const displayedNodeImpact = clsElementData.reduce((sum, {score}) => sum += score, 0);
+
+      // This is not necessarily the same as CLS due to normalization.
+      const totalNodeImpact = Array.from(impactByNodeId.values())
+        .reduce((sum, score) => sum + score);
+
       clsElementData.push({
         node: {
           type: 'code',
           value: str_(i18n.UIStrings.otherResourceType),
         },
-        score: remainingImpact,
+        score: totalNodeImpact - displayedNodeImpact,
       });
     }
 

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -1738,7 +1738,7 @@
           "layout-shift-elements": {
             "id": "layout-shift-elements",
             "title": "Avoid large layout shifts",
-            "description": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+            "description": "These DOM elements were most affected by layout shifts. Some layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
             "score": null,
             "scoreDisplayMode": "informative",
             "displayValue": "5 elements found",
@@ -9863,7 +9863,7 @@
           "layout-shift-elements": {
             "id": "layout-shift-elements",
             "title": "Avoid large layout shifts",
-            "description": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+            "description": "These DOM elements were most affected by layout shifts. Some layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
             "score": 0,
             "scoreDisplayMode": "metricSavings",
             "displayValue": "1 element found",
@@ -19644,7 +19644,7 @@
           "layout-shift-elements": {
             "id": "layout-shift-elements",
             "title": "Avoid large layout shifts",
-            "description": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+            "description": "These DOM elements were most affected by layout shifts. Some layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
             "score": null,
             "scoreDisplayMode": "notApplicable",
             "metricSavings": {

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -1738,7 +1738,7 @@
           "layout-shift-elements": {
             "id": "layout-shift-elements",
             "title": "Avoid large layout shifts",
-            "description": "These DOM elements contribute most to the CLS of the page. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+            "description": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
             "score": null,
             "scoreDisplayMode": "informative",
             "displayValue": "5 elements found",
@@ -1757,7 +1757,7 @@
                   "key": "score",
                   "valueType": "numeric",
                   "granularity": 0.001,
-                  "label": "CLS Contribution"
+                  "label": "Layout shift impact"
                 }
               ],
               "items": [
@@ -9863,7 +9863,7 @@
           "layout-shift-elements": {
             "id": "layout-shift-elements",
             "title": "Avoid large layout shifts",
-            "description": "These DOM elements contribute most to the CLS of the page. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+            "description": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
             "score": 0,
             "scoreDisplayMode": "metricSavings",
             "displayValue": "1 element found",
@@ -9882,7 +9882,7 @@
                   "key": "score",
                   "valueType": "numeric",
                   "granularity": 0.001,
-                  "label": "CLS Contribution"
+                  "label": "Layout shift impact"
                 }
               ],
               "items": [
@@ -19644,7 +19644,7 @@
           "layout-shift-elements": {
             "id": "layout-shift-elements",
             "title": "Avoid large layout shifts",
-            "description": "These DOM elements contribute most to the CLS of the page. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+            "description": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
             "score": null,
             "scoreDisplayMode": "notApplicable",
             "metricSavings": {

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -2468,7 +2468,7 @@
     "layout-shift-elements": {
       "id": "layout-shift-elements",
       "title": "Avoid large layout shifts",
-      "description": "These DOM elements contribute most to the CLS of the page. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+      "description": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
       "score": 0,
       "scoreDisplayMode": "metricSavings",
       "displayValue": "5 elements found",
@@ -2487,7 +2487,7 @@
             "key": "score",
             "valueType": "numeric",
             "granularity": 0.001,
-            "label": "CLS Contribution"
+            "label": "Layout shift impact"
           }
         ],
         "items": [

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -2468,7 +2468,7 @@
     "layout-shift-elements": {
       "id": "layout-shift-elements",
       "title": "Avoid large layout shifts",
-      "description": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
+      "description": "These DOM elements were most affected by layout shifts. Some layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)",
       "score": 0,
       "scoreDisplayMode": "metricSavings",
       "displayValue": "5 elements found",

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1161,7 +1161,7 @@
     "message": "Layout shift impact"
   },
   "core/audits/layout-shift-elements.js | description": {
-    "message": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)"
+    "message": "These DOM elements were most affected by layout shifts. Some layout shifts may not be included in the CLS metric value due to [windowing](https://web.dev/articles/cls#what_is_cls). [Learn how to improve CLS](https://web.dev/articles/optimize-cls)"
   },
   "core/audits/layout-shift-elements.js | title": {
     "message": "Avoid large layout shifts"

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1158,10 +1158,10 @@
     "message": "Largest Contentful Paint element"
   },
   "core/audits/layout-shift-elements.js | columnContribution": {
-    "message": "CLS Contribution"
+    "message": "Layout shift impact"
   },
   "core/audits/layout-shift-elements.js | description": {
-    "message": "These DOM elements contribute most to the CLS of the page. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)"
+    "message": "These DOM elements were most affected by layout shifts. Not all layout shifts are included in the CLS metric value due to CLS normalization. [Learn how to improve CLS](https://web.dev/articles/optimize-cls)"
   },
   "core/audits/layout-shift-elements.js | title": {
     "message": "Avoid large layout shifts"

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1161,7 +1161,7 @@
     "message": "L̂áŷóût́ ŝh́îf́t̂ ím̂ṕâćt̂"
   },
   "core/audits/layout-shift-elements.js | description": {
-    "message": "T̂h́êśê D́ÔḾ êĺêḿêńt̂ś ŵér̂é m̂óŝt́ âf́f̂éĉt́êd́ b̂ý l̂áŷóût́ ŝh́îf́t̂ś. N̂ót̂ ál̂ĺ l̂áŷóût́ ŝh́îf́t̂ś âŕê ín̂ćl̂úd̂éd̂ ín̂ t́ĥé ĈĹŜ ḿêt́r̂íĉ v́âĺûé d̂úê t́ô ĆL̂Ś n̂ór̂ḿâĺîźât́îón̂. [Ĺêár̂ń ĥóŵ t́ô ím̂ṕr̂óv̂é ĈĹŜ](https://web.dev/articles/optimize-cls)"
+    "message": "T̂h́êśê D́ÔḾ êĺêḿêńt̂ś ŵér̂é m̂óŝt́ âf́f̂éĉt́êd́ b̂ý l̂áŷóût́ ŝh́îf́t̂ś. Ŝóm̂é l̂áŷóût́ ŝh́îf́t̂ś m̂áŷ ńôt́ b̂é îńĉĺûd́êd́ îń t̂h́ê ĆL̂Ś m̂ét̂ŕîć v̂ál̂úê d́ûé t̂ó [ŵín̂d́ôẃîńĝ](https://web.dev/articles/cls#what_is_cls). [Ĺêár̂ń ĥóŵ t́ô ím̂ṕr̂óv̂é ĈĹŜ](https://web.dev/articles/optimize-cls)"
   },
   "core/audits/layout-shift-elements.js | title": {
     "message": "Âv́ôíd̂ ĺâŕĝé l̂áŷóût́ ŝh́îf́t̂ś"

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1158,10 +1158,10 @@
     "message": "L̂ár̂ǵêśt̂ Ćôńt̂én̂t́f̂úl̂ Ṕâín̂t́ êĺêḿêńt̂"
   },
   "core/audits/layout-shift-elements.js | columnContribution": {
-    "message": "ĈĹŜ Ćôńt̂ŕîb́ût́îón̂"
+    "message": "L̂áŷóût́ ŝh́îf́t̂ ím̂ṕâćt̂"
   },
   "core/audits/layout-shift-elements.js | description": {
-    "message": "T̂h́êśê D́ÔḾ êĺêḿêńt̂ś ĉón̂t́r̂íb̂út̂é m̂óŝt́ t̂ó t̂h́ê ĆL̂Ś ôf́ t̂h́ê ṕâǵê. [Ĺêár̂ń ĥóŵ t́ô ím̂ṕr̂óv̂é ĈĹŜ](https://web.dev/articles/optimize-cls)"
+    "message": "T̂h́êśê D́ÔḾ êĺêḿêńt̂ś ŵér̂é m̂óŝt́ âf́f̂éĉt́êd́ b̂ý l̂áŷóût́ ŝh́îf́t̂ś. N̂ót̂ ál̂ĺ l̂áŷóût́ ŝh́îf́t̂ś âŕê ín̂ćl̂úd̂éd̂ ín̂ t́ĥé ĈĹŜ ḿêt́r̂íĉ v́âĺûé d̂úê t́ô ĆL̂Ś n̂ór̂ḿâĺîźât́îón̂. [Ĺêár̂ń ĥóŵ t́ô ím̂ṕr̂óv̂é ĈĹŜ](https://web.dev/articles/optimize-cls)"
   },
   "core/audits/layout-shift-elements.js | title": {
     "message": "Âv́ôíd̂ ĺâŕĝé l̂áŷóût́ ŝh́îf́t̂ś"


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/lighthouse/issues/15423

Also updates the aggregate row to use the total impact from nodes and not the CLS metric value. This is probably a more meaningful value considering the audit isn't just focused on layout shifts that happened to be captured in the CLS window.
