### PR TITLE
core(driver): don't await cleanup in PAGE_HUNG case

### DIFF
--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -497,8 +497,10 @@ async function waitForFullyLoaded(session, networkMonitor, options) {
       log.warn('waitFor', 'Timed out waiting for page load. Checking if page is hung...');
       if (await isPageHung(session)) {
         log.warn('waitFor', 'Page appears to be hung, killing JavaScript...');
-        await session.sendCommand('Emulation.setScriptExecutionDisabled', {value: true});
-        await session.sendCommand('Runtime.terminateExecution');
+        // We don't await these, as we want to exit with PAGE_HUNG
+        void session.sendCommand('Emulation.setScriptExecutionDisabled', {value: true})
+          .catch(_ => {});
+        void session.sendCommand('Runtime.terminateExecution').catch(_ => {});
         throw new LighthouseError(LighthouseError.errors.PAGE_HUNG);
       }
 


### PR DESCRIPTION
Also discovered during the targetcrashed journey (#11840)  

