### PR TITLE
Uses innerText For Dom Text reinterpreted as HTML

### DIFF
--- a/viewer/app/src/lighthouse-report-viewer.js
+++ b/viewer/app/src/lighthouse-report-viewer.js
@@ -275,7 +275,7 @@ export class LighthouseReportViewer {
     const container = find('main', document);
 
     // Reset container content.
-    container.innerHTML = '';
+    container.innerText = '';
     const rootEl = document.createElement('div');
     container.append(rootEl);
 


### PR DESCRIPTION




By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.