### PR TITLE
core(trace-processor): correct overlapping tasks

### DIFF
--- a/core/lib/tracehouse/trace-processor.js
+++ b/core/lib/tracehouse/trace-processor.js
@@ -416,7 +416,8 @@ class TraceProcessor {
 
       // Temporary fix for a Chrome bug where some RunTask events can be overlapping.
       // We correct that here be ensuring each RunTask ends at least 1 microsecond before the next
-      // https://crbug.com/40825479
+      // https://github.com/GoogleChrome/lighthouse/issues/15896
+      // https://issues.chromium.org/issues/329678173
       if (prevToplevel && start < prevToplevel.end) {
         prevToplevel.end = start - 0.001;
       }

--- a/core/lib/tracehouse/trace-processor.js
+++ b/core/lib/tracehouse/trace-processor.js
@@ -403,6 +403,9 @@ class TraceProcessor {
    */
   static getMainThreadTopLevelEvents(trace, startTime = 0, endTime = Infinity) {
     const topLevelEvents = [];
+    /** @type {ToplevelEvent|undefined} */
+    let prevToplevel = undefined;
+
     // note: mainThreadEvents is already sorted by event start
     for (const event of trace.mainThreadEvents) {
       if (!this.isScheduleableTask(event) || !event.dur) continue;
@@ -411,11 +414,20 @@ class TraceProcessor {
       const end = (event.ts + event.dur - trace.timeOriginEvt.ts) / 1000;
       if (start > endTime || end < startTime) continue;
 
-      topLevelEvents.push({
+      // Temporary fix for a Chrome bug where some RunTask events can be overlapping.
+      // We correct that here be ensuring each RunTask ends at least 1 microsecond before the next
+      // https://crbug.com/40825479
+      if (prevToplevel && start < prevToplevel.end) {
+        prevToplevel.end = start - 0.001;
+      }
+
+      prevToplevel = {
         start,
         end,
         duration: event.dur / 1000,
-      });
+      };
+
+      topLevelEvents.push(prevToplevel);
     }
 
     return topLevelEvents;

--- a/core/test/audits/long-tasks-test.js
+++ b/core/test/audits/long-tasks-test.js
@@ -304,7 +304,7 @@ describe('Long tasks audit', () => {
         }],
       },
     });
-    expect(result.metricSavings.TBT).toBeApproximately(353.53);
+    expect(result.metricSavings.TBT).toBeApproximately(171.95);
 
     const debugData = result.details.debugData;
     expect(debugData).toStrictEqual({

--- a/core/test/audits/mainthread-work-breakdown-test.js
+++ b/core/test/audits/mainthread-work-breakdown-test.js
@@ -120,7 +120,7 @@ Object {
     expect(Math.round(output.numericValue)).toMatchInlineSnapshot(`979`);
     assert.equal(output.details.items.length, 7);
     assert.equal(output.score, 1);
-    expect(output.metricSavings.TBT).toBeCloseTo(353.5, 0.1);
+    expect(output.metricSavings.TBT).toBeCloseTo(171.95, 0.1);
   });
 
   it('should compute the correct values for the load trace (legacy)', async () => {


### PR DESCRIPTION
Tasks can sometimes be overlapping as of M122: https://crbug.com/329678173

This probably needs a fix for the trace events themselves, but until then we can approximate the correct behavior by cutting of tasks that overlap with the next task.

Ref https://github.com/GoogleChrome/lighthouse/issues/15896