### PR TITLE
deps: upgrade third-party-web to 0.26.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "robots-parser": "^3.0.1",
     "semver": "^5.3.0",
     "speedline-core": "^1.4.3",
-    "third-party-web": "^0.26.1",
+    "third-party-web": "^0.26.5",
     "tldts-icann": "^6.1.16",
     "ws": "^7.0.0",
     "yargs": "^17.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6947,10 +6947,10 @@ theredoc@^1.0.0:
   resolved "https://registry.yarnpkg.com/theredoc/-/theredoc-1.0.0.tgz#bcace376af6feb1873efbdd0f91ed026570ff062"
   integrity sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==
 
-third-party-web@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.26.1.tgz#1d5051777396eccc4fc0e2675b43861725eaa494"
-  integrity sha512-I5Y7YT4841769UjrAcy/c0G/Bb/4lqBzA7LHzx17z5rxE7zzNhf4gpOME3hK3oktZc36oZQpskUG2UXGrUAECA==
+third-party-web@^0.26.5:
+  version "0.26.5"
+  resolved "https://registry.yarnpkg.com/third-party-web/-/third-party-web-0.26.5.tgz#c442b2a16db66a6064e05e0f060c9ed780f31709"
+  integrity sha512-tDuKQJUTfjvi9Fcrs1s6YAQAB9mzhTSbBZMfNgtWNmJlHuoFeXO6dzBFdGeCWRvYL50jQGK0jPsBZYxqZQJ2SA==
 
 third-party-web@latest:
   version "0.26.2"


### PR DESCRIPTION
https://github.com/patrickhulce/third-party-web/releases/tag/v0.26.2
https://github.com/patrickhulce/third-party-web/releases/tag/v0.26.3
https://github.com/patrickhulce/third-party-web/releases/tag/v0.26.4
https://github.com/patrickhulce/third-party-web/releases/tag/v0.26.5
