### PR TITLE
deps: upgrade critical dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,8 +212,8 @@
     "yargs-parser": "^21.0.0"
   },
   "resolutions": {
-    "puppeteer/**/devtools-protocol": "0.0.1421213",
-    "puppeteer-core/**/devtools-protocol": "0.0.1421213"
+    "puppeteer/**/devtools-protocol": "0.0.1423531",
+    "puppeteer-core/**/devtools-protocol": "0.0.1423531"
   },
   "repository": "GoogleChrome/lighthouse",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,12 +2935,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-devtools-protocol@0.0.1402036, devtools-protocol@0.0.1421213:
-  version "0.0.1421213"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1421213.tgz#7d061c0748f2488fa429aaec3c42d700bb932092"
-  integrity sha512-E0JrRYeXiTZXJwFlJ0j8wz8TmM+VwCv128JaSyCEgTmyE54QE/GDhT4w6kS1m+nFKmulHWWrbrO2AHexZgcxFQ==
-
-devtools-protocol@0.0.1423531, devtools-protocol@^0.0.1423531:
+devtools-protocol@0.0.1402036, devtools-protocol@0.0.1423531:
   version "0.0.1423531"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1423531.tgz#43ba906340fb8ffbda566711ead31f139b2a150a"
   integrity sha512-z6cOcajZWxk80zvFnkTGa7tj3oqF+C5SnOF1KSMeAr5/WW/nLNHlEpKr7voSzMz8IaUoq5rjdI0Mqv5k/BUkhg==


### PR DESCRIPTION
```diff
-    "devtools-protocol": "^0.0.1421213",
-    "puppeteer": "^24.2.1",
-    "puppeteer-core": "^24.2.1",

+    "devtools-protocol": "0.0.1423531",
+    "puppeteer": "^24.3.0",
+    "puppeteer-core": "^24.3.0",
```