### PR TITLE
tests: fix ToT chrome install path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   basics:
     runs-on: ubuntu-latest
     env:
+      CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
       FORCE_COLOR: true
 
     # A few steps are duplicated across all jobs. Can be done better when this feature lands:
@@ -25,7 +26,6 @@ jobs:
         fetch-depth: 100
     - run: bash core/scripts/github-actions-commit-range.sh
       env:
-        CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
         GITHUB_CONTEXT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 100
     - run: bash core/scripts/github-actions-commit-range.sh
       env:
-        CHROME_PATH: ${{ github.workspace }}/lighthouse/.tmp/chrome-tot/chrome
+        CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
         GITHUB_CONTEXT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -92,7 +92,7 @@ jobs:
         node-version: 18.x
 
     - name: Define ToT chrome path
-      run: echo "CHROME_PATH=${env:GITHUB_WORKSPACE}\chrome-tot\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+      run: echo "CHROME_PATH=${env:GITHUB_WORKSPACE}\.tmp\chrome-tot\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
     # Chrome Stable is already installed by default.
     - name: Install Chrome ToT

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
+      CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
       # The total number of shards. Set dynamically when length of *single* matrix variable is
       # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
       SHARD_TOTAL: 3
@@ -39,10 +40,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18.x
-
-    - name: Define ToT chrome path
-      if: matrix.chrome-channel == 'ToT'
-      run: echo "CHROME_PATH=${{ github.workspace }}/lighthouse/.tmp/chrome-tot/chrome" >> $GITHUB_ENV
 
     # Chrome Stable is already installed by default.
     - name: Install Chrome ToT
@@ -95,7 +92,7 @@ jobs:
         node-version: 18.x
 
     - name: Define ToT chrome path
-      run: echo "CHROME_PATH=${env:GITHUB_WORKSPACE}\chrome-win\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+      run: echo "CHROME_PATH=${env:GITHUB_WORKSPACE}\chrome-tot\chrome.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
     # Chrome Stable is already installed by default.
     - name: Install Chrome ToT
@@ -126,7 +123,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
-      CHROME_PATH: ${{ github.workspace }}/lighthouse/.tmp/chrome-tot/chrome
+      CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
       # The total number of shards. Set dynamically when length of *single* matrix variable is
       # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
       SHARD_TOTAL: 3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     name: node ${{ matrix.node }}
     env:
-      CHROME_PATH: ${{ github.workspace }}/lighthouse/.tmp/chrome-tot/chrome
+      CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
       LATEST_NODE: '18'
       FORCE_COLOR: true
 

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -78,4 +78,4 @@ cd - && rm -rf .tmp-download
 echo "OUTPUT DIR: $chrome_out"
 ls "$chrome_out"
 
-echo "CHROME VERSION: ${$CHROME_PATH --version}"
+echo "CHROME VERSION: $($CHROME_PATH --version)"

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -75,4 +75,7 @@ curl "$url" -Lo chrome.zip && unzip -q chrome.zip && rm chrome.zip
 mv * "$chrome_out"
 cd - && rm -rf .tmp-download
 
+echo "OUTPUT DIR: $chrome_out"
 ls "$chrome_out"
+
+echo "CHROME VERSION: ${$CHROME_PATH --version}"

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -78,11 +78,14 @@ cd - && rm -rf .tmp-download
 echo "OUTPUT DIR: $chrome_out"
 ls "$chrome_out"
 
-echo "\nVerifying CHROME_PATH";
+echo "";
+echo "Verifying CHROME_PATH...";
 
 if ! [ -f $CHROME_PATH ]; then
   echo "CHROME_PATH does not point to a valid file"
   exit 1
+else
+  echo "CHROME_PATH is good!"
 fi
 
 # TODO: Find a convenient way to check the version in windows

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -83,7 +83,7 @@ echo "\nVerifying CHROME_PATH";
 if ! [ -f $CHROME_PATH ]; then
   echo "CHROME_PATH does not point to a valid file"
   exit 1
-else
+fi
 
 # TODO: Find a convenient way to check the version in windows
 if [ "$machine" != "MinGw" ]; then

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -78,5 +78,15 @@ cd - && rm -rf .tmp-download
 echo "OUTPUT DIR: $chrome_out"
 ls "$chrome_out"
 
-echo "CHROME_PATH version:"
-$CHROME_PATH --version
+echo "\nVerifying CHROME_PATH";
+
+if ! [ -f $CHROME_PATH ]; then
+  echo "CHROME_PATH does not point to a valid file"
+  exit 1
+else
+
+# TODO: Find a convenient way to check the version in windows
+if [ "$machine" != "MinGw" ]; then
+  echo "CHROME_PATH version:"
+  $CHROME_PATH --version
+fi

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -78,4 +78,5 @@ cd - && rm -rf .tmp-download
 echo "OUTPUT DIR: $chrome_out"
 ls "$chrome_out"
 
-echo "CHROME VERSION: $($CHROME_PATH --version)"
+echo "CHROME_PATH version:"
+$CHROME_PATH --version


### PR DESCRIPTION
I noticed in https://github.com/GoogleChrome/lighthouse/pull/15752 that we are not specifying the correct Chrome path in our smoke tests and then the tests revert back to using stable. Luckily it looks like the DevTools smoke tests specify the correct directory so we did not completely lose coverage.