### PR TITLE
i18n(back/forward cache): fix typo in "WebAuthetication API"

### DIFF
--- a/shared/localization/locales/ar-XB.json
+++ b/shared/localization/locales/ar-XB.json
@@ -1713,7 +1713,7 @@
     "message": "‏‮Pages‬‏ ‏‮that‬‏ ‏‮use‬‏ ‏‮Serial‬‏ ‏‮API‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮eligible‬‏ ‏‮for‬‏ ‏‮back‬‏/‏‮forward‬‏ ‏‮cache‬‏."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "‏‮Pages‬‏ ‏‮that‬‏ ‏‮use‬‏ ‏‮WebAuthetication‬‏ ‏‮API‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮eligible‬‏ ‏‮for‬‏ ‏‮back‬‏/‏‮forward‬‏ ‏‮cache‬‏."
+    "message": "‏‮Pages‬‏ ‏‮that‬‏ ‏‮use‬‏ ‏‮WebAuthentication‬‏ ‏‮API‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮eligible‬‏ ‏‮for‬‏ ‏‮back‬‏/‏‮forward‬‏ ‏‮cache‬‏."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "‏‮Pages‬‏ ‏‮that‬‏ ‏‮use‬‏ ‏‮WebBluetooth‬‏ ‏‮API‬‏ ‏‮are‬‏ ‏‮not‬‏ ‏‮eligible‬‏ ‏‮for‬‏ ‏‮back‬‏/‏‮forward‬‏ ‏‮cache‬‏."

--- a/shared/localization/locales/bg.json
+++ b/shared/localization/locales/bg.json
@@ -1713,7 +1713,7 @@
     "message": "Страниците, които използват Serial API, не отговарят на условията за кеша за назад/напред."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Страниците, които използват WebAuthetication API, не отговарят на условията за кеша за назад/напред."
+    "message": "Страниците, които използват WebAuthentication API, не отговарят на условията за кеша за назад/напред."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Страниците, които използват WebBluetooth API, не отговарят на условията за кеша за назад/напред."

--- a/shared/localization/locales/cs.json
+++ b/shared/localization/locales/cs.json
@@ -1713,7 +1713,7 @@
     "message": "Stránky, které používají rozhraní Serial API, nemohou využívat mezipaměť pro přechod zpět nebo vpřed."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Stránky, které používají rozhraní WebAuthetication API, nemohou využívat mezipaměť pro přechod zpět nebo vpřed."
+    "message": "Stránky, které používají rozhraní WebAuthentication API, nemohou využívat mezipaměť pro přechod zpět nebo vpřed."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Stránky, které používají rozhraní WebBluetooth API, nemohou využívat mezipaměť pro přechod zpět nebo vpřed."

--- a/shared/localization/locales/el.json
+++ b/shared/localization/locales/el.json
@@ -1713,7 +1713,7 @@
     "message": "Οι σελίδες που χρησιμοποιούν το Serial API δεν είναι κατάλληλες για την κρυφή μνήμη πίσω-εμπρός."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Οι σελίδες που χρησιμοποιούν το WebAuthetication API δεν είναι κατάλληλες για την κρυφή μνήμη πίσω-εμπρός."
+    "message": "Οι σελίδες που χρησιμοποιούν το WebAuthentication API δεν είναι κατάλληλες για την κρυφή μνήμη πίσω-εμπρός."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Οι σελίδες που χρησιμοποιούν το WebBluetooth API δεν είναι κατάλληλες για την κρυφή μνήμη πίσω-εμπρός."

--- a/shared/localization/locales/fi.json
+++ b/shared/localization/locales/fi.json
@@ -1713,7 +1713,7 @@
     "message": "Serial APIa käyttävät sivut eivät voi käyttää siirtymisvälimuistia."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "WebAuthetication APIa käyttävät sivut eivät voi käyttää siirtymisvälimuistia."
+    "message": "WebAuthentication APIa käyttävät sivut eivät voi käyttää siirtymisvälimuistia."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "WebBluetooth APIa käyttävät sivut eivät voi käyttää siirtymisvälimuistia."

--- a/shared/localization/locales/he.json
+++ b/shared/localization/locales/he.json
@@ -1713,7 +1713,7 @@
     "message": "דפים שנעשה בהם שימוש ב-Serial API לא מתאימים לשמירה במטמון לדף הקודם/הבא."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "דפים שנעשה בהם שימוש ב-WebAuthetication API לא מתאימים לשמירה במטמון לדף הקודם/הבא."
+    "message": "דפים שנעשה בהם שימוש ב-WebAuthentication API לא מתאימים לשמירה במטמון לדף הקודם/הבא."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "דפים שנעשה בהם שימוש ב-WebBluetooth API לא מתאימים לשמירה במטמון לדף הקודם/הבא."

