### PR TITLE
tests: invalidate devtools build cache

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -52,8 +52,8 @@ jobs:
         # 3) every change to file in Lighthouse repo important to running these tests.
         #
         # The number is how many times this hash key was manually updated to break the cache.
-        key: ${{ runner.os }}-11-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
-        restore-keys: ${{ runner.os }}-11
+        key: ${{ runner.os }}-12-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
+        restore-keys: ${{ runner.os }}-12
     - name: Set GHA_DEVTOOLS_CACHE_HIT
       if: steps.devtools-cache.outputs.cache-hit == 'true'
       run: echo "GHA_DEVTOOLS_CACHE_HIT=1" >> $GITHUB_ENV


### PR DESCRIPTION
This is failing in CI with `/Users/cjamcl/tools/depot_tools/update_depot_tools: line 148: goma_ctl: command not found`. I noticed it happened once locally, but then was fine with subsequent runs. So I guess clearing the cache will resolve the issue in CI.