### PR TITLE
Fix/usage of deprecated actions ci yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
 
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
 
       - name: Upload dist
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,61 +20,61 @@ jobs:
     #   https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations/16851
     #   https://github.com/actions/runner/issues/438
     steps:
-    - name: git clone
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 100
-    - run: bash core/scripts/github-actions-commit-range.sh
-      env:
-        GITHUB_CONTEXT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
+      - name: git clone
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+      - run: bash core/scripts/github-actions-commit-range.sh
+        env:
+          GITHUB_CONTEXT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_CONTEXT_BASE_SHA: ${{ github.event.before }}
 
-    - name: Use Node.js 18.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18.x
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
 
-    - run: yarn install --frozen-lockfile --network-timeout 1000000
-    - run: yarn type-check
-    - run: yarn build-all
+      - run: yarn install --frozen-lockfile --network-timeout 1000000
+      - run: yarn type-check
+      - run: yarn build-all
 
-    # Run pptr tests using ToT Chrome instead of stable default.
-    - name: Install Chrome ToT
-      run: bash $GITHUB_WORKSPACE/core/scripts/download-chrome.sh
+      # Run pptr tests using ToT Chrome instead of stable default.
+      - name: Install Chrome ToT
+        run: bash $GITHUB_WORKSPACE/core/scripts/download-chrome.sh
 
-    - name: yarn test-clients
-      run: bash $GITHUB_WORKSPACE/.github/scripts/test-retry.sh yarn test-clients
-    - name: yarn test-docs
-      run: yarn test-docs
-    - name: yarn test-treemap
-      run: bash $GITHUB_WORKSPACE/.github/scripts/test-retry.sh yarn test-treemap
+      - name: yarn test-clients
+        run: bash $GITHUB_WORKSPACE/.github/scripts/test-retry.sh yarn test-clients
+      - name: yarn test-docs
+        run: yarn test-docs
+      - name: yarn test-treemap
+        run: bash $GITHUB_WORKSPACE/.github/scripts/test-retry.sh yarn test-treemap
 
-    - run: yarn diff:sample-json
-    - run: yarn diff:flow-sample-json
-    - run: yarn lint
-    - run: yarn test-lantern
-    - run: yarn test-legacy-javascript
-    - run: yarn i18n:checks
-    - run: yarn dogfood-lhci
+      - run: yarn diff:sample-json
+      - run: yarn diff:flow-sample-json
+      - run: yarn lint
+      - run: yarn test-lantern
+      - run: yarn test-legacy-javascript
+      - run: yarn i18n:checks
+      - run: yarn dogfood-lhci
 
-    # Fail if any changes were written to any source files or generated untracked files (ex, from: build/build-cdt-lib.js).
-    - run: git add -A && git diff --cached --exit-code
+      # Fail if any changes were written to any source files or generated untracked files (ex, from: build/build-cdt-lib.js).
+      - run: git add -A && git diff --cached --exit-code
 
-    # buildtracker needs history and a common merge commit.
-    - name: Fixup git history (for buildtracker)
-      run: bash $GITHUB_WORKSPACE/.github/scripts/git-get-shared-history.sh
-      env:
-        # https://buildtracker.dev/docs/guides/github-actions#configuration
-        BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
-    - name: Store in buildtracker
-      # TODO(paulirish): Don't allow this to fail the build. https://github.com/paularmstrong/build-tracker/issues/200
-      run: yarn bt-cli upload-build || true
-      env:
-        # https://buildtracker.dev/docs/guides/github-actions#configuration
-        BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
+      # buildtracker needs history and a common merge commit.
+      - name: Fixup git history (for buildtracker)
+        run: bash $GITHUB_WORKSPACE/.github/scripts/git-get-shared-history.sh
+        env:
+          # https://buildtracker.dev/docs/guides/github-actions#configuration
+          BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
+      - name: Store in buildtracker
+        # TODO(paulirish): Don't allow this to fail the build. https://github.com/paularmstrong/build-tracker/issues/200
+        run: yarn bt-cli upload-build || true
+        env:
+          # https://buildtracker.dev/docs/guides/github-actions#configuration
+          BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}
 
-    - name: Upload dist
-      uses: actions/upload-artifact@v1
-      with:
-        name: dist
-        path: dist/
+      - name: Upload dist
+        uses: actions/upload-artifact@v1
+        with:
+          name: dist
+          path: dist/


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
This change makes it so that `ci.yml` doesn't use `actions/setup-node@v3`, which uses a `deprecated` version of `Node.js`.

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**

This pull request fixes #16094.
<!-- Provide any additional information we might need to understand the pull request -->