### PR TITLE
bugfix for unhandled exception in session.sendCommand

### DIFF
--- a/core/gather/session.js
+++ b/core/gather/session.js
@@ -128,7 +128,7 @@ class ProtocolSession extends CrdpEventEmitter {
       timeout: timeoutMs + PPTR_BUFFER,
     }).catch((error) => {
       log.formatProtocol('method <= browser ERR', {method}, 'error');
-      throw LighthouseError.fromProtocolMessage(method, error);
+      return Promise.reject(LighthouseError.fromProtocolMessage(method, error));
     });
     const resultWithTimeoutPromise =
       Promise.race([resultPromise, timeoutPromise, this._targetCrashedPromise]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
fixes unhandled exception when session tries to sendCommand

<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
bugfix

<!-- Describe the need for this change -->
The whole process exits if page was closed for some reason

