### PR TITLE
core(trace-elements): add sentry debugging for `impactedNodes`

### DIFF
--- a/core/audits/layout-shifts.js
+++ b/core/audits/layout-shifts.js
@@ -78,7 +78,7 @@ class LayoutShifts extends Audit {
       .slice(0, MAX_LAYOUT_SHIFTS);
     for (const event of topLayoutShiftEvents) {
       const biggestImpactNodeId = TraceElements.getBiggestImpactNodeForShiftEvent(
-        event.args.data.impacted_nodes || [], impactByNodeId);
+        event.args.data.impacted_nodes || [], impactByNodeId, event);
       const biggestImpactElement = traceElements.find(t => t.nodeId === biggestImpactNodeId);
 
       // Turn root causes into sub-items.

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -108,10 +108,25 @@ class TraceElements extends BaseGatherer {
       // `impactedNodes` should always be an array here, but it can randomly be something else for
       // currently unknown reasons. This exception handling will help us identify what
       // `impactedNodes` really is and also prevent the error from being fatal.
+
+      // It's possible `impactedNodes` is not JSON serializable, so let's add more supplemental
+      // fields just in case.
+      const impactedNodesType = typeof impactedNodes;
+      const impactedNodesClassName = impactedNodes?.constructor?.name;
+
+      let impactedNodesJson;
+      let eventJson;
+      try {
+        impactedNodesJson = JSON.parse(JSON.stringify(impactedNodes));
+        eventJson = JSON.parse(JSON.stringify(event));
+      } catch {}
+
       Sentry.captureException(err, {
         extra: {
-          impactedNodes,
-          event,
+          impactedNodes: impactedNodesJson,
+          event: eventJson,
+          impactedNodesType,
+          impactedNodesClassName,
         },
       });
       return;

--- a/core/test/gather/gatherers/trace-elements-test.js
+++ b/core/test/gather/gatherers/trace-elements-test.js
@@ -175,6 +175,13 @@ describe('Trace Elements gatherer - GetTopLayoutShiftElements', () => {
       {nodeId: 15}, // score: 0.1
     ]);
   });
+
+  describe('getBiggestImpactForShiftEvent', () => {
+    it('is non fatal if impactedNodes is not iterable', () => {
+      const result = TraceElementsGatherer.getBiggestImpactNodeForShiftEvent(1, new Map());
+      expect(result).toBeUndefined();
+    });
+  });
 });
 
 describe('Trace Elements gatherer - Animated Elements', () => {


### PR DESCRIPTION
This should alleviate the symptoms of https://github.com/GoogleChrome/lighthouse/issues/15870 and adds some extra sentry instrumentation to help us get to the bottom of this.