### PR TITLE
core: increase page hung check from 1s to 5s

### DIFF
--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -384,11 +384,11 @@ function waitForLoadEvent(session, pauseAfterLoadMs) {
  */
 async function isPageHung(session) {
   try {
-    session.setNextProtocolTimeout(1000);
+    session.setNextProtocolTimeout(5000);
     await session.sendCommand('Runtime.evaluate', {
       expression: '"ping"',
       returnByValue: true,
-      timeout: 1000,
+      timeout: 5000,
     });
 
     return false;


### PR DESCRIPTION
Some tests in google3 run with constrained CPU resources, so 1s is sometimes a tough budget to meet. Increase this to 5s.

#15542 enabled a heavy trace event, which was enough to hang the page of a test w/ lots of analytics on slow hardware.

🔒 b/325659693