### PR TITLE
tests(dbw): revert unload handler expectations

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -249,13 +249,6 @@ const expectations = {
               description: 'Failed to load resource: the server responded with a status of 404 (Not Found)',
               sourceLocation: {url: 'http://localhost:10200/favicon.ico'},
             },
-            {
-              // Unload handlers were moved behind a permission policy in M135.
-              _minChromiumVersion: '135',
-              source: 'violation',
-              description: 'Permissions policy violation: unload is not allowed in this document.',
-              sourceLocation: {url: 'http://localhost:10200/dobetterweb/dbw_tester.html'},
-            },
           ],
         },
       },
@@ -328,8 +321,6 @@ const expectations = {
               subItems: undefined,
             },
             {
-              // Unload handlers were moved behind a permission policy in M135.
-              _maxChromiumVersion: '134',
               value: 'UnloadHandler',
               source: {
                 type: 'source-location',
@@ -434,21 +425,8 @@ const expectations = {
         details: {
           items: [
             {
-              // Unload handlers were moved behind a permission policy in M135.
-              _maxChromiumVersion: '134',
               reason: 'The page has an unload handler in the main frame.',
               failureType: 'Actionable',
-              subItems: {
-                items: [{
-                  frameUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
-                }],
-              },
-            },
-            {
-              // Unload handlers were moved behind a permission policy in M135.
-              _minChromiumVersion: '135',
-              reason: 'There were permission requests upon navigating away.',
-              failureType: 'Pending browser support',
               subItems: {
                 items: [{
                   frameUrl: 'http://localhost:10200/dobetterweb/dbw_tester.html',
@@ -459,7 +437,6 @@ const expectations = {
               // This issue only appears in the DevTools runner for some reason.
               // TODO: Investigate why this doesn't happen on the CLI runner.
               _runner: 'devtools',
-              _maxChromiumVersion: '134',
               reason: 'There were permission requests upon navigating away.',
               failureType: 'Pending browser support',
               subItems: {


### PR DESCRIPTION
Reverts the dbw smoke test changes from https://github.com/GoogleChrome/lighthouse/pull/16335