### PR TITLE
core(driver): add verbose logs for wait-for page load components

### DIFF
--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -446,6 +446,21 @@ async function waitForFullyLoaded(session, networkMonitor, options) {
   // CPU listener. Resolves when the CPU has been idle for cpuQuietThresholdMs after network idle.
   let resolveOnCPUIdle = waitForNothing();
 
+  if (log.isVerbose()) {
+    resolveOnFcp.promise.then(() => {
+      log.verbose('waitFor', 'resolveOnFcp fired');
+    });
+    resolveOnLoadEvent.promise.then(() => {
+      log.verbose('waitFor', 'resolveOnLoadEvent fired');
+    });
+    resolveOnNetworkIdle.promise.then(() => {
+      log.verbose('waitFor', 'resolveOnNetworkIdle fired');
+    });
+    resolveOnCriticalNetworkIdle.promise.then(() => {
+      log.verbose('waitFor', 'resolveOnCriticalNetworkIdle fired');
+    });
+  }
+
   // Wait for all initial load promises. Resolves on cleanup function the clears load
   // timeout timer.
   /** @type {Promise<() => Promise<{timedOut: boolean}>>} */


### PR DESCRIPTION
was useful for debugging issue mentioned in #15816