### PR TITLE
tests: use new button class name for devtools run script

### DIFF
--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -213,7 +213,7 @@ async function runLighthouse() {
   // In CI clicking the start button just once is flaky and can cause a timeout.
   // Therefore, keep clicking the button until we detect that the run started.
   const intervalHandle = setInterval(() => {
-    const button = panel.contentElement.querySelector('devtools-button,button')
+    const button = panel.contentElement.querySelector('devtools-button,button');
     button.click();
   }, 100);
 


### PR DESCRIPTION
This fixes our devtools smoke tests.

ref https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/5440693