### PR TITLE
docs: remove await keyowrd

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -24,7 +24,7 @@ fs.writeFileSync('lhreport.html', reportHtml);
 console.log('Report is done for', runnerResult.lhr.finalDisplayedUrl);
 console.log('Performance score was', runnerResult.lhr.categories.performance.score * 100);
 
-await chrome.kill();
+chrome.kill();
 ```
 
 ### Performance-only Lighthouse run


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->
Hi,

**Summary**
<!-- What kind of change does this PR introduce? -->
I have removed the `await` keyoword for `chrome.kill` method because based on it's types it's a `void` method.

<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->
https://github.com/GoogleChrome/chrome-launcher/blob/main/src/chrome-launcher.ts#L51
**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
