### PR TITLE
tests(devtools): use `is_debug = true` for local builds

### DIFF
--- a/core/scripts/build-devtools.sh
+++ b/core/scripts/build-devtools.sh
@@ -45,9 +45,9 @@ yarn devtools "$DEVTOOLS_PATH"
 
 cd "$DEVTOOLS_PATH"
 if [[ "$CI" ]]; then
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+  gn gen "out/$BUILD_FOLDER" --args='is_debug=false'
 else
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false devtools_skip_typecheck=true'
+  gn gen "out/$BUILD_FOLDER" --args='is_debug=true devtools_skip_typecheck=true'
 fi
 gclient sync
 autoninja -C "out/$BUILD_FOLDER"

--- a/core/test/devtools-tests/download-devtools.sh
+++ b/core/test/devtools-tests/download-devtools.sh
@@ -36,7 +36,7 @@ fetch --nohooks --no-history devtools-frontend
 cd devtools-frontend
 gclient sync
 if [[ "$CI" ]]; then
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+  gn gen "out/$BUILD_FOLDER" --args='is_debug=false'
 else
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false devtools_skip_typecheck=true'
+  gn gen "out/$BUILD_FOLDER" --args='is_debug=true devtools_skip_typecheck=true'
 fi

--- a/core/test/devtools-tests/roll-devtools.sh
+++ b/core/test/devtools-tests/roll-devtools.sh
@@ -31,9 +31,9 @@ roll_devtools
 gclient sync --delete_unversioned_trees --reset
 
 if [[ "$CI" ]]; then
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false'
+  gn gen "out/$BUILD_FOLDER" --args='is_debug=false'
 else
-  gn gen "out/$BUILD_FOLDER" --args='devtools_dcheck_always_on=true is_debug=false devtools_skip_typecheck=true'
+  gn gen "out/$BUILD_FOLDER" --args='is_debug=true devtools_skip_typecheck=true'
 fi
 
 # Build devtools. By default, this creates `out/LighthouseIntegration/gen/front_end`.


### PR DESCRIPTION
According to simon (in chat):

> Release build do some additional bundling with rollup and minification with terser and are the slowest.

Let's use debug builds for local debugging. In theory we could also do debug builds for CI, but I would prefer to play it safe and verify everything we do is compatible with release builds in CI.

Additionally, doesn't look like `devtools_dcheck_always_on` does anything anymore. I couldn't find any usages of this build arg and all the dcheck stuff from [this CL](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/2894390) is gone.