### PR TITLE
core(lantern): correct overlapping tasks in CPU nodes

### DIFF
--- a/core/lib/lantern/cpu-node.js
+++ b/core/lib/lantern/cpu-node.js
@@ -15,13 +15,15 @@ class CPUNode extends BaseNode {
   /**
    * @param {LH.TraceEvent} parentEvent
    * @param {LH.TraceEvent[]=} childEvents
+   * @param {number=} correctedEndTs
    */
-  constructor(parentEvent, childEvents = []) {
+  constructor(parentEvent, childEvents = [], correctedEndTs) {
     const nodeId = `${parentEvent.tid}.${parentEvent.ts}`;
     super(nodeId);
 
     this._event = parentEvent;
     this._childEvents = childEvents;
+    this._correctedEndTs = correctedEndTs;
   }
 
   get type() {
@@ -39,7 +41,15 @@ class CPUNode extends BaseNode {
    * @return {number}
    */
   get endTime() {
+    if (this._correctedEndTs) return this._correctedEndTs;
     return this._event.ts + this._event.dur;
+  }
+
+  /**
+   * @return {number}
+   */
+  get duration() {
+    return this.endTime - this.startTime;
   }
 
   /**
@@ -83,7 +93,7 @@ class CPUNode extends BaseNode {
    * @return {CPUNode}
    */
   cloneWithoutRelationships() {
-    return new CPUNode(this._event, this._childEvents);
+    return new CPUNode(this._event, this._childEvents, this._correctedEndTs);
   }
 }
 

--- a/core/lib/lantern/metrics/interactive.js
+++ b/core/lib/lantern/metrics/interactive.js
@@ -37,7 +37,7 @@ class Interactive extends Metric {
     return dependencyGraph.cloneWithRelationships(node => {
       // Include everything that might be a long task
       if (node.type === BaseNode.TYPES.CPU) {
-        return node.event.dur > minimumCpuTaskDuration;
+        return node.duration > minimumCpuTaskDuration;
       }
 
       // Include all scripts and high priority requests, exclude all images

--- a/core/lib/lantern/simulator/simulator.js
+++ b/core/lib/lantern/simulator/simulator.js
@@ -276,7 +276,7 @@ class Simulator {
       ? this._layoutTaskMultiplier
       : this._cpuSlowdownMultiplier;
     const totalDuration = Math.min(
-      Math.round(cpuNode.event.dur / 1000 * multiplier),
+      Math.round(cpuNode.duration / 1000 * multiplier),
       DEFAULT_MAXIMUM_CPU_TASK_DURATION
     );
     const estimatedTimeElapsed = totalDuration - timingData.timeElapsed;

--- a/core/test/lib/lantern/page-dependency-graph-test.js
+++ b/core/test/lib/lantern/page-dependency-graph-test.js
@@ -160,6 +160,36 @@ describe('PageDependencyGraph computed artifact:', () => {
       assert.equal(node2.childEvents.length, 1);
       assert.equal(node2.childEvents[0].name, 'LaterEvent');
     });
+
+    it('should correct overlapping tasks', () => {
+      addTaskEvents(0, 500, [
+        {name: 'MyCustomEvent'},
+        {name: 'OtherEvent'},
+      ]);
+
+      addTaskEvents(400, 50, [
+        {name: 'OverlappingEvent'},
+      ]);
+
+      assert.equal(traceEvents.length, 5);
+      const nodes = PageDependencyGraph.getCPUNodes(traceEvents);
+      assert.equal(nodes.length, 2);
+
+      const node1 = nodes[0];
+      assert.equal(node1.id, '1.0');
+      assert.equal(node1.type, 'cpu');
+      assert.equal(node1.event, traceEvents[0]);
+      assert.equal(node1.childEvents.length, 2);
+      assert.equal(node1.childEvents[0].name, 'MyCustomEvent');
+      assert.equal(node1.childEvents[1].name, 'OtherEvent');
+
+      const node2 = nodes[1];
+      assert.equal(node2.id, '1.400000');
+      assert.equal(node2.type, 'cpu');
+      assert.equal(node2.event, traceEvents[3]);
+      assert.equal(node2.childEvents.length, 1);
+      assert.equal(node2.childEvents[0].name, 'OverlappingEvent');
+    });
   });
 
   describe('#createGraph', () => {


### PR DESCRIPTION
I was investigating the weird CI failures in https://github.com/GoogleChrome/lighthouse/pull/15839. Long story short the CI failure is caused by the same issue in https://github.com/GoogleChrome/lighthouse/issues/15896 where `RunTask` events can sometimes be overlapping.

We fixed this when calculating observed TBT in https://github.com/GoogleChrome/lighthouse/pull/15921, but we did not correct the overlapping tasks in Lantern.

I suspect we may need another PR to address this in `main-thread-tasks.js` as well...
