### PR TITLE
tests(lantern): remove devtools log from tests

### DIFF
--- a/core/test/lib/lantern/metrics/first-contentful-paint-test.js
+++ b/core/test/lib/lantern/metrics/first-contentful-paint-test.js
@@ -11,11 +11,10 @@ import {readJson} from '../../../test-utils.js';
 import {getComputationDataFromFixture} from './metric-test-utils.js';
 
 const trace = readJson('../../../fixtures/artifacts/progressive-app/trace.json', import.meta);
-const devtoolsLog = readJson('../../../fixtures/artifacts/progressive-app/devtoolslog.json', import.meta);
 
 describe('Metrics: Lantern FCP', () => {
   it('should compute predicted value', async () => {
-    const data = await getComputationDataFromFixture({trace, devtoolsLog});
+    const data = await getComputationDataFromFixture({trace});
     const result = await FirstContentfulPaint.compute(data);
 
     expect({
@@ -30,7 +29,7 @@ describe('Metrics: Lantern FCP', () => {
   });
 
   it('should handle negative request networkEndTime', async () => {
-    const data = await getComputationDataFromFixture({trace, devtoolsLog});
+    const data = await getComputationDataFromFixture({trace});
     data.graph.request.networkEndTime = -1;
     const result = await FirstContentfulPaint.compute(data);
 

--- a/core/test/lib/lantern/metrics/interactive-test.js
+++ b/core/test/lib/lantern/metrics/interactive-test.js
@@ -13,13 +13,11 @@ import {getComputationDataFromFixture} from './metric-test-utils.js';
 import {readJson} from '../../../test-utils.js';
 
 const trace = readJson('../../../fixtures/artifacts/progressive-app/trace.json', import.meta);
-const devtoolsLog = readJson('../../../fixtures/artifacts/progressive-app/devtoolslog.json', import.meta);
 const iframeTrace = readJson('../../../fixtures/artifacts/iframe/trace.json', import.meta);
-const iframeDevtoolsLog = readJson('../../../fixtures/artifacts/iframe/devtoolslog.json', import.meta);
 
 describe('Metrics: Lantern TTI', () => {
   it('should compute predicted value', async () => {
-    const data = await getComputationDataFromFixture({trace, devtoolsLog});
+    const data = await getComputationDataFromFixture({trace});
     const result = await Interactive.compute(data, {
       lcpResult: await LargestContentfulPaint.compute(data, {
         fcpResult: await FirstContentfulPaint.compute(data),
@@ -40,7 +38,6 @@ describe('Metrics: Lantern TTI', () => {
   it('should compute predicted value on iframes with substantial layout', async () => {
     const data = await getComputationDataFromFixture({
       trace: iframeTrace,
-      devtoolsLog: iframeDevtoolsLog,
     });
     const result = await Interactive.compute(data, {
       lcpResult: await LargestContentfulPaint.compute(data, {

--- a/core/test/lib/lantern/metrics/lantern-largest-contentful-paint-test.js
+++ b/core/test/lib/lantern/metrics/lantern-largest-contentful-paint-test.js
@@ -12,11 +12,10 @@ import {getComputationDataFromFixture} from './metric-test-utils.js';
 import {readJson} from '../../../test-utils.js';
 
 const trace = readJson('../../../fixtures/artifacts/paul/trace.json', import.meta);
-const devtoolsLog = readJson('../../../fixtures/artifacts/paul/devtoolslog.json', import.meta);
 
 describe('Metrics: Lantern LCP', () => {
   it('should compute predicted value', async () => {
-    const data = await getComputationDataFromFixture({trace, devtoolsLog});
+    const data = await getComputationDataFromFixture({trace});
     const result = await LargestContentfulPaint.compute(data, {
       fcpResult: await FirstContentfulPaint.compute(data),
     });

--- a/core/test/lib/lantern/metrics/metric-test-utils.js
+++ b/core/test/lib/lantern/metrics/metric-test-utils.js
@@ -10,26 +10,24 @@ import {PageDependencyGraph} from '../../../../lib/lantern/page-dependency-graph
 import {NetworkAnalyzer} from '../../../../lib/lantern/simulator/network-analyzer.js';
 import {Simulator} from '../../../../lib/lantern/simulator/simulator.js';
 import * as Lantern from '../../../../lib/lantern/types/lantern.js';
-import {getURLArtifactFromDevtoolsLog} from '../../../test-utils.js';
 
 /** @typedef {Lantern.NetworkRequest<import('@paulirish/trace_engine/models/trace/types/TraceEvents.js').SyntheticNetworkRequest>} NetworkRequest */
 
 // TODO(15841): remove usage of Lighthouse code to create test data
 
 /**
- * @param {{trace: LH.Trace, devtoolsLog: LH.DevtoolsLog, settings?: LH.Config.Settings, URL?: LH.Artifacts.URL}} opts
+ * @param {{trace: LH.Trace, settings?: LH.Config.Settings, URL?: LH.Artifacts.URL}} opts
  */
-async function getComputationDataFromFixture({trace, devtoolsLog, settings, URL}) {
+async function getComputationDataFromFixture({trace, settings, URL}) {
   settings = settings ?? /** @type {LH.Config.Settings} */({});
   if (!settings.throttlingMethod) settings.throttlingMethod = 'simulate';
-  if (!URL) URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
 
   const context = {settings, computedCache: new Map()};
   const traceEngineResult = await TraceEngineResult.request({trace}, context);
-  const {graph, records} =
+  const {graph, requests} =
     await PageDependencyGraph.createGraphFromTrace(trace, traceEngineResult, URL);
   const processedNavigation = createProcessedNavigation(traceEngineResult);
-  const networkAnalysis = NetworkAnalyzer.analyze(records);
+  const networkAnalysis = NetworkAnalyzer.analyze(requests);
   const simulator = Simulator.createSimulator({...settings, networkAnalysis});
 
   return {simulator, graph, processedNavigation};

--- a/core/test/lib/lantern/metrics/speed-index-test.js
+++ b/core/test/lib/lantern/metrics/speed-index-test.js
@@ -13,14 +13,13 @@ import {getComputationDataFromFixture} from './metric-test-utils.js';
 import {Speedline} from '../../../../computed/speedline.js';
 
 const trace = readJson('../../../fixtures/artifacts/progressive-app/trace.json', import.meta);
-const devtoolsLog = readJson('../../../fixtures/artifacts/progressive-app/devtoolslog.json', import.meta);
 
 const defaultThrottling = constants.throttling.mobileSlow4G;
 
 describe('Metrics: Lantern Speed Index', () => {
   it('should compute predicted value', async () => {
     const context = {computedCache: new Map()};
-    const data = await getComputationDataFromFixture({trace, devtoolsLog});
+    const data = await getComputationDataFromFixture({trace});
     const result = await SpeedIndex.compute(data, {
       fcpResult: await FirstContentfulPaint.compute(data),
       speedline: await Speedline.request(trace, context),
@@ -42,7 +41,7 @@ Object {
   it('should compute predicted value for different settings', async () => {
     const settings = {throttlingMethod: 'simulate', throttling: {...defaultThrottling, rttMs: 300}};
     const context = {computedCache: new Map()};
-    const data = await getComputationDataFromFixture({trace, devtoolsLog, settings});
+    const data = await getComputationDataFromFixture({trace, settings});
     const result = await SpeedIndex.compute(data, {
       fcpResult: await FirstContentfulPaint.compute(data),
       speedline: await Speedline.request(trace, context),


### PR DESCRIPTION
ref https://github.com/GoogleChrome/lighthouse/issues/15841

Removes all the devtools log from core/tests/lantern, which at this point was only being used to derive a `URL`.