### PR TITLE
deps: upgrade `trace_engine` to 0.0.19

### DIFF
--- a/cli/test/smokehouse/test-definitions/shift-attribution.js
+++ b/cli/test/smokehouse/test-definitions/shift-attribution.js
@@ -21,11 +21,13 @@ const expectations = {
                 node: {selector: 'body > div#blue'},
                 subItems: {items: [{cause: /font/, extra: {value: /Regular\.ttf/}}]},
               },
-              {
-                node: {selector: 'body > div#blue'},
-                // TODO: We can't get nodes from non-main frames yet. See runRootCauseAnalysis.
-                subItems: {items: [{cause: /iframe/, extra: undefined}]},
-              },
+              // iframe root causes are disabled due to performance issues
+              // https://github.com/GoogleChrome/lighthouse/issues/15869
+              // {
+              //   node: {selector: 'body > div#blue'},
+              //   // TODO: We can't get nodes from non-main frames yet. See runRootCauseAnalysis.
+              //   subItems: {items: [{cause: /iframe/, extra: undefined}]},
+              // },
               {
                 node: {selector: 'body > div#blue'},
                 subItems: {items: [{cause: /Media/, extra: {selector: 'body > img'}}]},

--- a/core/computed/metrics/cumulative-layout-shift.js
+++ b/core/computed/metrics/cumulative-layout-shift.js
@@ -163,10 +163,10 @@ class CumulativeLayoutShift {
       await processor.parse(/** @type {import('@paulirish/trace_engine').Types.TraceEvents.TraceEventData[]} */ (
         events
       ));
-      if (!processor.data) {
+      if (!processor.traceParsedData) {
         throw new Error('null trace engine result');
       }
-      return processor.data.LayoutShifts.sessionMaxScore;
+      return processor.traceParsedData.LayoutShifts.sessionMaxScore;
     };
     const cumulativeLayoutShift = await run(allFrameShiftEvents.map(e => e.event));
     const cumulativeLayoutShiftMainFrame = await run(mainFrameShiftEvents.map(e => e.event));

--- a/core/computed/trace-engine-result.js
+++ b/core/computed/trace-engine-result.js
@@ -32,7 +32,7 @@ class TraceEngineResult {
     ));
     // TODO: use TraceEngine.TraceProcessor.createWithAllHandlers above.
     return /** @type {import('@paulirish/trace_engine').Handlers.Types.TraceParseData} */(
-      engine.data);
+      engine.traceParsedData);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "webtreemap-cdt": "^3.2.1"
   },
   "dependencies": {
-    "@paulirish/trace_engine": "^0.0.12",
+    "@paulirish/trace_engine": "^0.0.19",
     "@sentry/node": "^6.17.4",
     "axe-core": "^4.9.0",
     "chrome-launcher": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,10 +1080,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@paulirish/trace_engine@^0.0.12":
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/@paulirish/trace_engine/-/trace_engine-0.0.12.tgz#6172c84f19d1e4254450d1927b1bb3eea5b5ba04"
-  integrity sha512-PglukOOYGvjqgMVKNSa3a4grWrWzL97L47bgDCzqAnDSTJ+vDOKxMPXR3rsnLECoZzpbb9LCzS3CEg/NwwhRHQ==
+"@paulirish/trace_engine@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@paulirish/trace_engine/-/trace_engine-0.0.19.tgz#794642d6b4947fc2a4b5724a57e3af61606029e2"
+  integrity sha512-3tjEzXBBtU83DkCJAdU2UwBBunspiwTCn+Y5jOxm592cfEuLr/T7Lcn+QhRerVqkSik2mnjN4X6NgHZjI9Biwg==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
This upgrade disables iframe root causes because the volume of applicable layout invalidations was creating performance issues https://github.com/GoogleChrome/lighthouse/issues/15869

https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/5421436