### PR TITLE
core(viewport): include meta viewport string in debugDetails

### DIFF
--- a/cli/test/fixtures/dobetterweb/dbw_tester.html
+++ b/cli/test/fixtures/dobetterweb/dbw_tester.html
@@ -9,7 +9,7 @@
 <head>
 <title>DoBetterWeb Mega Tester... Of Death</title>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+<meta name="viewport" content="width=2899">
 <meta property="og:description" content="Open Graph smoke test description">
 
 <template id="links-blocking-first-paint-tmpl">
@@ -47,6 +47,12 @@
 
 <!-- Malformed links should not show in TagsBlockingFirstPaint artifact -->
 <link rel="stylesheet" href="">
+
+<script>
+  // Set a mobile-friendly viewport only on load.
+  const metaViewport = document.querySelector('meta[name="viewport"]');
+  metaViewport.content = 'width=device-width, initial-scale=1, minimum-scale=1';
+</script>
 
 <!-- FAIL: block rendering -->
 <script src="./dbw_tester.js" id="dbw-tester-script"></script>

--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -615,6 +615,12 @@ const expectations = {
           ],
         },
       },
+      'viewport': {
+        score: 1,
+        details: {
+          viewportContent: 'width=device-width, initial-scale=1, minimum-scale=1',
+        },
+      },
     },
     fullPageScreenshot: {
       screenshot: {

--- a/cli/test/smokehouse/test-definitions/seo-failing.js
+++ b/cli/test/smokehouse/test-definitions/seo-failing.js
@@ -46,6 +46,10 @@ const expectations = {
     audits: {
       'viewport': {
         score: 0,
+        details: {
+          type: 'debugdata',
+          viewportContent: 'invalid-content=should_have_looked_it_up',
+        },
       },
       'document-title': {
         score: 0,

--- a/core/audits/viewport.js
+++ b/core/audits/viewport.js
@@ -63,12 +63,22 @@ class Viewport extends Audit {
       inpSavings = 0;
     }
 
+    /** @type {LH.Audit.Details.DebugData|undefined} */
+    let details;
+    if (viewportMeta.rawContentString !== undefined) {
+      details = {
+        type: 'debugdata',
+        viewportContent: viewportMeta.rawContentString,
+      };
+    }
+
     return {
       score: Number(viewportMeta.isMobileOptimized),
       metricSavings: {
         INP: inpSavings,
       },
       warnings: viewportMeta.parserWarnings,
+      details,
     };
   }
 }

--- a/core/computed/viewport-meta.js
+++ b/core/computed/viewport-meta.js
@@ -21,11 +21,13 @@ class ViewportMeta {
         hasViewportTag: false,
         isMobileOptimized: false,
         parserWarnings: [],
+        rawContentString: undefined,
       };
     }
 
     const warnings = [];
-    const parsedProps = Parser.parseMetaViewPortContent(viewportMeta.content || '');
+    const rawContentString = viewportMeta.content || '';
+    const parsedProps = Parser.parseMetaViewPortContent(rawContentString);
 
     if (Object.keys(parsedProps.unknownProperties).length) {
       warnings.push(`Invalid properties found: ${JSON.stringify(parsedProps.unknownProperties)}`);
@@ -42,6 +44,7 @@ class ViewportMeta {
         hasViewportTag: true,
         isMobileOptimized: false,
         parserWarnings: warnings,
+        rawContentString,
       };
     }
 
@@ -51,6 +54,7 @@ class ViewportMeta {
       hasViewportTag: true,
       isMobileOptimized,
       parserWarnings: warnings,
+      rawContentString,
     };
   }
 }
@@ -63,4 +67,5 @@ export {ViewportMetaComputed as ViewportMeta};
  * @property {boolean} hasViewportTag Whether the page has any viewport tag.
  * @property {boolean} isMobileOptimized Whether the viewport tag is optimized for mobile screens.
  * @property {Array<string>} parserWarnings Warnings if the parser encountered invalid content in the viewport tag.
+ * @property {string|undefined} rawContentString The `content` attribute value, if a viewport was defined.
  */

