### PR TITLE
report: fix hidden audit handling for non-perf categories

### DIFF
--- a/report/renderer/category-renderer.js
+++ b/report/renderer/category-renderer.js
@@ -239,7 +239,6 @@ export class CategoryRenderer {
 
     for (const auditRef of auditRefs) {
       const groupId = auditRef.group || notAGroup;
-      if (groupId === 'hidden') continue;
       const groupAuditRefs = grouped.get(groupId) || [];
       groupAuditRefs.push(auditRef);
       grouped.set(groupId, groupAuditRefs);
@@ -531,6 +530,7 @@ export class CategoryRenderer {
 
     // Sort audits into clumps.
     for (const auditRef of category.auditRefs) {
+      if (auditRef.group === 'hidden') continue;
       const clumpId = this._getClumpIdForAuditRef(auditRef);
       const clump = /** @type {Array<LH.ReportResult.AuditRef>} */ (clumps.get(clumpId)); // already defined
       clump.push(auditRef);

--- a/report/test/renderer/category-renderer-test.js
+++ b/report/test/renderer/category-renderer-test.js
@@ -223,12 +223,12 @@ describe('CategoryRenderer', () => {
       assert.ok(categoryDOM.querySelector(
         '.lh-clump--notapplicable .lh-audit-group__summary'));
 
-      const notApplicableCount = a11yCategory.auditRefs.reduce((sum, audit) =>
-        sum += audit.result.scoreDisplayMode === 'notApplicable' ? 1 : 0, 0);
+      const notApplicableAudits = a11yCategory.auditRefs.filter(audit => {
+        return audit.result.scoreDisplayMode === 'notApplicable' && audit.group !== 'hidden';
+      });
       assert.equal(
         categoryDOM.querySelectorAll('.lh-clump--notapplicable .lh-audit').length,
-        notApplicableCount,
-        'score shows informative and dash icon'
+        notApplicableAudits.length
       );
     });
 
@@ -351,7 +351,9 @@ describe('CategoryRenderer', () => {
     it('renders the passed audits ungrouped', () => {
       const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
       const passedAudits = category.auditRefs.filter(audit =>
-          audit.result.scoreDisplayMode !== 'notApplicable' && audit.result.score === 1);
+          audit.result.scoreDisplayMode !== 'notApplicable' &&
+          audit.group !== 'hidden' &&
+          audit.result.score === 1);
 
       const passedAuditGroups = categoryDOM.querySelectorAll('.lh-clump--passed .lh-audit-group');
       const passedAuditsElems = categoryDOM.querySelectorAll('.lh-clump--passed .lh-audit');
@@ -363,7 +365,8 @@ describe('CategoryRenderer', () => {
     it('renders all the audits', () => {
       const categoryDOM = renderer.render(category, sampleResults.categoryGroups);
       const auditsElements = categoryDOM.querySelectorAll('.lh-audit');
-      assert.equal(auditsElements.length, category.auditRefs.length);
+      const visibleAudits = category.auditRefs.filter(a => a.group !== 'hidden');
+      assert.equal(auditsElements.length, visibleAudits.length);
     });
 
     it('renders audits without a group before grouped ones', () => {

--- a/report/test/renderer/report-renderer-test.js
+++ b/report/test/renderer/report-renderer-test.js
@@ -280,7 +280,6 @@ describe('ReportRenderer', () => {
       .filter(url => DOCS_ORIGINS.includes(url.origin))
       .map(url => url.searchParams.get('utm_medium'));
 
-    console.log(utmChannels.length);
     assert.ok(utmChannels.length >= 75);
     for (const utmChannel of utmChannels) {
       assert.strictEqual(utmChannel, lhrChannel);
@@ -290,9 +289,18 @@ describe('ReportRenderer', () => {
   it('renders `not_applicable` audits as `notApplicable`', () => {
     const clonedSampleResult = JSON.parse(JSON.stringify(sampleResultsOrig));
 
+    const hiddenAuditIds = new Set();
+    for (const category of Object.values(clonedSampleResult.categories)) {
+      for (const auditRef of category.auditRefs) {
+        if (auditRef.group === 'hidden') {
+          hiddenAuditIds.add(auditRef.id);
+        }
+      }
+    }
+
     let notApplicableCount = 0;
     Object.values(clonedSampleResult.audits).forEach(audit => {
-      if (audit.scoreDisplayMode === 'notApplicable') {
+      if (audit.scoreDisplayMode === 'notApplicable' && !hiddenAuditIds.has(audit.id)) {
         notApplicableCount++;
         // Switch to old-style `not_applicable` to test fallback behavior.
         audit.scoreDisplayMode = 'not_applicable';

--- a/viewer/test/viewer-test-pptr.js
+++ b/viewer/test/viewer-test-pptr.js
@@ -172,17 +172,14 @@ describe('Lighthouse Viewer', () => {
         'work-during-interaction',
       ];
       for (const category of lighthouseCategories) {
-        let expected = getAuditsOfCategory(category);
-        if (category === 'performance') {
-          expected = getAuditsOfCategory(category)
-            .filter(a => a.group !== 'hidden' && !nonNavigationAudits.includes(a.id));
-        }
-        expected = expected.map(audit => audit.id);
+        const expectedAuditIds = getAuditsOfCategory(category)
+          .filter(a => a.group !== 'hidden' && !nonNavigationAudits.includes(a.id))
+          .map(a => a.id);
         const elementIds = await getAuditElementsIds({category, selector: selectors.audits});
 
         assert.deepStrictEqual(
           elementIds.sort(),
-          expected.sort(),
+          expectedAuditIds.sort(),
           `${category} does not have the identical audits`
         );
       }


### PR DESCRIPTION
The artifact refresh in https://github.com/GoogleChrome/lighthouse/pull/15962 revealed that we were not always handling the `hidden` group correctly. Before, if an audit had group `hidden` it would only be omitted from the report if it would be in the `failed` clump. So an audit marked N/A that had group `hidden` *would* appear in the report (under the N/A section)

This wasn't picked up by unit tests because the unit tests were indifferent to the `hidden` group *and* the sample artifacts didn't have any audits with group `hidden` that failed. With the artifact refresh, there was an audit that failed but was in group `hidden` which started tripping up the tests with incorrect expectations.

This PR splits out the report fix and the associated test expectation corrections from https://github.com/GoogleChrome/lighthouse/pull/15962
