### PR TITLE
tests(devtools): skip type checking in local builds

### DIFF
--- a/core/scripts/build-devtools.sh
+++ b/core/scripts/build-devtools.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # 1) Builds Lighthouse bundle for DevTools
 # 2) Rolls to local devtools repo. By default, this is the temporary checkout in .tmp
 # 3) Builds devtools frontend with new Lighthouse roll
-# 
+#
 # Run `bash core/test/devtools-tests/setup.sh` first to update the temporary devtools checkout.
 # Specify `$DEVTOOLS_PATH` to use a different devtools repo.
 # Specify `$BUILD_FOLDER` to use a build other than 'LighthouseIntegration' (ex: Default).
@@ -22,6 +22,7 @@ TEST_DIR="$LH_ROOT/.tmp/chromium-web-tests"
 DEFAULT_DEVTOOLS_PATH="$TEST_DIR/devtools/devtools-frontend"
 DEVTOOLS_PATH=${DEVTOOLS_PATH:-"$DEFAULT_DEVTOOLS_PATH"}
 BUILD_FOLDER="${BUILD_FOLDER:-LighthouseIntegration}"
+CI="${CI:-}"
 
 echo "DEVTOOLS_PATH: $DEVTOOLS_PATH"
 
@@ -43,10 +44,10 @@ fi
 yarn devtools "$DEVTOOLS_PATH"
 
 cd "$DEVTOOLS_PATH"
-if git config user.email | grep -q '@google.com'; then
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false use_goma=true'
-else
+if [[ "$CI" ]]; then
   gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+else
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false devtools_skip_typecheck=true'
 fi
 gclient sync
 autoninja -C "out/$BUILD_FOLDER"

--- a/core/test/devtools-tests/download-devtools.sh
+++ b/core/test/devtools-tests/download-devtools.sh
@@ -9,6 +9,7 @@ set -euxo pipefail
 ##
 
 BUILD_FOLDER="${BUILD_FOLDER:-LighthouseIntegration}"
+CI="${CI:-}"
 
 if [ -d "$DEVTOOLS_PATH" ]
 then
@@ -34,8 +35,8 @@ cd `dirname $DEVTOOLS_PATH`
 fetch --nohooks --no-history devtools-frontend
 cd devtools-frontend
 gclient sync
-if git config user.email | grep -q '@google.com'; then
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false use_goma=true'
-else
+if [[ "$CI" ]]; then
   gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+else
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false devtools_skip_typecheck=true'
 fi

--- a/core/test/devtools-tests/roll-devtools.sh
+++ b/core/test/devtools-tests/roll-devtools.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 LH_ROOT="$SCRIPT_DIR/../../.."
 BUILD_FOLDER="${BUILD_FOLDER:-LighthouseIntegration}"
+CI="${CI:-}"
 
 roll_devtools() {
   # Roll devtools. Besides giving DevTools the latest lighthouse source files,
@@ -29,10 +30,10 @@ roll_devtools
 # `yarn devtools` deleted.
 gclient sync --delete_unversioned_trees --reset
 
-if git config user.email | grep -q '@google.com'; then
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false use_goma=true'
-else
+if [[ "$CI" ]]; then
   gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+else
+  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false devtools_skip_typecheck=true'
 fi
 
 # Build devtools. By default, this creates `out/LighthouseIntegration/gen/front_end`.


### PR DESCRIPTION
`devtools_skip_typecheck=true` is the only way to really speed up DT builds according to this doc:
https://chromium.googlesource.com/devtools/devtools-frontend/+/main/docs/get_the_code.md#standalone-checkout-build

Validating types is still valuable for each patch, so leaving it on in CI.

One annoying problem is that local builds will spit out a bunch of `[WARNING] Unrecognized target environment "es2022"` warnings for some reason :/

-----

This PR also removes the `use_goma=true` and requisite user email check because it has been removed from non-windows builds as of recently.
