### PR TITLE
tests(dbw): fix server latency flake

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -566,7 +566,9 @@ const expectations = {
           items: {
             _includes: [
               {origin: 'http://localhost:10200', serverResponseTime: '>0'},
-              // TODO: Figure out why this can be 0 sometimes
+              // The response time estimate is based on just 1 request which can force Lighthouse
+              // to report a response time of 0 sometimes.
+              // https://github.com/GoogleChrome/lighthouse/pull/15729#issuecomment-1877869991
               {origin: 'http://[::1]:10503', serverResponseTime: '>=0'},
             ],
             _excludes: [{}],

--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -566,7 +566,8 @@ const expectations = {
           items: {
             _includes: [
               {origin: 'http://localhost:10200', serverResponseTime: '>0'},
-              {origin: 'http://[::1]:10503', serverResponseTime: '>0'},
+              // TODO: Figure out why this can be 0 sometimes
+              {origin: 'http://[::1]:10503', serverResponseTime: '>=0'},
             ],
             _excludes: [{}],
           },


### PR DESCRIPTION
This has been happening a lot since this condition was added. ~Not entirely sure how this can happen. Maybe there is just higher variance since the sample size for the domain is just 1 request?~ Edit: see https://github.com/GoogleChrome/lighthouse/pull/15729#issuecomment-1877869991