--- a/core/test/computed/viewport-meta-test.js
+++ b/core/test/computed/viewport-meta-test.js
@@ -20,34 +20,38 @@ describe('ViewportMeta computed artifact', () => {
   /* eslint-disable-next-line max-len */
   it('is not mobile optimized when HTML contains a non-mobile friendly viewport meta tag', async () => {
     const viewport = 'maximum-scale=1';
-    const {hasViewportTag, isMobileOptimized} =
+    const {hasViewportTag, isMobileOptimized, rawContentString} =
       await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(hasViewportTag, true);
     assert.equal(isMobileOptimized, false);
+    assert.equal(rawContentString, viewport);
   });
 
   it('is not mobile optimized when HTML contains an invalid viewport meta tag key', async () => {
     const viewport = 'nonsense=true';
-    const {hasViewportTag, isMobileOptimized} =
+    const {hasViewportTag, isMobileOptimized, rawContentString} =
       await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(hasViewportTag, true);
     assert.equal(isMobileOptimized, false);
+    assert.equal(rawContentString, viewport);
   });
 
   it('is not mobile optimized when HTML contains an invalid viewport meta tag value', async () => {
     const viewport = 'initial-scale=microscopic';
-    const {isMobileOptimized, parserWarnings} =
+    const {isMobileOptimized, parserWarnings, rawContentString} =
       await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(isMobileOptimized, false);
+    assert.equal(rawContentString, viewport);
     assert.equal(parserWarnings[0], 'Invalid values found: {"initial-scale":"microscopic"}');
   });
 
   /* eslint-disable-next-line max-len */
   it('is not mobile optimized when HTML contains an invalid viewport meta tag key and value', async () => {
     const viewport = 'nonsense=true, initial-scale=microscopic';
-    const {isMobileOptimized, parserWarnings} =
+    const {isMobileOptimized, parserWarnings, rawContentString} =
       await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(isMobileOptimized, false);
+    assert.equal(rawContentString, viewport);
     assert.equal(parserWarnings[0], 'Invalid properties found: {"nonsense":"true"}');
     assert.equal(parserWarnings[1], 'Invalid values found: {"initial-scale":"microscopic"}');
   });
@@ -55,9 +59,10 @@ describe('ViewportMeta computed artifact', () => {
   // eslint-disable-next-line max-len
   it('is not mobile optimized when a viewport contains an initial-scale value lower than 1', async () => {
     const viewport = 'width=device-width, initial-scale=0.9';
-    const {isMobileOptimized} =
+    const {isMobileOptimized, rawContentString} =
       await ViewportMeta.compute_(makeMetaElements(viewport));
     assert.equal(isMobileOptimized, false);
+    assert.equal(rawContentString, viewport);
   });
 
   it('is mobile optimized when a valid viewport is provided', async () => {
@@ -69,16 +74,20 @@ describe('ViewportMeta computed artifact', () => {
     ];
 
     await Promise.all(viewports.map(async viewport => {
-      const {isMobileOptimized} =
+      const {isMobileOptimized, rawContentString} =
         await ViewportMeta.compute_(makeMetaElements(viewport));
       assert.equal(isMobileOptimized, true);
+      assert.equal(rawContentString, viewport);
     }));
   });
 
   it('recognizes interactive-widget property', async () => {
     const viewport = 'width=device-width, interactive-widget=resizes-content';
-    const {parserWarnings} = await ViewportMeta.compute_(makeMetaElements(viewport));
-    assert.equal(parserWarnings[0], undefined);
+    const {parserWarnings, rawContentString} =
+        await ViewportMeta.compute_(makeMetaElements(viewport));
+    assert.equal(rawContentString, viewport);
+    assert.equal(parserWarnings.length, 0);
+    assert.equal(rawContentString, viewport);
   });
 
   it('doesn\'t throw when viewport contains "invalid" iOS properties', async () => {
@@ -87,11 +96,11 @@ describe('ViewportMeta computed artifact', () => {
       'width=device-width, viewport-fit=cover',
     ];
     await Promise.all(viewports.map(async viewport => {
-      const {isMobileOptimized, parserWarnings} =
+      const {isMobileOptimized, parserWarnings, rawContentString} =
         await ViewportMeta.compute_(makeMetaElements(viewport));
       assert.equal(isMobileOptimized, true);
-      assert.equal(parserWarnings[0], undefined);
+      assert.equal(parserWarnings.length, 0);
+      assert.equal(rawContentString, viewport);
     }));
   });
 });
-

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -42,6 +42,10 @@
             "metricSavings": {
               "INP": 0
             },
+            "details": {
+              "type": "debugdata",
+              "viewportContent": "width=device-width"
+            },
             "guidanceLevel": 3
           },
           "first-contentful-paint": {
@@ -12757,6 +12761,10 @@
             "metricSavings": {
               "INP": 0
             },
+            "details": {
+              "type": "debugdata",
+              "viewportContent": "width=device-width"
+            },
             "guidanceLevel": 3
           },
           "image-aspect-ratio": {
@@ -17993,6 +18001,10 @@
             "warnings": [],
             "metricSavings": {
               "INP": 0
+            },
+            "details": {
+              "type": "debugdata",
+              "viewportContent": "width=device-width"
             },
             "guidanceLevel": 3
           },

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -56,6 +56,10 @@
       "metricSavings": {
         "INP": 0
       },
+      "details": {
+        "type": "debugdata",
+        "viewportContent": "width=device-width, initial-scale=1, minimum-scale=1"
+      },
       "guidanceLevel": 3
     },
     "first-contentful-paint": {


### PR DESCRIPTION
I've dipped my toes into #15627 a bit and discovered that reality is even more nuanced than the proposed changes listed there. However, any analysis after the fact is difficult because we don't include the page's actual meta viewport `content` anywhere in the LHR, just whether or not it passed the audit's _current_ mobile viewport checks.

This PR just includes the full viewport string in the audit's debugData.