### PR TITLE
misc(types): add missing type for explanation in NodeValue

### DIFF
--- a/types/lhr/audit-details.d.ts
+++ b/types/lhr/audit-details.d.ts
@@ -230,6 +230,8 @@ declare module Details {
     snippet?: string;
     /** A human-friendly text descriptor that's used to identify the node more quickly. */
     nodeLabel?: string;
+    /** A human-friendly explainer on how to approach the possible fix. */
+    explanation?: string;
   }
 
   /**


### PR DESCRIPTION
**Summary**

Type for `node.explanation` was missing from `NodeValue`. I think its only present in accessibility audits.