### PR TITLE
report: small renderAudit simplification

### DIFF
--- a/report/renderer/category-renderer.js
+++ b/report/renderer/category-renderer.js
@@ -41,19 +41,9 @@ export class CategoryRenderer {
    * @return {HTMLElement}
    */
   renderAudit(audit) {
-    const component = this.dom.createComponent('audit');
-    return /** @type {HTMLElement} */ (this.populateAuditValues(audit, component));
-  }
-
-  /**
-   * Populate an DOM tree with audit details. Used by renderAudit and renderOpportunity
-   * @param {LH.ReportResult.AuditRef} audit
-   * @param {DocumentFragment} component
-   * @return {!Element}
-   */
-  populateAuditValues(audit, component) {
     const strings = Globals.strings;
-    const auditEl = this.dom.find('.lh-audit', component);
+    const component = this.dom.createComponent('audit');
+    const auditEl = this.dom.find('div.lh-audit', component);
     auditEl.id = audit.result.id;
     const scoreDisplayMode = audit.result.scoreDisplayMode;
 


### PR DESCRIPTION
Total driveby, but it felt wrong to cast the result of the only remaining call to `populateAuditValues` :) From the template we know we always want `div.lh-audit`, and adding the `div` makes `dom.find()` know it's returning an `HTMLElement`, not just an `Element`.

But then I also realized with only a single caller of `populateAuditValues` now, we don't need separate `renderAudit`/`populateAuditValues` functions at all anymore (👋  #5136).