### PR TITLE
tests: update network target type expectations

### DIFF
--- a/cli/test/smokehouse/test-definitions/oopif-scripts.js
+++ b/cli/test/smokehouse/test-definitions/oopif-scripts.js
@@ -50,8 +50,9 @@ const expectations = {
               // From in-process iframe
               {url: 'http://localhost:10200/simple-script.js', resourceType: 'Script', sessionTargetType: 'page'},
               {url: 'http://localhost:10200/simple-script.js', resourceType: 'Fetch', sessionTargetType: 'page'},
-              {url: 'http://localhost:10200/simple-worker.js', sessionTargetType: 'page'},
-              // This target type can vary depending on if Chrome's field trial config is being used
+              // The target type of worker requests can vary depending on the Chrome version and if
+              // the field trial config is being used.
+              {url: 'http://localhost:10200/simple-worker.js', sessionTargetType: /(page|worker)/},
               {url: 'http://localhost:10200/simple-worker.mjs', sessionTargetType: /(page|worker)/},
               // From in-process iframe -> simple-worker.js
               {url: 'http://localhost:10200/simple-script.js?importScripts', resourceType: 'Other', sessionTargetType: 'worker'},
@@ -61,8 +62,9 @@ const expectations = {
               // From OOPIF
               {url: 'http://localhost:10503/simple-script.js', resourceType: 'Script', sessionTargetType: 'iframe'},
               {url: 'http://localhost:10503/simple-script.js', resourceType: 'Fetch', sessionTargetType: 'iframe'},
-              {url: 'http://localhost:10503/simple-worker.js', sessionTargetType: 'iframe'},
-              // This target type can vary depending on if Chrome's field trial config is being used
+              // The target type of worker requests can vary depending on the Chrome version and if
+              // the field trial config is being used.
+              {url: 'http://localhost:10503/simple-worker.js', sessionTargetType: /(iframe|worker)/},
               {url: 'http://localhost:10503/simple-worker.mjs', sessionTargetType: /(iframe|worker)/},
               // From OOPIF -> simple-worker.js
               {url: 'http://localhost:10503/simple-script.js?importScripts', resourceType: 'Other', sessionTargetType: 'worker'},

--- a/core/test/scenarios/api-test-pptr.js
+++ b/core/test/scenarios/api-test-pptr.js
@@ -163,7 +163,7 @@ describe('Individual modes API', function() {
     });
 
     // eslint-disable-next-line max-len
-    it('should know target type of network requests from frames created before timespan', async () => {
+    it.only('should know target type of network requests from frames created before timespan', async () => {
       const spy = jestMock.spyOn(TargetManager.prototype, '_onExecutionContextCreated');
       state.server.baseDir = `${LH_ROOT}/cli/test/fixtures`;
       const {page, serverBaseUrl} = state;
@@ -191,10 +191,11 @@ describe('Individual modes API', function() {
         .sort((a, b) => a.url.localeCompare(b.url));
 
       // These results can change depending on which Chrome version is used.
-      // The expectation here is tuned for ToT Chromium WITHOUT the `--disable-field-trial-config`
+      // The expectation here is tuned for Chromium 133.0.6876.0
       //
-      // Adding the `--disable-field-trial-config` flag or using Chrome canary can change which
-      // target the root worker requests are associated with.
+      // Using an older Chromium version can change which target the root
+      // worker requests are associated with.
+      // (also depends on --disable-field-trial-config for older versions)
       expect(networkRequests).toMatchInlineSnapshot(`
 Array [
   Object {
@@ -210,11 +211,11 @@ Array [
     "url": "http://localhost:10200/simple-script.js?importScripts",
   },
   Object {
-    "sessionTargetType": "page",
+    "sessionTargetType": "worker",
     "url": "http://localhost:10200/simple-worker.js",
   },
   Object {
-    "sessionTargetType": "page",
+    "sessionTargetType": "worker",
     "url": "http://localhost:10200/simple-worker.mjs",
   },
   Object {
@@ -230,11 +231,11 @@ Array [
     "url": "http://localhost:10503/simple-script.js?importScripts",
   },
   Object {
-    "sessionTargetType": "iframe",
+    "sessionTargetType": "worker",
     "url": "http://localhost:10503/simple-worker.js",
   },
   Object {
-    "sessionTargetType": "iframe",
+    "sessionTargetType": "worker",
     "url": "http://localhost:10503/simple-worker.mjs",
   },
 ]

--- a/core/test/scenarios/api-test-pptr.js
+++ b/core/test/scenarios/api-test-pptr.js
@@ -163,7 +163,7 @@ describe('Individual modes API', function() {
     });
 
     // eslint-disable-next-line max-len
-    it.only('should know target type of network requests from frames created before timespan', async () => {
+    it('should know target type of network requests from frames created before timespan', async () => {
       const spy = jestMock.spyOn(TargetManager.prototype, '_onExecutionContextCreated');
       state.server.baseDir = `${LH_ROOT}/cli/test/fixtures`;
       const {page, serverBaseUrl} = state;


### PR DESCRIPTION
Seems like something in the field trial config was updated again. It's still pretty inconsequential for us, so this PR just updates the tests for the latest ToT.
