### PR TITLE
core(driver): checkForQuiet bugfix to properly handle setTimeout()

### DIFF
--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -231,26 +231,37 @@ function waitForCPUIdle(session, waitForCPUQuiet) {
 
   /**
    * @param {ExecutionContext} executionContext
-   * @param {() => void} resolve
    * @return {Promise<void>}
    */
-  async function checkForQuiet(executionContext, resolve) {
-    if (canceled) return;
-    const timeSinceLongTask =
-      await executionContext.evaluate(
-        checkTimeSinceLastLongTaskInPage, {args: [], useIsolation: true});
-    if (canceled) return;
-
-    if (typeof timeSinceLongTask === 'number') {
-      if (timeSinceLongTask >= waitForCPUQuiet) {
-        log.verbose('waitFor', `CPU has been idle for ${timeSinceLongTask} ms`);
-        resolve();
-      } else {
-        log.verbose('waitFor', `CPU has been idle for ${timeSinceLongTask} ms`);
-        const timeToWait = waitForCPUQuiet - timeSinceLongTask;
-        lastTimeout = setTimeout(() => checkForQuiet(executionContext, resolve), timeToWait);
-      }
+  function checkForQuiet(executionContext) {
+    if (canceled) {
+      return Promise.resolve();
     }
+
+    return executionContext.evaluate(
+      checkTimeSinceLastLongTaskInPage, {args: [], useIsolation: true})
+      .then((timeSinceLongTask) => {
+        if (canceled) {
+          return;
+        }
+
+        if (typeof timeSinceLongTask === 'number') {
+          if (timeSinceLongTask >= waitForCPUQuiet) {
+            log.verbose('waitFor', `CPU has been idle for ${timeSinceLongTask} ms`);
+            return;
+          } else {
+            log.verbose('waitFor', `CPU has been idle for ${timeSinceLongTask} ms`);
+            const timeToWait = waitForCPUQuiet - timeSinceLongTask;
+            return new Promise((resolve, reject) => {
+              lastTimeout = setTimeout(() => {
+                checkForQuiet(executionContext)
+                  .then(resolve)
+                  .catch(reject);
+              }, timeToWait);
+            });
+          }
+        }
+      });
   }
 
   /** @type {(() => void)} */
@@ -262,7 +273,8 @@ function waitForCPUIdle(session, waitForCPUQuiet) {
   /** @type {Promise<void>} */
   const promise = new Promise((resolve, reject) => {
     executionContext.evaluate(registerPerformanceObserverInPage, {args: [], useIsolation: true})
-      .then(() => checkForQuiet(executionContext, resolve))
+      .then(() => checkForQuiet(executionContext))
+      .then(resolve)
       .catch(reject);
     cancel = () => {
       if (canceled) return;

--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -252,10 +252,6 @@ function waitForCPUIdle(session, waitForCPUQuiet) {
             const timeToWait = waitForCPUQuiet - timeSinceLongTask;
             return new Promise((resolve, reject) => {
               setTimeout(() => {
-                if (canceled) {
-                  resolve();
-                  return;
-                }
                 checkForQuiet(executionContext)
                   .then(resolve)
                   .catch(reject);

--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -225,8 +225,6 @@ function waitForCPUIdle(session, waitForCPUQuiet) {
     };
   }
 
-  /** @type {NodeJS.Timeout|undefined} */
-  let lastTimeout;
   let canceled = false;
 
   /**
@@ -253,7 +251,11 @@ function waitForCPUIdle(session, waitForCPUQuiet) {
             log.verbose('waitFor', `CPU has been idle for ${timeSinceLongTask} ms`);
             const timeToWait = waitForCPUQuiet - timeSinceLongTask;
             return new Promise((resolve, reject) => {
-              lastTimeout = setTimeout(() => {
+              setTimeout(() => {
+                if (canceled) {
+                  resolve();
+                  return;
+                }
                 checkForQuiet(executionContext)
                   .then(resolve)
                   .catch(reject);
@@ -279,7 +281,6 @@ function waitForCPUIdle(session, waitForCPUQuiet) {
     cancel = () => {
       if (canceled) return;
       canceled = true;
-      if (lastTimeout) clearTimeout(lastTimeout);
       reject(new Error('Wait for CPU idle canceled'));
     };
   });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
The PR fixes unhandled rejections which happen in setTimeout(checkForQuiet).

<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
It is a bugfix.

<!-- Describe the need for this change -->
When target page gets closed during waitForCPUIdle, lighthouse crashes.

<!-- Link any documentation or information that would help understand this change -->