--- a/shared/localization/locales/hi.json
+++ b/shared/localization/locales/hi.json
@@ -1713,7 +1713,7 @@
     "message": "Serial API का इस्तेमाल करने वाले पेज, बैक-फ़ॉरवर्ड कैश मेमोरी की सुविधा का इस्तेमाल नहीं कर सकते."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "WebAuthetication API का इस्तेमाल करने वाले पेज, बैक-फ़ॉरवर्ड कैश मेमोरी की सुविधा का इस्तेमाल नहीं कर सकते."
+    "message": "WebAuthentication API का इस्तेमाल करने वाले पेज, बैक-फ़ॉरवर्ड कैश मेमोरी की सुविधा का इस्तेमाल नहीं कर सकते."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "WebBluetooth API का इस्तेमाल करने वाले पेज, बैक-फ़ॉरवर्ड कैश मेमोरी की सुविधा का इस्तेमाल नहीं कर सकते."

--- a/shared/localization/locales/hr.json
+++ b/shared/localization/locales/hr.json
@@ -1713,7 +1713,7 @@
     "message": "Stranice koje koriste Serial API ne ispunjavaju kriterije za predmemoriranje cijele stranice."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Stranice koje koriste WebAuthetication API ne ispunjavaju kriterije za predmemoriranje cijele stranice."
+    "message": "Stranice koje koriste WebAuthentication API ne ispunjavaju kriterije za predmemoriranje cijele stranice."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Stranice koje koriste WebBluetooth API ne ispunjavaju kriterije za predmemoriranje cijele stranice."

--- a/shared/localization/locales/it.json
+++ b/shared/localization/locales/it.json
@@ -1713,7 +1713,7 @@
     "message": "Le pagine che utilizzano l'API Serial non possono essere memorizzate nella cache back-forward."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Le pagine che utilizzano l'API WebAuthetication non possono essere memorizzate nella cache back-forward."
+    "message": "Le pagine che utilizzano l'API WebAuthentication non possono essere memorizzate nella cache back-forward."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Le pagine che utilizzano l'API WebBluetooth non possono essere memorizzate nella cache back-forward."

--- a/shared/localization/locales/ko.json
+++ b/shared/localization/locales/ko.json
@@ -1713,7 +1713,7 @@
     "message": "Serial API를 사용하는 페이지에서는 뒤로-앞으로 캐시를 사용할 수 없습니다."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "WebAuthetication API를 사용하는 페이지에서는 뒤로-앞으로 캐시를 사용할 수 없습니다."
+    "message": "WebAuthentication API를 사용하는 페이지에서는 뒤로-앞으로 캐시를 사용할 수 없습니다."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "WebBluetooth API를 사용하는 페이지에서는 뒤로-앞으로 캐시를 사용할 수 없습니다."

--- a/shared/localization/locales/lt.json
+++ b/shared/localization/locales/lt.json
@@ -1713,7 +1713,7 @@
     "message": "Puslapiams, kuriuose naudojama serijos API, negalima taikyti ilgalaikio viso puslapio saugojimo talpykloje funkcijos."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Puslapiams, kuriuose naudojama „WebAuthetication“ API, negalima taikyti ilgalaikio viso puslapio saugojimo talpykloje funkcijos."
+    "message": "Puslapiams, kuriuose naudojama „WebAuthentication“ API, negalima taikyti ilgalaikio viso puslapio saugojimo talpykloje funkcijos."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Puslapiams, kuriuose naudojama „WebBluetooth“ API, negalima taikyti ilgalaikio viso puslapio saugojimo talpykloje funkcijos."

--- a/shared/localization/locales/lv.json
+++ b/shared/localization/locales/lv.json
@@ -1713,7 +1713,7 @@
     "message": "Lapas, kurās tiek izmantota saskarne Serial API, nevar pilnīgi saglabāt kešatmiņā."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Lapas, kurās tiek izmantota saskarne WebAuthetication API, nevar pilnīgi saglabāt kešatmiņā."
+    "message": "Lapas, kurās tiek izmantota saskarne WebAuthentication API, nevar pilnīgi saglabāt kešatmiņā."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Lapas, kurās tiek izmantota saskarne WebBluetooth API, nevar pilnīgi saglabāt kešatmiņā."

--- a/shared/localization/locales/nl.json
+++ b/shared/localization/locales/nl.json
@@ -1713,7 +1713,7 @@
     "message": "Pagina's die de Serial API gebruiken, komen niet in aanmerking voor Back-Forward Cache."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Pagina's die de WebAuthetication API gebruiken, komen niet in aanmerking voor Back-Forward Cache."
+    "message": "Pagina's die de WebAuthentication API gebruiken, komen niet in aanmerking voor Back-Forward Cache."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Pagina's die de WebBluetooth API gebruiken, komen niet in aanmerking voor Back-Forward Cache."

