### PR TITLE
tests(dbw): revert expectations for unload handler removal

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -208,8 +208,6 @@ const expectations = {
       },
     ],
     GlobalListeners: [{
-      // Unload handlers were disabled in M122
-      _maxChromiumVersion: '121',
       type: 'unload',
       scriptId: /^\d+$/,
       lineNumber: '>300',
@@ -308,13 +306,6 @@ const expectations = {
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
               sourceLocation: {url: 'http://localhost:10200/favicon.ico'},
             },
-            {
-              // Unload handlers were disabled in M122
-              _minChromiumVersion: '122',
-              source: 'violation',
-              description: 'Permissions policy violation: unload is not allowed in this document.',
-              sourceLocation: {url: 'http://localhost:10200/dobetterweb/dbw_tester.html'},
-            },
           ],
         },
       },
@@ -387,10 +378,7 @@ const expectations = {
               subItems: undefined,
             },
             {
-              // Deprecation warning was added in M121
               _minChromiumVersion: '121',
-              // Unload handlers were disabled in M122
-              _maxChromiumVersion: '121',
               value: 'UnloadHandler',
               source: {
                 type: 'source-location',
@@ -492,8 +480,6 @@ const expectations = {
         },
       },
       'no-unload-listeners': {
-        // Unload handlers were disabled in M122
-        _maxChromiumVersion: '121',
         score: 0,
         details: {
           items: [{
@@ -511,8 +497,6 @@ const expectations = {
         details: {
           items: [
             {
-              // Unload handlers were disabled in M122
-              _maxChromiumVersion: '121',
               reason: 'The page has an unload handler in the main frame.',
               failureType: 'Actionable',
               subItems: {
@@ -522,8 +506,9 @@ const expectations = {
               },
             },
             {
-              // Unload handlers create a permission request in M122
-              _minChromiumVersion: '122',
+              // This issue only appears in the DevTools runner for some reason.
+              // TODO: Investigate why this doesn't happen on the CLI runner.
+              _runner: 'devtools',
               reason: 'There were permission requests upon navigating away.',
               failureType: 'Pending browser support',
               subItems: {

--- a/cli/test/smokehouse/test-definitions/oopif-scripts.js
+++ b/cli/test/smokehouse/test-definitions/oopif-scripts.js
@@ -107,14 +107,14 @@ const expectations = {
         source: 'network',
       },
       {
-        // Worker requests emitted on the worker's parent target since M121.
-        _minChromiumVersion: '121',
+        // Worker requests emitted on the worker's parent target since M123.
+        _minChromiumVersion: '123',
         src: 'http://localhost:10200/simple-worker.mjs',
         source: 'network',
       },
       {
-        // Worker requests emitted on the worker's parent target since M121.
-        _minChromiumVersion: '121',
+        // Worker requests emitted on the worker's parent target since M123.
+        _minChromiumVersion: '123',
         src: 'http://localhost:10200/simple-worker.js',
         source: 'network',
       },


### PR DESCRIPTION
This reverts commit 3d27df19160a60f3a1c0dcf26f0563f7ed786f5f / PR https://github.com/GoogleChrome/lighthouse/pull/15765

I guess Chrome backed off the unload handler removal (for now). I also verified this works on Chrome beta (M122).

This PR also updates the version for ScriptElements expectations from https://github.com/GoogleChrome/lighthouse/pull/15601 which is another smoke failure that appeared recently.
