### PR TITLE
core(fix): recognize zstd as a compression algorithm

### DIFF
--- a/core/lib/network-request.js
+++ b/core/lib/network-request.js
@@ -634,7 +634,7 @@ class NetworkRequest {
       /^content-encoding$/i,
       /^x-content-encoding-over-network$/i,
     ];
-    const compressionTypes = ['gzip', 'br', 'deflate'];
+    const compressionTypes = ['gzip', 'br', 'deflate', 'zstd'];
     return record.responseHeaders.some(header =>
       patterns.some(p => header.name.match(p)) && compressionTypes.includes(header.value)
     );

--- a/core/test/lib/network-request-test.js
+++ b/core/test/lib/network-request-test.js
@@ -389,4 +389,22 @@ describe('NetworkRequest', () => {
       })).toBe(false);
     });
   });
+
+  describe('#isContentEncoded', () => {
+    const isContentEncoded = NetworkRequest.isContentEncoded;
+
+    it('correctly identifies no compression', () => {
+      expect(isContentEncoded({responseHeaders: {}})).toBe(false);
+    });
+    it('correctly identifies brotli', () => {
+      expect(isContentEncoded({
+        responseHeaders: [{name: 'content-encoding', value: 'br'}],
+      })).toBe(true);
+    });
+    it('correctly identifies zstd', () => {
+      expect(isContentEncoded({
+        responseHeaders: [{name: 'content-encoding', value: 'zstd'}],
+      })).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
bugfix

<!-- Describe the need for this change -->
chromium M123 [adds zstd content-encoding](https://chromestatus.com/feature/6186023867908096). lighthouse checks a list of compression algorithms to see if a response was compressed.

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
closes https://github.com/GoogleChrome/lighthouse/issues/15882