--- a/shared/localization/locales/pl.json
+++ b/shared/localization/locales/pl.json
@@ -1713,7 +1713,7 @@
     "message": "Strony, które używają interfejsu Serial API, nie kwalifikują się do korzystania z pamięci podręcznej stanu strony internetowej."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Strony, które używają interfejsu WebAuthetication API, nie kwalifikują się do korzystania z pamięci podręcznej stanu strony internetowej."
+    "message": "Strony, które używają interfejsu WebAuthentication API, nie kwalifikują się do korzystania z pamięci podręcznej stanu strony internetowej."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Strony, które używają interfejsu WebBluetooth API, nie kwalifikują się do korzystania z pamięci podręcznej stanu strony internetowej."

--- a/shared/localization/locales/pt-PT.json
+++ b/shared/localization/locales/pt-PT.json
@@ -1713,7 +1713,7 @@
     "message": "As páginas que usam a API Serial não são elegíveis para a cache para a frente/para trás."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "As páginas que usam a API WebAuthetication não são elegíveis para a cache para a frente/para trás."
+    "message": "As páginas que usam a API WebAuthentication não são elegíveis para a cache para a frente/para trás."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "As páginas que usam a API WebBluetooth não são elegíveis para a cache para a frente/para trás."

--- a/shared/localization/locales/pt.json
+++ b/shared/localization/locales/pt.json
@@ -1713,7 +1713,7 @@
     "message": "As páginas que usam a API Serial não são qualificadas para o cache de avanço e retorno."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "As páginas que usam a API WebAuthetication não são qualificadas para o cache de avanço e retorno."
+    "message": "As páginas que usam a API WebAuthentication não são qualificadas para o cache de avanço e retorno."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "As páginas que usam a API WebBluetooth não são qualificadas para o cache de avanço e retorno."

--- a/shared/localization/locales/ru.json
+++ b/shared/localization/locales/ru.json
@@ -1713,7 +1713,7 @@
     "message": "Страницы, которые используют Serial API, нельзя добавить в возвратный кеш."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Страницы, которые используют WebAuthetication API, нельзя добавить в возвратный кеш."
+    "message": "Страницы, которые используют WebAuthentication API, нельзя добавить в возвратный кеш."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Страницы, которые используют WebBluetooth API, нельзя добавить в возвратный кеш."

--- a/shared/localization/locales/sk.json
+++ b/shared/localization/locales/sk.json
@@ -1713,7 +1713,7 @@
     "message": "Stránky s rozhraním Serial API nemôžu používať spätnú vyrovnávaciu pamäť."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Stránky s rozhraním WebAuthetication API nemôžu používať spätnú vyrovnávaciu pamäť."
+    "message": "Stránky s rozhraním WebAuthentication API nemôžu používať spätnú vyrovnávaciu pamäť."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Stránky s rozhraním WebBluetooth API nemôžu používať spätnú vyrovnávaciu pamäť."

--- a/shared/localization/locales/sr-Latn.json
+++ b/shared/localization/locales/sr-Latn.json
@@ -1713,7 +1713,7 @@
     "message": "Stranice koje koriste Serial API trenutno ne ispunjavaju uslove za keširanje cele stranice."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Stranice koje koriste WebAuthetication API trenutno ne ispunjavaju uslove za keširanje cele stranice."
+    "message": "Stranice koje koriste WebAuthentication API trenutno ne ispunjavaju uslove za keširanje cele stranice."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Stranice koje koriste WebBluetooth API trenutno ne ispunjavaju uslove za keširanje cele stranice."

--- a/shared/localization/locales/sr.json
+++ b/shared/localization/locales/sr.json
@@ -1713,7 +1713,7 @@
     "message": "Странице које користе Serial API тренутно не испуњавају услове за кеширање целе странице."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Странице које користе WebAuthetication API тренутно не испуњавају услове за кеширање целе странице."
+    "message": "Странице које користе WebAuthentication API тренутно не испуњавају услове за кеширање целе странице."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Странице које користе WebBluetooth API тренутно не испуњавају услове за кеширање целе странице."

--- a/shared/localization/locales/te.json
+++ b/shared/localization/locales/te.json
@@ -1713,7 +1713,7 @@
     "message": "Serial APIని ఉపయోగించే పేజీలకు వెనుకకు/ముందుకు కాష్‌ను యాక్సెస్ చేయడానికి ప్రస్తుతం అర్హత లేదు."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "WebAuthetication APIని ఉపయోగించే పేజీలకు వెనుకకు/ముందుకు కాష్‌ను యాక్సెస్ చేయడానికి అర్హత లేదు."
