### PR TITLE
misc(ci): fix deprecated node usage in checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     #   https://github.com/actions/runner/issues/438
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 100
     - run: bash core/scripts/github-actions-commit-range.sh

--- a/.github/workflows/cron-weekly.yml
+++ b/.github/workflows/cron-weekly.yml
@@ -8,7 +8,7 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@a996638015fbc9ef96beef1a41bbad7df8e06154
         # checks all markdown files from /docs including all subfolders
         with:
@@ -16,7 +16,7 @@ jobs:
           use-verbose-mode: 'yes'
           config-file: '.github/workflows/markdown.links.config.json'
           folder-path: 'docs/'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@a996638015fbc9ef96beef1a41bbad7df8e06154
         # checks all markdown files from root but ignores subfolders
         with:
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Use Node.js 18.x
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -21,7 +21,7 @@ jobs:
       run: echo "$DEPOT_TOOLS_PATH" >> $GITHUB_PATH
 
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: lighthouse
 
@@ -87,7 +87,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: lighthouse
 
@@ -133,7 +133,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: lighthouse
 

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Use Node.js 18.x
       uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: print latest_commit
         run: echo ${{ github.sha }}
 
@@ -28,7 +28,7 @@ jobs:
       (github.repository == 'GoogleChrome/lighthouse' && ${{ needs.check_date.outputs.should_run != 'false' }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Depth of at least 2 for codecov coverage diffs. See https://github.com/GoogleChrome/lighthouse/pull/12079
         fetch-depth: 2
@@ -83,7 +83,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Use Node 18 here earlier than everywhere else, see https://github.com/GoogleChrome/lighthouse/issues/15160#issuecomment-1589913408
     - name: Use Node.js 18.x
@@ -132,7 +132,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Use Node.js 18.x
       uses: actions/setup-node@v3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # Depth of at least 2 for codecov coverage diffs. See https://github.com/GoogleChrome/lighthouse/pull/12079
         fetch-depth: 2
@@ -94,7 +94,7 @@ jobs:
 
     steps:
     - name: git clone
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Use Node.js 18.x
       uses: actions/setup-node@v3


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
CI uses `actions/checkout@v3`, which uses a `deprecated` version of `Node.js`. This pull request updates that action to the latest version.

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
This pull request fixes #16021.