### PR TITLE
WIP: use inspector issues as SOT for unload listeners

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -207,12 +207,6 @@ const expectations = {
         },
       },
     ],
-    GlobalListeners: [{
-      type: 'unload',
-      scriptId: /^\d+$/,
-      lineNumber: '>300',
-      columnNumber: '>30',
-    }],
     DevtoolsLog: {
       _includes: [
         // Ensure we are getting async call stacks.
@@ -488,7 +482,7 @@ const expectations = {
               url: 'http://localhost:10200/dobetterweb/dbw_tester.html',
               urlProvider: 'network',
               line: '>300',
-              column: '>30',
+              column: '>5',
             },
           }],
         },

--- a/core/audits/no-unload-listeners.js
+++ b/core/audits/no-unload-listeners.js
@@ -29,7 +29,7 @@ class NoUnloadListeners extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.failureTitle),
       description: str_(UIStrings.description),
-      requiredArtifacts: ['GlobalListeners', 'SourceMaps', 'Scripts'],
+      requiredArtifacts: ['InspectorIssues', 'SourceMaps', 'Scripts'],
     };
   }
 
@@ -39,8 +39,9 @@ class NoUnloadListeners extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit(artifacts, context) {
-    const unloadListeners = artifacts.GlobalListeners.filter(l => l.type === 'unload');
-    if (!unloadListeners.length) {
+    const unloadListenerIssues = artifacts.InspectorIssues.deprecationIssue
+      .filter(issue => issue.type === 'UnloadHandler');
+    if (!unloadListenerIssues.length) {
       return {
         score: 1,
       };
@@ -54,9 +55,9 @@ class NoUnloadListeners extends Audit {
     ];
 
     /** @type {Array<{source: LH.Audit.Details.ItemValue}>} */
-    const tableItems = unloadListeners.map(listener => {
-      const {lineNumber, columnNumber} = listener;
-      const script = artifacts.Scripts.find(s => s.scriptId === listener.scriptId);
+    const tableItems = unloadListenerIssues.map(issue => {
+      const {lineNumber, columnNumber, scriptId} = issue.sourceCodeLocation;
+      const script = artifacts.Scripts.find(s => s.scriptId === scriptId);
 
       // If we can't find a url, still show something so the user can manually
       // look for where an `unload` handler is being created.


### PR DESCRIPTION
New deprecation issue added in M121 (not stable as of writing this) https://chromiumdash.appspot.com/commit/f2e3f6240e74c36be745f086a2ec372b31900a1d

This doesn't change much about the audit itself, but does allow us to deprecate the `GlobalListeners` gatherer.