### PR TITLE
Add missing types for `Result.Category` and `NodeDetails`

### DIFF
--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -191,6 +191,7 @@ declare module Artifacts {
     boundingRect: Rect,
     snippet: string,
     nodeLabel: string,
+    explanation?: string,
   }
 
   interface RuleExecutionError {

--- a/types/lhr/lhr.d.ts
+++ b/types/lhr/lhr.d.ts
@@ -103,6 +103,8 @@ declare module Result {
     score: number|null;
     /** An array of references to all the audit members of this category. */
     auditRefs: AuditRef[];
+    /** An array of all the modes supported by the category. */
+    supportedModes?:  Result.GatherMode[];
   }
 
   interface AuditRef {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->
This PR fixes #15799.
**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
1. The property `supportedModes` has been added to `Result.Category` since it is being emitted as a part of the generated results.
2. The property `explanation` has been added to `Artifacts.NodeDetails` since it is being set in `axe-audit.js` (line 79).
<!-- Describe the need for this change -->
I've added them in as optional types, please let me know if that is incorrect. Cheers!
<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
Related Issue - #15799 