### PR TITLE
core(network-request): use rendererStartTime for initiator candidates

### DIFF
--- a/core/lib/network-recorder.js
+++ b/core/lib/network-recorder.js
@@ -257,7 +257,7 @@ class NetworkRecorder extends RequestEventEmitter {
     let candidates = recordsByURL.get(initiatorURL) || [];
     // The (valid) initiator must come before the initiated request.
     candidates = candidates.filter(c => {
-      return c.responseHeadersEndTime <= record.networkRequestTime &&
+      return c.responseHeadersEndTime <= record.rendererStartTime &&
           c.finished && !c.failed;
     });
     if (candidates.length > 1) {


### PR DESCRIPTION
ref #14500

addressing old comment from @paulirish  https://github.com/GoogleChrome/lighthouse/pull/14311#discussion_r1014444628