### PR TITLE
core(interactive): also use LCP as bounds in observed metric

### DIFF
--- a/core/audits/metrics/interactive.js
+++ b/core/audits/metrics/interactive.js
@@ -18,7 +18,7 @@ const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 /**
  * @fileoverview This audit identifies the time the page is "consistently interactive".
- * Looks for the first period of at least 5 seconds after FCP where both CPU and network were quiet,
+ * Looks for the first period of at least 5 seconds after LCP where both CPU and network were quiet,
  * and returns the timestamp of the beginning of the CPU quiet period.
  * @see https://docs.google.com/document/d/1GGiI9-7KeY3TPqS3YT271upUVimo-XiL5mwWorDUD4c/edit#
  */

--- a/core/computed/metrics/interactive.js
+++ b/core/computed/metrics/interactive.js
@@ -86,11 +86,13 @@ class Interactive extends NavigationMetric {
    * @return {{cpuQuietPeriod: TimePeriod, networkQuietPeriod: TimePeriod, cpuQuietPeriods: Array<TimePeriod>, networkQuietPeriods: Array<TimePeriod>}}
    */
   static findOverlappingQuietPeriods(longTasks, networkRecords, processedNavigation) {
-    const FcpTsInMs = processedNavigation.timestamps.firstContentfulPaint / 1000;
+    const minTime = processedNavigation.timestamps.largestContentfulPaint !== undefined ?
+      processedNavigation.timestamps.largestContentfulPaint / 1000 :
+      processedNavigation.timestamps.firstContentfulPaint / 1000;
 
     /** @type {function(TimePeriod):boolean} */
     const isLongEnoughQuietPeriod = period =>
-        period.end > FcpTsInMs + REQUIRED_QUIET_WINDOW &&
+        period.end > minTime + REQUIRED_QUIET_WINDOW &&
         period.end - period.start >= REQUIRED_QUIET_WINDOW;
     const networkQuietPeriods = this._findNetworkQuietPeriods(networkRecords, processedNavigation)
         .filter(isLongEnoughQuietPeriod);

--- a/core/test/computed/metrics/interactive-test.js
+++ b/core/test/computed/metrics/interactive-test.js
@@ -93,10 +93,10 @@ describe('Metrics: TTI', () => {
   describe('#findOverlappingQuietPeriods', () => {
     it('should return entire range when no activity is present', () => {
       const timeOrigin = 220023532;
-      const firstContentfulPaint = 2500 * 1000 + timeOrigin;
+      const largestContentfulPaint = 2500 * 1000 + timeOrigin;
       const traceEnd = 10000 * 1000 + timeOrigin;
       const processedTrace = /** @type {LH.Artifacts.ProcessedNavigation} */ (
-        {timestamps: {timeOrigin, firstContentfulPaint, traceEnd}}
+        {timestamps: {timeOrigin, largestContentfulPaint, traceEnd}}
       );
       const network = generateNetworkRecords([], timeOrigin);
 
@@ -105,7 +105,21 @@ describe('Metrics: TTI', () => {
       assert.deepEqual(result.networkQuietPeriod, {start: 0, end: traceEnd / 1000});
     });
 
-    it('should throw when trace ended too soon after FCP', () => {
+    it('should throw when trace ended too soon after LCP', () => {
+      const timeOrigin = 220023532;
+      const largestContentfulPaint = 2500 * 1000 + timeOrigin;
+      const traceEnd = 5000 * 1000 + timeOrigin;
+      const processedTrace = /** @type {LH.Artifacts.ProcessedNavigation} */ (
+        {timestamps: {timeOrigin, largestContentfulPaint, traceEnd}}
+      );
+      const network = generateNetworkRecords([], timeOrigin);
+
+      assert.throws(() => {
+        Interactive.findOverlappingQuietPeriods([], network, processedTrace);
+      }, /NO.*IDLE_PERIOD/);
+    });
+
+    it('should throw when trace ended too soon after FCP (when LCP is missing)', () => {
       const timeOrigin = 220023532;
       const firstContentfulPaint = 2500 * 1000 + timeOrigin;
       const traceEnd = 5000 * 1000 + timeOrigin;
@@ -183,14 +197,14 @@ describe('Metrics: TTI', () => {
 
     it('should find first overlapping quiet period', () => {
       const timeOrigin = 220023532;
-      const firstContentfulPaint = 10000 * 1000 + timeOrigin;
+      const largestContentfulPaint = 10000 * 1000 + timeOrigin;
       const traceEnd = 45000 * 1000 + timeOrigin;
       const processedTrace = /** @type {LH.Artifacts.ProcessedNavigation} */ (
-        {timestamps: {timeOrigin, firstContentfulPaint, traceEnd}}
+        {timestamps: {timeOrigin, largestContentfulPaint, traceEnd}}
       );
 
       const cpu = [
-        // quiet period before FCP
+        // quiet period before LCP
         {start: 9000, end: 9900},
         {start: 11000, end: 13000},
         // quiet period during network activity


### PR DESCRIPTION
#16046 changed this audit to use LCP instead of FMP, but incorrectly referred to FCP in a non-user facing doc comment.

Thanks to @csswizardry for pointing this out.

Also updates `findOverlappingQuietPeriods`, used in the observed metric computation, which was still using FCP as the bounds. Now uses LCP to match Lantern (but I allowed for a fallback to FCP to still get something in the case LCP is missing).