### PR TITLE
docs: update deprecated link to shared flags

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -41,7 +41,8 @@ You can also craft your own config (e.g. [experimental-config.js](https://github
 
 ### Differences from CLI flags
 
-Note that some flag functionality is only available to the CLI. The set of shared flags that work in both node and CLI can be found [in our typedefs](https://github.com/GoogleChrome/lighthouse/blob/888bd6dc9d927a734a8e20ea8a0248baa5b425ed/typings/externs.d.ts#L82-L119). In most cases, the functionality is not offered in the node module simply because it is easier and more flexible to do it yourself.
+Note that some flag functionality is only available to the CLI.
+The set of shared flags that work in both node and CLI can be found [in our typedefs](https://github.com/GoogleChrome/lighthouse/blob/main/types/lhr/settings.d.ts#L55-L130). In most cases, the functionality is not offered in the node module simply because it is easier and more flexible to do it yourself.
 
 | CLI Flag | Differences in Node |
 | - | - |

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -42,7 +42,7 @@ You can also craft your own config (e.g. [experimental-config.js](https://github
 ### Differences from CLI flags
 
 Note that some flag functionality is only available to the CLI.
-The set of shared flags that work in both node and CLI can be found [in our typedefs](https://github.com/GoogleChrome/lighthouse/blob/main/types/lhr/settings.d.ts#L55-L130). In most cases, the functionality is not offered in the node module simply because it is easier and more flexible to do it yourself.
+The set of shared flags that work in both node and CLI can be found [in our typedefs](https://github.com/GoogleChrome/lighthouse/blob/main/types/lhr/settings.d.ts#:~:text=interface%20SharedFlagsSettings). In most cases, the functionality is not offered in the node module simply because it is easier and more flexible to do it yourself.
 
 | CLI Flag | Differences in Node |
 | - | - |

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -41,8 +41,7 @@ You can also craft your own config (e.g. [experimental-config.js](https://github
 
 ### Differences from CLI flags
 
-Note that some flag functionality is only available to the CLI.
-The set of shared flags that work in both node and CLI can be found [in our typedefs](https://github.com/GoogleChrome/lighthouse/blob/main/types/lhr/settings.d.ts#:~:text=interface%20SharedFlagsSettings). In most cases, the functionality is not offered in the node module simply because it is easier and more flexible to do it yourself.
+Note that some flag functionality is only available to the CLI. The set of shared flags that work in both node and CLI can be found [in our typedefs](https://github.com/GoogleChrome/lighthouse/blob/main/types/lhr/settings.d.ts#:~:text=interface%20SharedFlagsSettings). In most cases, the functionality is not offered in the node module simply because it is easier and more flexible to do it yourself.
 
 | CLI Flag | Differences in Node |
 | - | - |


### PR DESCRIPTION
**Summary**
In the file https://github.com/GoogleChrome/lighthouse/blob/main/docs/readme.md#differences-from-cli-flags is a link in the section "Differences from CLI flags" which points to a commit from over 6 years ago. 

The linked information is outdated. 

I understand that the commit was included in the link because then the highlighting of the lines will work correctly in the future when changes are made to this file. 

This solution is also only a band-aid solution, because if changes are made to the linked file, this link may have to be adapted again. 

The only thing I can think of to solve this permanently would be to move the shared flags to a separate file. But I don't know where this would have to be adjusted and it might also be better as a downstream ticket. 