### PR TITLE
tests(mocha): fix snapshot expectations in retries

### DIFF
--- a/core/test/scenarios/__snapshots__/api-test-pptr.js.snap
+++ b/core/test/scenarios/__snapshots__/api-test-pptr.js.snap
@@ -258,6 +258,7 @@ Array [
   "largest-contentful-paint",
   "largest-contentful-paint-element",
   "layout-shift-elements",
+  "layout-shifts",
   "lcp-lazy-loaded",
   "legacy-javascript",
   "link-in-text-block",
@@ -454,6 +455,7 @@ Array [
   "interaction-to-next-paint",
   "is-on-https",
   "layout-shift-elements",
+  "layout-shifts",
   "legacy-javascript",
   "long-tasks",
   "main-thread-tasks",
@@ -492,6 +494,7 @@ Array [
 
 exports[`Individual modes API startTimespan should compute ConsoleMessage results across a span of time 2`] = `
 Array [
+  "layout-shifts",
   "non-composited-animations",
   "preload-fonts",
   "third-party-summary",
@@ -515,6 +518,7 @@ Array [
   "interaction-to-next-paint",
   "is-on-https",
   "layout-shift-elements",
+  "layout-shifts",
   "legacy-javascript",
   "long-tasks",
   "main-thread-tasks",
@@ -556,6 +560,7 @@ Array [
   "bootup-time",
   "duplicated-javascript",
   "efficient-animated-content",
+  "layout-shifts",
   "legacy-javascript",
   "modern-image-formats",
   "network-rtt",

--- a/core/test/test-env/mocha-setup.js
+++ b/core/test/test-env/mocha-setup.js
@@ -63,7 +63,7 @@ function getSnapshotState(testFile) {
   const snapshotDir = path.join(path.dirname(testFile), '__snapshots__');
   const snapshotFile = path.join(snapshotDir, path.basename(testFile) + '.snap');
   snapshotState = new SnapshotState(snapshotFile, {
-    updateSnapshot: process.env.SNAPSHOT_UPDATE ? 'all' : 'new',
+    updateSnapshot: process.env.SNAPSHOT_UPDATE ? 'all' : 'none',
     prettierPath: '',
     snapshotFormat: {},
   });
@@ -98,6 +98,17 @@ expect.extend({
 
     const title = makeTestTitle(test);
     const snapshotState = getSnapshotState(test.file);
+
+    // If a test is retried the snapshot indices will start where the previous attempt left off.
+    // This can lead to several problems including the test passing where it should be failing.
+    //
+    // Jest itself clears the snapshot state on retries although they seem to execute retries after
+    // all tests finish and not immediately after the initial test failure.
+    // https://github.com/jestjs/jest/pull/8629
+    if (test.retries()) {
+      snapshotState.clear();
+    }
+
     const context = {snapshotState, currentTestName: title};
     // @ts-expect-error - this is enough for snapshots to work.
     const matcher = toMatchSnapshot.bind(context);

--- a/core/test/test-env/mocha-setup.js
+++ b/core/test/test-env/mocha-setup.js
@@ -99,16 +99,6 @@ expect.extend({
     const title = makeTestTitle(test);
     const snapshotState = getSnapshotState(test.file);
 
-    // If a test is retried the snapshot indices will start where the previous attempt left off.
-    // This can lead to several problems including the test passing where it should be failing.
-    //
-    // Jest itself clears the snapshot state on retries although they seem to execute retries after
-    // all tests finish and not immediately after the initial test failure.
-    // https://github.com/jestjs/jest/pull/8629
-    if (test.retries()) {
-      snapshotState.clear();
-    }
-
     const context = {snapshotState, currentTestName: title};
     // @ts-expect-error - this is enough for snapshots to work.
     const matcher = toMatchSnapshot.bind(context);
@@ -157,6 +147,17 @@ const rootHooks = {
 
     // Needed so `expect` extension method can access information about the current test.
     mochaCurrentTest = this.currentTest;
+
+    // If a test is retried the snapshot indices will start where the previous attempt left off.
+    // This can lead to several problems including the test passing where it should be failing.
+    //
+    // Jest itself clears the snapshot state on retries although they seem to execute retries after
+    // all tests finish and not immediately after the initial test failure.
+    // https://github.com/jestjs/jest/pull/8629
+    if (this.currentTest.retries() && this.currentTest.file) {
+      const snapshotState = getSnapshotState(this.currentTest.file);
+      snapshotState.clear();
+    }
   },
   /** @this {Mocha.Context} */
   afterEach() {


### PR DESCRIPTION
Noticed that snapshot tests were passing where they should be failing in CI (https://github.com/GoogleChrome/lighthouse/pull/15730#discussion_r1442352597)

If a test is retried, the snapshot expectation indices will start where the previous attempt left off. This leads to `jest-snapshot` treating the second attempt as a "new" snapshot which we automatically treat as passing because of the `updateSnapshot: 'new'` setting.

This PR uses `updateSnapshot: 'none'` by default so that CI will never accidentally pass. This means we have to use `-u` to set an initial snapshot for new tests, but that seems like a small price to pay.

However, mocha will only report the *last* failure attempt if a test is retried, which will now by a "snapshot does not exist" failure instead of a helpful snapshot diff. To fix this, this PR also resets the snapshot state between each test.
