### PR TITLE
core(css-usage): prevent late stylesheet additions

### DIFF
--- a/core/gather/gatherers/css-usage.js
+++ b/core/gather/gatherers/css-usage.js
@@ -66,41 +66,40 @@ class CSSUsage extends BaseGatherer {
   /**
    * @param {LH.Gatherer.Context} context
    */
-  async startCSSUsageTracking(context) {
+  async startInstrumentation(context) {
     const session = context.driver.defaultSession;
     this._session = session;
-    session.on('CSS.styleSheetAdded', this._onStylesheetAdded);
+
+    // Calling `CSS.enable` will emit events for stylesheets currently on the page.
+    // We want to ignore these events in navigation mode because they are not relevant to the
+    // navigation that is about to happen. Adding the event listener *after* calling `CSS.enable`
+    // ensures that the events for pre-existing stylesheets are ignored.
+    const isNavigation = context.gatherMode === 'navigation';
+    if (!isNavigation) {
+      session.on('CSS.styleSheetAdded', this._onStylesheetAdded);
+    }
 
     await session.sendCommand('DOM.enable');
     await session.sendCommand('CSS.enable');
     await session.sendCommand('CSS.startRuleUsageTracking');
+
+    if (isNavigation) {
+      session.on('CSS.styleSheetAdded', this._onStylesheetAdded);
+    }
   }
 
-
-  /**
-   * @param {LH.Gatherer.Context} context
-   */
-  async stopCSSUsageTracking(context) {
-    const session = context.driver.defaultSession;
-    const coverageResponse = await session.sendCommand('CSS.stopRuleUsageTracking');
-    this._ruleUsage = coverageResponse.ruleUsage;
-    session.off('CSS.styleSheetAdded', this._onStylesheetAdded);
-  }
-
-  /**
-   * @param {LH.Gatherer.Context} context
-   */
-  async startInstrumentation(context) {
-    if (context.gatherMode !== 'timespan') return;
-    await this.startCSSUsageTracking(context);
-  }
 
   /**
    * @param {LH.Gatherer.Context} context
    */
   async stopInstrumentation(context) {
-    if (context.gatherMode !== 'timespan') return;
-    await this.stopCSSUsageTracking(context);
+    const session = context.driver.defaultSession;
+    const coverageResponse = await session.sendCommand('CSS.stopRuleUsageTracking');
+    this._ruleUsage = coverageResponse.ruleUsage;
+    session.off('CSS.styleSheetAdded', this._onStylesheetAdded);
+
+    await session.sendCommand('CSS.disable');
+    await session.sendCommand('DOM.disable');
   }
 
   /**
@@ -108,17 +107,16 @@ class CSSUsage extends BaseGatherer {
    * @return {Promise<LH.Artifacts['CSSUsage']>}
    */
   async getArtifact(context) {
-    const session = context.driver.defaultSession;
     const executionContext = context.driver.executionContext;
 
-    if (context.gatherMode !== 'timespan') {
-      await this.startCSSUsageTracking(context);
+    if (context.gatherMode === 'snapshot') {
+      await this.startInstrumentation(context);
 
       // Force style to recompute.
       // Doesn't appear to be necessary in newer versions of Chrome.
       await executionContext.evaluateAsync('getComputedStyle(document.body)');
 
-      await this.stopCSSUsageTracking(context);
+      await this.stopInstrumentation(context);
     }
 
     /** @type {Map<string, LH.Artifacts.CSSStyleSheetInfo>} */
@@ -139,9 +137,6 @@ class CSSUsage extends BaseGatherer {
 
       dedupedStylesheets.set(sheet.content, sheet);
     }
-
-    await session.sendCommand('CSS.disable');
-    await session.sendCommand('DOM.disable');
 
     if (!this._ruleUsage) throw new Error('Issue collecting rule usages');
 

--- a/core/gather/gatherers/root-causes.js
+++ b/core/gather/gatherers/root-causes.js
@@ -124,9 +124,7 @@ class RootCauses extends BaseGatherer {
       rootCauses.layoutShifts[layoutShiftEvents.indexOf(event)] = r;
     }
 
-    // Yeah this gatherer enabled it, and so you'd think it should disable it too...
-    // ...but we don't give gatherers their own session so this stomps on others.
-    // await driver.defaultSession.sendCommand('DOM.disable');
+    await driver.defaultSession.sendCommand('DOM.disable');
     await driver.defaultSession.sendCommand('CSS.disable');
 
     return rootCauses;

--- a/core/test/fixtures/user-flows/css-change/end.html
+++ b/core/test/fixtures/user-flows/css-change/end.html
@@ -9,5 +9,14 @@
 <body>
   <style>h1 {color: red}</style>
   <h1>Should have different styles than the start page</h1>
+  <button>Add more styles</button>
+  <script>
+    const button = document.querySelector('button');
+    button.onclick = () => {
+      const style = document.createElement('style');
+      style.innerHTML = 'h1 {font-size: 30px}';
+      document.body.append(style);
+    }
+  </script>
 </body>
 </html>

--- a/core/test/scenarios/css-usage-over-navigation-test-pptr.js
+++ b/core/test/scenarios/css-usage-over-navigation-test-pptr.js
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as api from '../../index.js';
+import {createTestState} from './pptr-test-utils.js';
+import {LH_ROOT} from '../../../shared/root.js';
+
+/* eslint-env browser */
+
+describe('CSS usage over a flow navigation', function() {
+  // eslint-disable-next-line no-invalid-this
+  this.timeout(120_000);
+
+  const state = createTestState();
+
+  state.installSetupAndTeardownHooks();
+
+  before(() => {
+    state.server.baseDir = `${LH_ROOT}/core/test/fixtures/user-flows/css-change`;
+  });
+
+  it('should correctly scope CSS usage information', async () => {
+    const pageUrl = `${state.serverBaseUrl}/start.html`;
+    await state.page.goto(pageUrl, {waitUntil: ['networkidle0']});
+
+    const flow = await api.startFlow(state.page);
+
+    await flow.navigate(`${state.serverBaseUrl}/start.html`);
+
+    await flow.navigate(async () => {
+      await state.page.click('a');
+    });
+
+    await flow.startTimespan();
+    await state.page.click('button');
+    await flow.endTimespan();
+
+    const flowArtifacts = flow.createArtifactsJson();
+
+    const artifacts0 = flowArtifacts.gatherSteps[0].artifacts;
+    const artifacts1 = flowArtifacts.gatherSteps[1].artifacts;
+    const artifacts2 = flowArtifacts.gatherSteps[2].artifacts;
+
+    state.saveTrace(artifacts1.Trace);
+
+    const stylesheets0 = artifacts0.CSSUsage.stylesheets
+      .map(s => s.content.trim())
+      .sort((a, b) => a.localeCompare(b));
+    const stylesheets1 = artifacts1.CSSUsage.stylesheets
+      .map(s => s.content.trim())
+      .sort((a, b) => a.localeCompare(b));
+    const stylesheets2 = artifacts2.CSSUsage.stylesheets
+      .map(s => s.content.trim())
+      .sort((a, b) => a.localeCompare(b));
+
+    expect(stylesheets0).toEqual([
+      'body {\n  border: 5px solid black;\n}',
+      'h1 {color: gray}',
+    ]);
+
+    // Some stylesheets are pre-existing but they are out of scope for navigation mode
+    expect(stylesheets1).toEqual([
+      'body {\n  border: 5px solid red;\n}',
+      'h1 {color: red}',
+    ]);
+
+    // Some stylesheets are pre-existing and they are out in scope for timespan mode
+    expect(stylesheets2).toEqual([
+      'body {\n  border: 5px solid red;\n}',
+      'h1 {color: red}',
+      'h1 {font-size: 30px}',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/GoogleChrome/lighthouse/issues/15864

If there is enough of a gap between the end of the page load and `CSSUsage.getArtifact`, stylesheets that were added late in the page lifecycle can show up without a matching network request. This PR changes the behavior of `CSSUsage` to stop collecting new stylesheets immediately once the navigation ends.