### PR TITLE
core(lantern): refactor LH.Gatherer.Simulation

### DIFF
--- a/core/computed/load-simulator.js
+++ b/core/computed/load-simulator.js
@@ -9,6 +9,8 @@ import * as constants from '../config/constants.js';
 import {Simulator} from '../lib/lantern/simulator/simulator.js';
 import {NetworkAnalysis} from './network-analysis.js';
 
+/** @typedef {import('../../types/internal/lantern.js').Lantern.Simulation.Options} SimulationOptions */
+
 class LoadSimulator {
   /**
    * @param {{devtoolsLog: LH.DevtoolsLog, settings: LH.Audit.Context['settings']}} data
@@ -19,7 +21,7 @@ class LoadSimulator {
     const {throttlingMethod, throttling, precomputedLanternData} = data.settings;
     const networkAnalysis = await NetworkAnalysis.request(data.devtoolsLog, context);
 
-    /** @type {LH.Gatherer.Simulation.Options} */
+    /** @type {SimulationOptions} */
     const options = {
       additionalRttByOrigin: networkAnalysis.additionalRttByOrigin,
       serverResponseTimeByOrigin: networkAnalysis.serverResponseTimeByOrigin,

--- a/core/lib/lantern/simulator/simulator.js
+++ b/core/lib/lantern/simulator/simulator.js
@@ -9,7 +9,7 @@
 /** @typedef {import('../../../../types/internal/lantern.js').Lantern.NetworkRequest} NetworkRequest */
 /** @typedef {import('../../../../types/internal/lantern.js').Lantern.Simulation.Options} SimulationOptions */
 /** @typedef {import('../../../../types/internal/lantern.js').Lantern.Simulation.NodeTiming} SimulationNodeTiming */
-/** @typedef {import('../../../../types/internal/lantern.js').Lantern.Simulation.Result} SimulationResult */
+/** @template T @typedef {import('../../../../types/internal/lantern.js').Lantern.Simulation.Result<T>} SimulationResult */
 
 import {BaseNode} from '../base-node.js';
 import {TcpConnection} from './tcp-connection.js';
@@ -52,6 +52,9 @@ const PriorityStartTimePenalty = {
 /** @type {Map<string, Map<Node, CompleteNodeTiming>>} */
 const ALL_SIMULATION_NODE_TIMINGS = new Map();
 
+/**
+ * @template [T=any]
+ */
 class Simulator {
   /**
    * @param {SimulationOptions} [options]
@@ -435,7 +438,7 @@ class Simulator {
    *
    * @param {Node} graph
    * @param {{flexibleOrdering?: boolean, label?: string}=} options
-   * @return {SimulationResult}
+   * @return {SimulationResult<T>}
    */
   simulate(graph, options) {
     if (BaseNode.hasCycle(graph)) {

--- a/types/gatherer.d.ts
+++ b/types/gatherer.d.ts
@@ -7,9 +7,6 @@
 import {Protocol as Crdp} from 'devtools-protocol/types/protocol.js';
 import {ProtocolMapping as CrdpMappings} from 'devtools-protocol/types/protocol-mapping.js';
 
-import {NetworkNode as _NetworkNode} from '../core/lib/lantern/network-node.js';
-import {CPUNode as _CPUNode} from '../core/lib/lantern/cpu-node.js';
-import {Simulator as _Simulator} from '../core/lib/lantern/simulator/simulator.js';
 import {ExecutionContext} from '../core/gather/driver/execution-context.js';
 import {NetworkMonitor} from '../core/gather/driver/network-monitor.js';
 import {Fetcher} from '../core/gather/fetcher.js';
@@ -20,6 +17,7 @@ import Config from './config.js';
 import Result from './lhr/lhr.js';
 import Protocol from './protocol.js';
 import Puppeteer from './puppeteer.js';
+import {Lantern} from '../types/internal/lantern.js';
 
 type CrdpEvents = CrdpMappings.Events;
 type CrdpCommands = CrdpMappings.Commands;
@@ -132,40 +130,14 @@ declare module Gatherer {
       GathererInstance<Exclude<TDependencies, DefaultDependenciesKey>>
   type AnyGathererInstance = GathererInstanceExpander<Gatherer.DependencyKey>
 
-  // TODO(15841): use from lantern.d.ts
   namespace Simulation {
-    type GraphNode = import('../core/lib/lantern/base-node.js').Node<Artifacts.NetworkRequest>;
-    type GraphNetworkNode = _NetworkNode<Artifacts.NetworkRequest>;
-    type GraphCPUNode = _CPUNode;
-    type Simulator = _Simulator;
-
-    interface MetricCoefficients {
-      intercept: number;
-      optimistic: number;
-      pessimistic: number;
-    }
-
-    interface Options {
-      rtt?: number;
-      throughput?: number;
-      observedThroughput: number;
-      maximumConcurrentRequests?: number;
-      cpuSlowdownMultiplier?: number;
-      layoutTaskMultiplier?: number;
-      additionalRttByOrigin?: Map<string, number>;
-      serverResponseTimeByOrigin?: Map<string, number>;
-    }
-
-    interface NodeTiming {
-      startTime: number;
-      endTime: number;
-      duration: number;
-    }
-
-    interface Result {
-      timeInMs: number;
-      nodeTimings: Map<GraphNode, NodeTiming>;
-    }
+    type GraphNode = Lantern.Simulation.GraphNode<Artifacts.NetworkRequest>;
+    type GraphNetworkNode = Lantern.Simulation.GraphNetworkNode<Artifacts.NetworkRequest>;
+    type GraphCPUNode = Lantern.Simulation.GraphCPUNode;
+    type Simulator = Lantern.Simulation.Simulator<Artifacts.NetworkRequest>;
+    type NodeTiming = Lantern.Simulation.NodeTiming;
+    type MetricCoefficients = Lantern.Simulation.MetricCoefficients;
+    type Result = Lantern.Simulation.Result<Artifacts.NetworkRequest>;
   }
 }
 

--- a/types/internal/lantern.d.ts
+++ b/types/internal/lantern.d.ts
@@ -80,11 +80,11 @@ declare namespace Lantern {
         priority: LH.Crdp.Network.ResourcePriority;
     }
 
-    namespace Simulation {
-        type GraphNode = import('../../core/lib/lantern/base-node.js').Node;
-        type GraphNetworkNode = import('../../core/lib/lantern/network-node.js').NetworkNode;
+    export namespace Simulation {
+        type GraphNode<T> = import('../../core/lib/lantern/base-node.js').Node<T>;
+        type GraphNetworkNode<T> = import('../../core/lib/lantern/network-node.js').NetworkNode<T>;
         type GraphCPUNode = import('../../core/lib/lantern/cpu-node.js').CPUNode;
-        type Simulator = import('../../core/lib/lantern/simulator/simulator.js').Simulator;
+        type Simulator<T> = import('../../core/lib/lantern/simulator/simulator.js').Simulator<T>;
 
         interface MetricCoefficients {
             intercept: number;
@@ -109,9 +109,9 @@ declare namespace Lantern {
             duration: number;
         }
 
-        interface Result {
+        interface Result<T = any> {
             timeInMs: number;
-            nodeTimings: Map<GraphNode, NodeTiming>;
+            nodeTimings: Map<GraphNode<T>, NodeTiming>;
         }
     }
 }


### PR DESCRIPTION
ref https://github.com/GoogleChrome/lighthouse/issues/15841

Dedupes the types of LH.Gatherer.Simulation to re-export Lantern's types.

Adds a type parameter to `Lantern.Simulation.Simulator` and `Lantern.Simulation.Results` to keep `simulator.simulate` typechecked with our NetworkRequest.