### PR TITLE
core(driver): fix protocol timeout being ignored for isolated eval

### DIFF
--- a/core/test/gather/driver/execution-context-test.js
+++ b/core/test/gather/driver/execution-context-test.js
@@ -120,6 +120,27 @@ describe('.evaluateAsync', () => {
     await expect(evaluatePromise).rejects.toBeTruthy();
   });
 
+  it('uses the specific timeout given (isolation)', async () => {
+    const expectedTimeout = 5000;
+    const setNextProtocolTimeout = sessionMock.setNextProtocolTimeout = fnAny();
+    sessionMock.hasNextProtocolTimeout = fnAny().mockReturnValue(true);
+    sessionMock.getNextProtocolTimeout = fnAny().mockReturnValue(expectedTimeout);
+    sessionMock.sendCommand
+      .mockResponse('Page.enable')
+      .mockResponse('Runtime.enable')
+      .mockResponse('Page.getFrameTree', {frameTree: {frame: {id: '1337'}}})
+      .mockResponse('Page.createIsolatedWorld', {executionContextId: 1});
+
+    const evaluatePromise = makePromiseInspectable(executionContext.evaluateAsync('1 + 1', {
+      useIsolation: true,
+    }));
+
+    await flushAllTimersAndMicrotasks();
+    expect(setNextProtocolTimeout).toHaveBeenCalledWith(expectedTimeout);
+    expect(evaluatePromise).toBeDone();
+    await expect(evaluatePromise).rejects.toBeTruthy();
+  });
+
   it('evaluates an expression in isolation', async () => {
     sessionMock.sendCommand
       .mockResponse('Page.enable')


### PR DESCRIPTION
I noticed this when attempting to increase the timeout for `executionContext.evaluate` did not change the timeout used.

Only `fetchElementWithSizeInformation` is existing code which attempted to set a timeout. In that case, the intention was to wait no more than 250ms. That regressed with https://github.com/GoogleChrome/lighthouse/pull/14005