### PR TITLE
core(mpfid): add max LoAFs to debugdata

### DIFF
--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -198,7 +198,52 @@
       "scoreDisplayMode": "numeric",
       "numericValue": 1174.877,
       "numericUnit": "millisecond",
-      "displayValue": "1,170 ms"
+      "displayValue": "1,170 ms",
+      "details": {
+        "type": "debugdata",
+        "observedMaxDurationLoaf": {
+          "args": {
+            "data": {
+              "blockingDuration": 1139.261,
+              "duration": 1199.518,
+              "numScripts": 1,
+              "renderDuration": 14.777,
+              "styleAndLayoutDuration": 13.034
+            }
+          },
+          "cat": "devtools.timeline",
+          "id2": {
+            "local": "0x13b00174d98"
+          },
+          "name": "LongAnimationFrame",
+          "ph": "b",
+          "pid": 31161,
+          "scope": "devtools.timeline",
+          "tid": 259,
+          "ts": 8703546175
+        },
+        "observedMaxBlockingLoaf": {
+          "args": {
+            "data": {
+              "blockingDuration": 1139.261,
+              "duration": 1199.518,
+              "numScripts": 1,
+              "renderDuration": 14.777,
+              "styleAndLayoutDuration": 13.034
+            }
+          },
+          "cat": "devtools.timeline",
+          "id2": {
+            "local": "0x13b00174d98"
+          },
+          "name": "LongAnimationFrame",
+          "ph": "b",
+          "pid": 31161,
+          "scope": "devtools.timeline",
+          "tid": 259,
+          "ts": 8703546175
+        }
+      }
     },
     "cumulative-layout-shift": {
       "id": "cumulative-layout-shift",

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -1017,6 +1017,8 @@ export interface TraceEvent {
       type?: string;
       functionName?: string;
       name?: string;
+      duration?: number;
+      blockingDuration?: number;
     };
     frame?: string;
     name?: string;


### PR DESCRIPTION
As a first step to evaluating where [Long Animation Frames (LoAF)](https://github.com/w3c/longtasks/blob/main/loaf-explainer.md) will be a better measure of main-thread blocking than long tasks, this PR adds the longest LoAFs (after FCP) by `duration` and `blockingDuration` to the debug data of the `max-potential-fid` hidden audit.

No visible changes. The primary purpose is to have the data in HTTP Archive for querying and comparing to other metrics like MPFID and TBT.

Tests are minimal because we have fairly minimal tests for MPFID in the first place (e.g. no smoke tests). Happy to add more if it seems necessary.