### PR TITLE
misc: remove `BenchmarkIndexes` base artifact

### DIFF
--- a/core/config/filters.js
+++ b/core/config/filters.js
@@ -13,7 +13,6 @@ const baseArtifactKeySource = {
   fetchTime: '',
   LighthouseRunWarnings: '',
   BenchmarkIndex: '',
-  BenchmarkIndexes: '',
   settings: '',
   Timing: '',
   URL: '',

--- a/core/runner.js
+++ b/core/runner.js
@@ -106,7 +106,6 @@ class Runner {
           networkUserAgent: artifacts.NetworkUserAgent,
           hostUserAgent: artifacts.HostUserAgent,
           benchmarkIndex: artifacts.BenchmarkIndex,
-          benchmarkIndexes: artifacts.BenchmarkIndexes,
           credits,
         },
         audits: auditResultsById,

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -46,8 +46,6 @@ interface UniversalBaseArtifacts {
   LighthouseRunWarnings: Array<string | IcuMessage>;
   /** The benchmark index that indicates rough device class. */
   BenchmarkIndex: number;
-  /** Many benchmark indexes. Many. */
-  BenchmarkIndexes?: number[];
   /** An object containing information about the testing configuration used by Lighthouse. */
   settings: Config.Settings;
   /** The timing instrumentation of the gather portion of a run. */

--- a/types/lhr/lhr.d.ts
+++ b/types/lhr/lhr.d.ts
@@ -71,8 +71,6 @@ declare module Result {
     networkUserAgent: string;
     /** The benchmark index number that indicates rough device class. */
     benchmarkIndex: number;
-    /** Many benchmark indexes. */
-    benchmarkIndexes?: number[];
     /** The version of libraries with which these results were generated. Ex: axe-core. */
     credits?: Record<string, string|undefined>,
   }


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/pull/14075 This hack was added to legacy navigation but never added to the new navigation runner.

It's always empty now, and confirmed with @paulirish that it's not needed anymore so we can just remove it.
