### PR TITLE
clients(lr): adjust CPU throttling based on benchmark

### DIFF
--- a/core/config/lr-mobile-config.js
+++ b/core/config/lr-mobile-config.js
@@ -13,7 +13,7 @@ const config = {
     throttling: {
       // Determined using PSI CPU benchmark median and
       // https://lighthouse-cpu-throttling-calculator.vercel.app/
-      cpuSlowdownMultiplier: 1.5,
+      cpuSlowdownMultiplier: 1.2,
     },
     skipAudits: [
       // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539


### PR DESCRIPTION
Further analysis indicates that 1.2x might be better than 1.5x in PSI. 1.2x is recommended by https://lighthouse-cpu-throttling-calculator.vercel.app/ but 1.5x was just the high end of the reported range.
