### PR TITLE
core: allow placeholder anchor elements

### DIFF
--- a/core/audits/seo/crawlable-anchors.js
+++ b/core/audits/seo/crawlable-anchors.js
@@ -18,6 +18,16 @@ const UIStrings = {
   columnFailingLink: 'Uncrawlable Link',
 };
 
+const hrefAssociatedAttributes = [
+  'target',
+  'download',
+  'ping',
+  'rel',
+  'hreflang',
+  'type',
+  'referrerpolicy',
+];
+
 const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
 class CrawlableAnchors extends Audit {
@@ -45,6 +55,8 @@ class CrawlableAnchors extends Audit {
       role = '',
       id,
       href,
+      attributeNames = [],
+      ariaCurrent = '',
     }) => {
       rawHref = rawHref.replace( /\s/g, '');
       name = name.trim();
@@ -61,6 +73,17 @@ class CrawlableAnchors extends Audit {
 
       if (rawHref.startsWith('file:')) return true;
       if (name.length > 0) return;
+
+      if (
+        // https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element
+        // If the a element has no href attribute, then the element represents a placeholder for where a link might otherwise have been placed, if it had been relevant, consisting of just the element's contents.
+        // The target, download, ping, rel, hreflang, type, and referrerpolicy attributes must be omitted if the href attribute is not present.
+        !attributeNames.includes('href') &&
+        !hrefAssociatedAttributes.some(attribute => attributeNames.includes(attribute)) &&
+        // https://github.com/GoogleChrome/lighthouse/pull/158941
+        // Because there is so much to consider, as a provisional response, allow the a element as a placeholder only if it has aria-current="page" or aria-current="location".
+        ['page', 'location'].includes((ariaCurrent))
+      ) return;
 
       if (href === '') return true;
       if (javaScriptVoidRegExp.test(rawHref)) return true;

--- a/core/gather/gatherers/anchor-elements.js
+++ b/core/gather/gatherers/anchor-elements.js
@@ -54,6 +54,8 @@ function collectAnchorElements() {
         rel: node.rel,
         target: node.target,
         id: node.getAttribute('id') || '',
+        attributeNames: node.getAttributeNames(),
+        ariaCurrent: node.getAttribute('aria-current') || '',
         // @ts-expect-error - getNodeDetails put into scope via stringification
         node: getNodeDetails(node),
       };
@@ -68,6 +70,8 @@ function collectAnchorElements() {
       rel: '',
       target: node.target.baseVal || '',
       id: node.getAttribute('id') || '',
+      attributeNames: node.getAttributeNames(),
+      ariaCurrent: node.getAttribute('aria-current') || '',
       // @ts-expect-error - getNodeDetails put into scope via stringification
       node: getNodeDetails(node),
     };

--- a/core/test/audits/seo/crawlable-anchors-test.js
+++ b/core/test/audits/seo/crawlable-anchors-test.js
@@ -15,6 +15,10 @@ function runAudit({
   onclick = '',
   name = '',
   id = '',
+  attributeNames = [
+    (rawHref || href) ? 'href' : null, role ? 'role' : null, name ? 'name' : null,
+  ].filter(Boolean),
+  ariaCurrent = '',
   listeners = onclick.trim().length ? [{type: 'click'}] : [],
   node = {
     snippet: '',
@@ -34,6 +38,8 @@ function runAudit({
       role,
       node,
       id,
+      attributeNames,
+      ariaCurrent,
     }],
     URL: {
       finalDisplayedUrl: 'http://example.com',
@@ -56,11 +62,14 @@ describe('SEO: Crawlable anchors audit', () => {
     assert.equal(runAudit({rawHref: '//example.com'}), 1, 'protocol relative link');
     assert.equal(runAudit({rawHref: 'tel:5555555'}), 1, 'email link with a tel URI');
     assert.equal(runAudit({rawHref: '#'}), 1, 'link with only a hash symbol');
+    assert.equal(runAudit({ariaCurrent: 'page'}), 1, 'placeholder anchor element');
+    assert.equal(runAudit({ariaCurrent: 'location'}), 1, 'placeholder anchor element');
     assert.equal(runAudit({
       rawHref: '?query=string',
     }), 1, 'relative link which specifies a query string');
 
     assert.equal(runAudit({rawHref: 'ftp://'}), 0, 'invalid FTP links fails');
+    assert.equal(runAudit({rawHref: '', href: 'https://example.com', attributeNames: ['href']}), 1, 'empty attribute that links to current page');
     assert.equal(runAudit({rawHref: '', href: 'https://example.com'}), 1, 'empty attribute that links to current page');
   });
 
@@ -78,6 +87,11 @@ describe('SEO: Crawlable anchors audit', () => {
       rawHref: 'javascript:void(0)',
     });
     assert.equal(auditResult, 1, 'Href value has no effect when a role is present');
+    assert.equal(
+      runAudit({role: ' ', attributeNames: ['rel']}),
+      0,
+      'A role value of a space character fails the audit'
+    );
     assert.equal(runAudit({role: 'a'}), 1, 'Using a role attribute value is an immediate pass');
     assert.equal(runAudit({role: ' '}), 0, 'A role value of a space character fails the audit');
   });
@@ -103,7 +117,24 @@ describe('SEO: Crawlable anchors audit', () => {
   });
 
   it('disallows uncrawlable anchors', () => {
+    assert.equal(
+      runAudit({attributeNames: ['href']}),
+      0,
+      'link with an empty href and no other meaningful attributes and no event handlers'
+    );
+    assert.equal(runAudit({attributeNames: ['target']}), 0, 'link with only a target attribute');
+    assert.equal(runAudit({rawHref: 'file:///image.png'}), 0, 'hyperlink with a `file:` URI');
+    assert.equal(
+      runAudit({name: ' ', attributeNames: ['rel']}),
+      0,
+      'name attribute with only space characters'
+    );
     assert.equal(runAudit({}), 0, 'link with no meaningful attributes and no event handlers');
+    assert.equal(
+      runAudit({ariaCurrent: 'true'}),
+      0,
+      'link with no href attribute and aria-current is neither page nor location.'
+    );
     assert.equal(runAudit({rawHref: 'file:///image.png'}), 0, 'hyperlink with a `file:` URI');
     assert.equal(runAudit({name: ' '}), 0, 'name attribute with only space characters');
     assert.equal(runAudit({rawHref: ' '}), 1, 'href attribute with only space characters');

--- a/types/artifacts.d.ts
+++ b/types/artifacts.d.ts
@@ -365,6 +365,8 @@ declare module Artifacts {
     node: NodeDetails
     onclick: string
     id: string
+    attributeNames: Array<string>
+    ariaCurrent: string
     listeners?: Array<{
       type: Crdp.DOMDebugger.EventListener['type']
     }>


### PR DESCRIPTION
**Summary**

Acknowledgements: This is a continuation of Mr. @romainmenke 's great pull request. [#15894]

> Anchor elements without an `href` or specific attributes are considered placeholder elements and should not produce audit failures.
> 
> See : [#15820 (comment)](https://github.com/GoogleChrome/lighthouse/issues/15820#issuecomment-2544452061)

Since #15894 says there are many issues to be resolved, I would like to allow at least the a element that clearly indicates that it is a placeholder.


**Related Issues/PRs**

Base : #15894
Fixes : #15820