+    "message": "WebAuthentication APIని ఉపయోగించే పేజీలకు వెనుకకు/ముందుకు కాష్‌ను యాక్సెస్ చేయడానికి అర్హత లేదు."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "WebBluetooth APIని ఉపయోగించే పేజీలకు వెనుకకు/ముందుకు కాష్‌ను యాక్సెస్ చేయడానికి ప్రస్తుతం అర్హత లేదు."

--- a/shared/localization/locales/th.json
+++ b/shared/localization/locales/th.json
@@ -1713,7 +1713,7 @@
     "message": "หน้าที่ใช้ Serial API ไม่มีสิทธิ์ใช้ฟีเจอร์ Back-Forward Cache"
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "หน้าที่ใช้ WebAuthetication API ไม่มีสิทธิ์ใช้ฟีเจอร์ Back-Forward Cache"
+    "message": "หน้าที่ใช้ WebAuthentication API ไม่มีสิทธิ์ใช้ฟีเจอร์ Back-Forward Cache"
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "หน้าที่ใช้ WebBluetooth API ไม่มีสิทธิ์ใช้ฟีเจอร์ Back-Forward Cache"

--- a/shared/localization/locales/tr.json
+++ b/shared/localization/locales/tr.json
@@ -1713,7 +1713,7 @@
     "message": "Serial API kullanan sayfalar geri-ileri önbelleğe alınmaya uygun değildir."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "WebAuthetication API kullanan sayfalar geri-ileri önbelleğe alınmaya uygun değildir."
+    "message": "WebAuthentication API kullanan sayfalar geri-ileri önbelleğe alınmaya uygun değildir."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "WebBluetooth API kullanan sayfalar geri-ileri önbelleğe alınmaya uygun değildir."

--- a/shared/localization/locales/uk.json
+++ b/shared/localization/locales/uk.json
@@ -1713,7 +1713,7 @@
     "message": "Сторінки, які використовують Serial API, не підтримуються для зворотного кешу."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Сторінки, які використовують WebAuthetication API, не підтримуються для зворотного кешу."
+    "message": "Сторінки, які використовують WebAuthentication API, не підтримуються для зворотного кешу."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Сторінки, які використовують WebBluetooth API, не підтримуються для зворотного кешу."

--- a/shared/localization/locales/vi.json
+++ b/shared/localization/locales/vi.json
@@ -1713,7 +1713,7 @@
     "message": "Những trang sử dụng API nối tiếp không đủ điều kiện dùng bộ nhớ đệm cho thao tác tiến/lùi."
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "Những trang sử dụng API WebAuthetication không đủ điều kiện dùng bộ nhớ đệm cho thao tác tiến/lùi."
+    "message": "Những trang sử dụng API WebAuthentication không đủ điều kiện dùng bộ nhớ đệm cho thao tác tiến/lùi."
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "Những trang sử dụng API WebBluetooth không đủ điều kiện dùng bộ nhớ đệm cho thao tác tiến/lùi."

--- a/shared/localization/locales/zh-HK.json
+++ b/shared/localization/locales/zh-HK.json
@@ -1713,7 +1713,7 @@
     "message": "使用序號 API 的網頁不符合向前/返回快取的資格。"
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "使用 WebAuthetication API 的網頁不符合向前/返回快取的資格。"
+    "message": "使用 WebAuthentication API 的網頁不符合向前/返回快取的資格。"
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "使用 WebBluetooth API 的網頁不符合向前/返回快取的資格。"

--- a/shared/localization/locales/zh-TW.json
+++ b/shared/localization/locales/zh-TW.json
@@ -1713,7 +1713,7 @@
     "message": "使用 Serial API 的網頁不適用往返快取。"
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "使用 WebAuthetication API 的網頁不適用往返快取。"
+    "message": "使用 WebAuthentication API 的網頁不適用往返快取。"
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "使用 WebBluetooth API 的網頁不適用往返快取。"

--- a/shared/localization/locales/zh.json
+++ b/shared/localization/locales/zh.json
@@ -1713,7 +1713,7 @@
     "message": "使用 Serial API 的网页无法储存至往返缓存。"
   },
   "core/lib/bf-cache-strings.js | contentWebAuthenticationAPI": {
-    "message": "使用 WebAuthetication API 的网页无法储存至往返缓存。"
+    "message": "使用 WebAuthentication API 的网页无法储存至往返缓存。"
   },
   "core/lib/bf-cache-strings.js | contentWebBluetooth": {
     "message": "使用 WebBluetooth API 的网页无法储存至往返缓存。"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
This is a typo fix in the "Pages that use WebAuthe**n**tication API are not eligible for back/forward cache." string.

![image](https://github.com/GoogleChrome/lighthouse/assets/29845135/79eb0deb-7c94-456d-b77f-15a878a01724)

**Related Issues/PRs**
