### PR TITLE
core(render-blocking-resources): reduce metric savings if LCP is an image

### DIFF
--- a/core/test/audits/byte-efficiency/render-blocking-resources-test.js
+++ b/core/test/audits/byte-efficiency/render-blocking-resources-test.js
@@ -88,7 +88,7 @@ describe('Render blocking resources audit', () => {
       // it look like Montserrat starts after Fira Sans finishes. It would be preferred
       // if eventual simulation improvements list Montserrat here as well.
     ]);
-    expect(result.metricSavings).toEqual({FCP: 469, LCP: 469});
+    expect(result.metricSavings).toEqual({FCP: 469, LCP: 0});
   });
 
   describe('#estimateSavingsWithGraphs', () => {

--- a/core/test/audits/byte-efficiency/render-blocking-resources-test.js
+++ b/core/test/audits/byte-efficiency/render-blocking-resources-test.js
@@ -18,6 +18,8 @@ const trace = readJson('../../fixtures/traces/progressive-app-m60.json', import.
 const devtoolsLog = readJson('../../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
 const ampTrace = readJson('../../fixtures/traces/amp-m86.trace.json', import.meta);
 const ampDevtoolsLog = readJson('../../fixtures/traces/amp-m86.devtoolslog.json', import.meta);
+const textLcpTrace = readJson('../../fixtures/traces/frame-metrics-m90.json', import.meta);
+const textLcpDevtoolsLog = readJson('../../fixtures/traces/frame-metrics-m90.devtools.log.json', import.meta);
 
 const mobileSlow4G = constants.throttling.mobileSlow4G;
 
@@ -42,6 +44,29 @@ describe('Render blocking resources audit', () => {
     assert.equal(result.score, 1);
     assert.equal(result.numericValue, 0);
     assert.deepStrictEqual(result.metricSavings, {FCP: 0, LCP: 0});
+  });
+
+  it('evaluates correct wastedMs when LCP is text', async () => {
+    const artifacts = {
+      URL: getURLArtifactFromDevtoolsLog(textLcpDevtoolsLog),
+      GatherContext: {gatherMode: 'navigation'},
+      traces: {defaultPass: textLcpTrace},
+      devtoolsLogs: {defaultPass: textLcpDevtoolsLog},
+      TagsBlockingFirstPaint: [
+        {
+          tag: {url: 'http://localhost:10200/perf/frame-metrics-inner.html'},
+        },
+        {
+          tag: {url: 'http://localhost:10200/favicon.ico'},
+        },
+      ],
+      Stacks: [],
+    };
+
+    const settings = {throttlingMethod: 'simulate', throttling: mobileSlow4G};
+    const computedCache = new Map();
+    const result = await RenderBlockingResourcesAudit.audit(artifacts, {settings, computedCache});
+    assert.deepStrictEqual(result.metricSavings, {FCP: 783, LCP: 783});
   });
 
   it('evaluates amp page correctly', async () => {


### PR DESCRIPTION
Render blocking resources most of the time don't affect the LCP if the LCP is an image. In these cases, we should avoid overestimating the potential LCP savings. If the LCP is an image we set potential savings to 0, else we use our fcp savings.