### PR TITLE
clients(lr): always apply category filter/ignoreStatusCode

### DIFF
--- a/clients/lightrider/lightrider-entry.js
+++ b/clients/lightrider/lightrider-entry.js
@@ -96,11 +96,12 @@ async function runLighthouseInLR(connection, url, flags, lrOpts) {
     config = configOverride;
   } else {
     config = lrDevice === 'desktop' ? LR_PRESETS.desktop : LR_PRESETS.mobile;
-    config.settings = config.settings || {};
-    config.settings.ignoreStatusCode = ignoreStatusCode;
-    if (categoryIDs) {
-      config.settings.onlyCategories = categoryIDs;
-    }
+  }
+
+  config.settings = config.settings || {};
+  config.settings.ignoreStatusCode = ignoreStatusCode;
+  if (categoryIDs) {
+    config.settings.onlyCategories = categoryIDs;
   }
 
   try {


### PR DESCRIPTION
There's no reason to not apply these when given a explicit config. This allows the others options of a LR request to compose nicely with the internal "use this config" option.