### PR TITLE
misc: correct .npmignore for node >=18.20

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,20 +3,20 @@
 # folders
 .vscode/
 .github/
-assets/
-build/
-coverage/
-proto/
-docs/
+/assets/
+/build/
+/coverage/
+/proto/
+/docs/
 
-core/scripts/*
-viewer/
-treemap/
-clients/
-cli/results/
-lighthouse-logger/
+/core/scripts/*
+/viewer/
+/treemap/
+/clients/
+/cli/results/
+/lighthouse-logger/
 **/test/**
-report/test-assets/
+/report/test-assets/
 
 # keep a few scripts useful for CI
 !core/scripts/manual-chrome-launcher.js
@@ -25,12 +25,12 @@ report/test-assets/
 
 # Exclude the CLI smoketests but keep the smoketest runner that is used
 # by downstream projects (e.g. publisher ads).
-!cli/test/smokehouse/**
-cli/test/smokehouse/test-definitions/
+!/cli/test/smokehouse/**
+/cli/test/smokehouse/test-definitions/
 
-results/
-lantern-data/
-timings-data/
+/results/
+/lantern-data/
+/timings-data/
 
 # ignore all folders named as such
 node_modules
@@ -74,3 +74,4 @@ CODE_OF_CONDUCT.md
 eslint-local-rules.cjs
 vercel.json
 yarn.lock
+.

--- a/.npmignore
+++ b/.npmignore
@@ -28,7 +28,7 @@
 !/cli/test/smokehouse/**
 /cli/test/smokehouse/test-definitions/
 
-/results/
+results/
 /lantern-data/
 /timings-data/
 

--- a/.npmignore
+++ b/.npmignore
@@ -74,4 +74,3 @@ CODE_OF_CONDUCT.md
 eslint-local-rules.cjs
 vercel.json
 yarn.lock
-.


### PR DESCRIPTION
This fixes the weird package-test errors we have been getting recently.

Some change in node 18.20.0 appears to have fixed a bug that our .npmignore was relying on.

[Without a leading slash, entries in .npmignore should refer to *any* file/folder with that name in the directory structure.](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring:~:text=%23%20ignore%20all%20files%20in%20any%20directory%20named%20build%0Abuild/) Before 18.20.0 this wasn't happening for some reason.

I attempted to correct as many entires in our .npmignore as I could, and verified that the contents by diffing [old .npmignore & node 18.19] against [new .npmignore & 18.20]

Ref https://github.com/nodejs/node/issues/52382