### PR TITLE
misc(ci): workaround Chrome developer sandbox restrictions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
+      # Dev builds like ToT need this in Ubuntu 23.10+
+      # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+      CHROME_DEVEL_SANDBOX: ${{ github.workspace }}/.tmp/chrome-tot/chrome_sandbox
       FORCE_COLOR: true
 
     # A few steps are duplicated across all jobs. Can be done better when this feature lands:

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -128,6 +128,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHROME_PATH: ${{ github.workspace }}/lighthouse/.tmp/chrome-tot/chrome
+      # Dev builds like ToT need this in Ubuntu 23.10+
+      # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+      CHROME_DEVEL_SANDBOX: ${{ github.workspace }}/.tmp/chrome-tot/chrome_sandbox
       FORCE_COLOR: true
     name: DevTools smoke ${{ matrix.smoke-test-shard }}/${{ strategy.job-total }}
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
+      # Dev builds like ToT need this in Ubuntu 23.10+
+      # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+      CHROME_DEVEL_SANDBOX: ${{ github.workspace }}/.tmp/chrome-tot/chrome_sandbox
       # The total number of shards. Set dynamically when length of *single* matrix variable is
       # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
       SHARD_TOTAL: 3
@@ -132,6 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
+      # Dev builds like ToT need this in Ubuntu 23.10+
+      # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+      CHROME_DEVEL_SANDBOX: ${{ github.workspace }}/.tmp/chrome-tot/chrome_sandbox
       # The total number of shards. Set dynamically when length of *single* matrix variable is
       # computable. See https://github.community/t/get-length-of-strategy-matrix-or-get-all-matrix-options/18342
       SHARD_TOTAL: 3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -19,6 +19,9 @@ jobs:
     name: node ${{ matrix.node }}
     env:
       CHROME_PATH: ${{ github.workspace }}/.tmp/chrome-tot/chrome
+      # Dev builds like ToT need this in Ubuntu 23.10+
+      # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
+      CHROME_DEVEL_SANDBOX: ${{ github.workspace }}/.tmp/chrome-tot/chrome_sandbox
       LATEST_NODE: '18'
       FORCE_COLOR: true
 

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -93,3 +93,9 @@ if [ "$machine" != "MinGw" ]; then
   echo "CHROME_PATH version:"
   $CHROME_PATH --version
 fi
+
+# https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md
+if [ "$machine" == "Linux" && -n "$CI" ]; then
+  sudo chown root:root "$chrome_out/chrome_sandbox"
+  sudo chmod 4755 "$chrome_out/chrome_sandbox"
+fi

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -95,7 +95,7 @@ if [ "$machine" != "MinGw" ]; then
 fi
 
 # https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md
-if [ "$machine" == "Linux" && -n "$CI" ]; then
+if [ "$machine" == "Linux" ] && [ -n "$CI" ]; then
   sudo chown root:root "$chrome_out/chrome_sandbox"
   sudo chmod 4755 "$chrome_out/chrome_sandbox"
 fi

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -95,7 +95,7 @@ if [ "$machine" != "MinGw" ]; then
 fi
 
 # https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md
-if [ "$machine" == "Linux" ] && [ -n "$CI" ]; then
-  sudo chown root:root "$chrome_out/chrome_sandbox"
-  sudo chmod 4755 "$chrome_out/chrome_sandbox"
+if [ "$machine" == "Linux" ] && [[ "${CI:-}" ]]; then
+  chmod 4755 "$chrome_out/chrome_sandbox"
+  chown root:root "$chrome_out/chrome_sandbox"
 fi

--- a/core/scripts/download-chrome.sh
+++ b/core/scripts/download-chrome.sh
@@ -97,5 +97,5 @@ fi
 # https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md
 if [ "$machine" == "Linux" ] && [[ "${CI:-}" ]]; then
   chmod 4755 "$chrome_out/chrome_sandbox"
-  chown root:root "$chrome_out/chrome_sandbox"
+  sudo chown root:root "$chrome_out/chrome_sandbox"
 fi


### PR DESCRIPTION
See https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md

This was preventing Chrome from launching on the latest version of Ubuntu used by our CI bots:
https://github.com/GoogleChrome/lighthouse/actions/runs/12619489314/job/35197834181