### PR TITLE
core(prioritize-lcp-image): report negative savings as 0

### DIFF
--- a/core/audits/prioritize-lcp-image.js
+++ b/core/audits/prioritize-lcp-image.js
@@ -216,7 +216,7 @@ class PrioritizeLcpImage extends Audit {
     }
 
     const wastedMs = lcpTimingsBefore.endTime -
-      Math.max(lcpTimingsAfter.endTime, maxDependencyEndTime);
+      Math.max(lcpTimingsAfter.endTime, maxDependencyEndTime > lcpTimingsBefore.endTime ? lcpTimingsBefore.endTime : maxDependencyEndTime);
 
     return {
       wastedMs,


### PR DESCRIPTION
Part of https://github.com/GoogleChrome/lighthouse/issues/16261.