### PR TITLE
core: create separate product savings type

### DIFF
--- a/core/audits/audit.js
+++ b/core/audits/audit.js
@@ -10,7 +10,7 @@ import {Util} from '../../shared/util.js';
 
 const DEFAULT_PASS = 'defaultPass';
 
-/** @type {LH.Audit.MetricSavings} */
+/** @type {Record<keyof LH.Audit.ProductMetricSavings, number>} */
 const METRIC_SAVINGS_PRECISION = {
   FCP: 50,
   LCP: 50,
@@ -349,16 +349,17 @@ class Audit {
   }
 
   /**
-   * @param {LH.Audit.MetricSavings|undefined} metricSavings
-   * @return {LH.Audit.MetricSavings|undefined}
+   * @param {LH.Audit.ProductMetricSavings|undefined} metricSavings
+   * @return {LH.Audit.ProductMetricSavings|undefined}
    */
   static _quantizeMetricSavings(metricSavings) {
     if (!metricSavings) return;
 
-    /** @type {LH.Audit.MetricSavings} */
+    /** @type {LH.Audit.ProductMetricSavings} */
     const normalizedMetricSavings = {...metricSavings};
 
-    for (const key of /** @type {Array<LH.Result.MetricAcronym>} */ (Object.keys(metricSavings))) {
+    // eslint-disable-next-line max-len
+    for (const key of /** @type {Array<keyof LH.Audit.ProductMetricSavings>} */ (Object.keys(metricSavings))) {
       let value = metricSavings[key];
       if (value === undefined) continue;
 

--- a/core/audits/byte-efficiency/byte-efficiency-audit.js
+++ b/core/audits/byte-efficiency/byte-efficiency-audit.js
@@ -194,7 +194,7 @@ class ByteEfficiencyAudit extends Audit {
 
     const wastedBytes = results.reduce((sum, item) => sum + item.wastedBytes, 0);
 
-    /** @type {LH.Audit.MetricSavings} */
+    /** @type {LH.Audit.ProductMetricSavings} */
     const metricSavings = {
       FCP: 0,
       LCP: 0,

--- a/report/renderer/performance-category-renderer.js
+++ b/report/renderer/performance-category-renderer.js
@@ -5,7 +5,6 @@
  */
 
 /** @typedef {import('./dom.js').DOM} DOM */
-/** @typedef {string} FilterType */
 
 import {CategoryRenderer} from './category-renderer.js';
 import {ReportUtils} from './report-utils.js';
@@ -233,7 +232,7 @@ export class PerformanceCategoryRenderer extends CategoryRenderer {
     groupEl.classList.add('lh-audit-group--diagnostics');
 
     /**
-     * @param {FilterType} acronym
+     * @param {string} acronym
      */
     function refreshFilteredAudits(acronym) {
       for (const audit of allInsights) {
@@ -352,7 +351,7 @@ export class PerformanceCategoryRenderer extends CategoryRenderer {
    * Render the control to filter the audits by metric. The filtering is done at runtime by CSS only
    * @param {LH.ReportResult.AuditRef[]} filterableMetrics
    * @param {HTMLDivElement} categoryEl
-   * @param {(acronym: FilterType) => void} onFilterChange
+   * @param {(acronym: string) => void} onFilterChange
    */
   renderMetricAuditFilter(filterableMetrics, categoryEl, onFilterChange) {
     const metricFilterEl = this.dom.createElement('div', 'lh-metricfilter');

--- a/report/renderer/performance-category-renderer.js
+++ b/report/renderer/performance-category-renderer.js
@@ -5,7 +5,7 @@
  */
 
 /** @typedef {import('./dom.js').DOM} DOM */
-/** @typedef {LH.Result.MetricAcronym | 'All'} FilterType */
+/** @typedef {string} FilterType */
 
 import {CategoryRenderer} from './category-renderer.js';
 import {ReportUtils} from './report-utils.js';
@@ -360,7 +360,7 @@ export class PerformanceCategoryRenderer extends CategoryRenderer {
     textEl.textContent = Globals.strings.showRelevantAudits;
 
     const filterChoices = [
-      /** @type {const} */ ({acronym: 'All'}),
+      /** @type {const} */ ({acronym: 'All', id: 'All'}),
       ...filterableMetrics,
     ];
 

--- a/types/audit.d.ts
+++ b/types/audit.d.ts
@@ -20,6 +20,14 @@ declare module Audit {
   export type ScoreDisplayModes = AuditResult.ScoreDisplayModes;
   export type MetricSavings = AuditResult.MetricSavings;
 
+  export type ProductMetricSavings = {
+    FCP?: number;
+    LCP?: number;
+    TBT?: number;
+    CLS?: number;
+    INP?: number;
+  };
+
   type Context = Util.Immutable<{
     /** audit options */
     options: Record<string, any>;
@@ -87,7 +95,7 @@ declare module Audit {
     /** If an audit encounters unusual execution circumstances, strings can be put in this optional array to add top-level warnings to the LHR. */
     runWarnings?: Array<IcuMessage>;
     /** Estimates of how much this audit affects various performance metrics. Values will be in the unit of the respective metrics. */
-    metricSavings?: MetricSavings;
+    metricSavings?: ProductMetricSavings;
     /** Score details including p10 and median for calculating an audit's log-normal score. */
     scoringOptions?: ScoreOptions;
     /** A string identifying how the score should be interpreted for display. Overrides audit meta `scoreDisplayMode` if defined. */

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -82,7 +82,7 @@ declare module Config {
     id: string;
     weight: number;
     group?: string;
-    acronym?: Result.MetricAcronym;
+    acronym?: string;
     relevantAudits?: string[];
   }
 

--- a/types/lhr/audit-result.d.ts
+++ b/types/lhr/audit-result.d.ts
@@ -6,7 +6,6 @@
 
 import {FormattedIcu} from './i18n.js';
 import AuditDetails from './audit-details.js';
-import LHResult from './lhr.js';
 
 interface ScoreDisplayModes {
   /** Scores of 0-1 (map to displayed scores of 0-100). */
@@ -32,9 +31,7 @@ interface ScoreDisplayModes {
 
 type ScoreDisplayMode = ScoreDisplayModes[keyof ScoreDisplayModes];
 
-export type MetricSavings = {
-  [M in LHResult.MetricAcronym]?: number;
-};
+export type MetricSavings = Partial<Record<string, number>>;
 
 /** Audit result returned in Lighthouse report. All audits offer a description and score of 0-1. */
 export interface Result {

--- a/types/lhr/lhr.d.ts
+++ b/types/lhr/lhr.d.ts
@@ -115,7 +115,7 @@ declare module Result {
     /** Optional grouping within the category. Matches the key of a Result.Group. */
     group?: string;
     /** The conventional acronym for the audit/metric. */
-    acronym?: MetricAcronym;
+    acronym?: string;
     /** Any audit IDs closely relevant to this one. */
     relevantAudits?: string[];
   }
@@ -197,8 +197,6 @@ declare module Result {
 
   /** Gather mode used to collect artifacts. */
   type GatherMode = 'navigation'|'timespan'|'snapshot';
-
-  type MetricAcronym = 'FCP' | 'LCP' | 'TBT' | 'CLS' | 'INP' | 'SI' | 'TTI' | 'FMP';
 }
 
 export default Result;


### PR DESCRIPTION
Addresses https://github.com/GoogleChrome/lighthouse/pull/15721#discussion_r1442102832. This is really just reshuffling the types so that metrics can define their acronym to be any string, but the audit product still needs to be one of FCP/LCP/TBT/CLS/INP.

Follow up to #15721 and https://github.com/GoogleChrome/lighthouse/pull/15540
