### PR TITLE
core(navigation-runner): only run `getArtifact` phase once

### DIFF
--- a/core/gather/gatherers/devtools-log.js
+++ b/core/gather/gatherers/devtools-log.js
@@ -50,6 +50,13 @@ class DevtoolsLog extends BaseGatherer {
   }
 
   /**
+   * @return {LH.Artifacts['DevtoolsLog']}
+   */
+  getDebugData() {
+    return this._messageLog.messages;
+  }
+
+  /**
    * @return {Promise<LH.Artifacts['DevtoolsLog']>}
    */
   async getArtifact() {

--- a/core/gather/gatherers/trace.js
+++ b/core/gather/gatherers/trace.js
@@ -126,6 +126,10 @@ class Trace extends BaseGatherer {
     this._trace = await Trace.endTraceAndCollectEvents(driver.defaultSession);
   }
 
+  getDebugData() {
+    return this._trace;
+  }
+
   getArtifact() {
     return this._trace;
   }

--- a/core/test/gather/navigation-runner-test.js
+++ b/core/test/gather/navigation-runner-test.js
@@ -33,7 +33,7 @@ const DevtoolsLogGatherer = (await import('../../gather/gatherers/devtools-log.j
 const TraceGatherer = (await import('../../gather/gatherers/trace.js')).default;
 const {initializeConfig} = await import('../../config/config.js');
 
-/** @typedef {{meta: LH.Gatherer.GathererMeta<'Accessibility'>, getArtifact: Mock<any, any>, startInstrumentation: Mock<any, any>, stopInstrumentation: Mock<any, any>, startSensitiveInstrumentation: Mock<any, any>, stopSensitiveInstrumentation:  Mock<any, any>, getDebugData?: Mock<any, any>}} MockGatherer */
+/** @typedef {{meta: LH.Gatherer.GathererMeta<'Accessibility'>, getArtifact: Mock<any, any>, startInstrumentation: Mock<any, any>, stopInstrumentation: Mock<any, any>, startSensitiveInstrumentation: Mock<any, any>, stopSensitiveInstrumentation:  Mock<any, any>}} MockGatherer */
 
 describe('NavigationRunner', () => {
   let requestedUrl = '';

--- a/core/test/gather/navigation-runner-test.js
+++ b/core/test/gather/navigation-runner-test.js
@@ -33,7 +33,7 @@ const DevtoolsLogGatherer = (await import('../../gather/gatherers/devtools-log.j
 const TraceGatherer = (await import('../../gather/gatherers/trace.js')).default;
 const {initializeConfig} = await import('../../config/config.js');
 
-/** @typedef {{meta: LH.Gatherer.GathererMeta<'Accessibility'>, getArtifact: Mock<any, any>, startInstrumentation: Mock<any, any>, stopInstrumentation: Mock<any, any>, startSensitiveInstrumentation: Mock<any, any>, stopSensitiveInstrumentation:  Mock<any, any>}} MockGatherer */
+/** @typedef {{meta: LH.Gatherer.GathererMeta<'Accessibility'>, getArtifact: Mock<any, any>, startInstrumentation: Mock<any, any>, stopInstrumentation: Mock<any, any>, startSensitiveInstrumentation: Mock<any, any>, stopSensitiveInstrumentation:  Mock<any, any>, getDebugData?: Mock<any, any>}} MockGatherer */
 
 describe('NavigationRunner', () => {
   let requestedUrl = '';
@@ -344,13 +344,27 @@ describe('NavigationRunner', () => {
     });
 
     it('finds page load errors in network records when available', async () => {
-      const {resolvedConfig, gatherers} = createMockConfig();
-      mocks.navigationMock.gotoURL.mockResolvedValue({mainDocumentUrl: requestedUrl, warnings: []});
+      mocks.navigationMock.gotoURL.mockReturnValue({
+        requestedUrl,
+        mainDocumentUrl: requestedUrl,
+        warnings: [],
+      });
+
+      const devtoolsLogInstance = new DevtoolsLogGatherer();
+      const traceInstance = new TraceGatherer();
+
+      // @ts-expect-error mock config
+      const resolvedConfig = /** @type {LH.Config.ResolvedConfig} */ ({
+        settings: JSON.parse(JSON.stringify(defaultSettings)),
+        artifacts: [
+          {id: 'DevtoolsLog', gatherer: {instance: devtoolsLogInstance}},
+          {id: 'Trace', gatherer: {instance: traceInstance}},
+        ],
+      });
+
       const devtoolsLog = networkRecordsToDevtoolsLog([{url: requestedUrl, failed: true}]);
-      gatherers.timespan.meta.symbol = DevtoolsLogGatherer.symbol;
-      gatherers.timespan.getArtifact = fnAny().mockResolvedValue(devtoolsLog);
-      gatherers.navigation.meta.symbol = TraceGatherer.symbol;
-      gatherers.navigation.getArtifact = fnAny().mockResolvedValue({traceEvents: []});
+      devtoolsLogInstance.getDebugData = fnAny().mockReturnValue(devtoolsLog);
+      traceInstance.getDebugData = fnAny().mockReturnValue({traceEvents: []});
 
       const artifacts = await runner._navigation({
         driver,


### PR DESCRIPTION
@connorjclark noticed that we are running the `getArtifact` phase of the DT log and trace *twice* during a normal navigation run:

![image](https://github.com/GoogleChrome/lighthouse/assets/6752989/2478ef94-4847-4c61-aed6-c3ed63d0b76e)

The root cause is that we attempt to get a preview of the `DevtoolsLog` and `Trace` artifacts *before* running through the `getArtifact` phase properly. This doesn't actually cause any problems because the `getArtifact` implementation is idempotent in both cases. However this could theoretically cause problems if that were to change down the line.

This PR adds a separate path for the navigation runner to get it's preview of the DT log and trace so that making changes to `getArtifact` is safer.
