### PR TITLE
core(script-treemap-data): keep duplicate info when collapsing nodes

### DIFF
--- a/core/audits/script-treemap-data.js
+++ b/core/audits/script-treemap-data.js
@@ -114,8 +114,12 @@ class ScriptTreemapDataAudit extends Audit {
      */
     function collapseAll(node) {
       while (node.children && node.children.length === 1) {
-        node.name += '/' + node.children[0].name;
-        node.children = node.children[0].children;
+        const child = node.children[0];
+        node.name += '/' + child.name;
+        if (child.duplicatedNormalizedModuleName) {
+          node.duplicatedNormalizedModuleName = child.duplicatedNormalizedModuleName;
+        }
+        node.children = child.children;
       }
 
       if (node.children) {

--- a/core/test/audits/__snapshots__/script-treemap-data-test.js.snap
+++ b/core/test/audits/__snapshots__/script-treemap-data-test.js.snap
@@ -265,6 +265,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "Control/assets/js/analytics/global_tracking.js",
                     "name": "analytics/global_tracking.js",
                     "resourceBytes": 4531,
                   },
@@ -280,6 +281,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "Control/javascript/widgets/product-thumbnail-stats.js",
                     "name": "widgets/product-thumbnail-stats.js",
                     "resourceBytes": 3768,
                   },
@@ -828,6 +830,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "node_modules/extend/index.js",
                     "name": "extend/index.js?",
                     "resourceBytes": 829,
                   },
@@ -886,11 +889,13 @@ Array [
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/api/api-service.js",
                         "name": "api/api-service.js?",
                         "resourceBytes": 1284,
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/action/actions.js",
                         "name": "action/actions.js?",
                         "resourceBytes": 1486,
                       },
@@ -900,6 +905,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "node_modules/reqwest/reqwest.js",
                     "name": "reqwest/reqwest.js?",
                     "resourceBytes": 9799,
                   },
@@ -1000,6 +1006,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "node_modules/process/browser.js",
                     "name": "process/browser.js?",
                     "resourceBytes": 1675,
                   },
@@ -1162,6 +1169,7 @@ Array [
                           },
                           Object {
                             "children": undefined,
+                            "duplicatedNormalizedModuleName": "js/src/common/component/button/button.tsx",
                             "name": "button/button.tsx?",
                             "resourceBytes": 1216,
                           },
@@ -1297,11 +1305,13 @@ Array [
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/common/service/content-item-service.ts",
                         "name": "service/content-item-service.ts?",
                         "resourceBytes": 1480,
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/common/actions/content-actions.ts",
                         "name": "actions/content-actions.ts?",
                         "resourceBytes": 918,
                       },
@@ -1309,6 +1319,7 @@ Array [
                         "children": Array [
                           Object {
                             "children": undefined,
+                            "duplicatedNormalizedModuleName": "js/src/common/store/model/content.ts",
                             "name": "model/content.ts?",
                             "resourceBytes": 7682,
                           },
@@ -1644,6 +1655,7 @@ Array [
                           },
                           Object {
                             "children": undefined,
+                            "duplicatedNormalizedModuleName": "js/src/search/2018/app/search-results.tsx",
                             "name": "app/search-results.tsx?",
                             "resourceBytes": 11160,
                           },
@@ -1742,6 +1754,7 @@ Array [
                               },
                               Object {
                                 "children": undefined,
+                                "duplicatedNormalizedModuleName": "js/src/search/results/store/item/resource-types.ts",
                                 "name": "item/resource-types.ts?",
                                 "resourceBytes": 783,
                               },
@@ -1777,6 +1790,7 @@ Array [
                           },
                           Object {
                             "children": undefined,
+                            "duplicatedNormalizedModuleName": "js/src/search/results/service/api/filter-api-service.ts",
                             "name": "service/api/filter-api-service.ts?",
                             "resourceBytes": 554,
                           },
@@ -1897,6 +1911,7 @@ Array [
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/user/service/api/user-api-service.ts",
                         "name": "service/api/user-api-service.ts?",
                         "resourceBytes": 1451,
                       },
@@ -1908,11 +1923,13 @@ Array [
                     "children": Array [
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/document/common/constant/upload-statuses.ts",
                         "name": "constant/upload-statuses.ts?",
                         "resourceBytes": 3528,
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/document/common/service/document-upload-service.ts",
                         "name": "service/document-upload-service.ts?",
                         "resourceBytes": 1356,
                       },
@@ -1924,6 +1941,7 @@ Array [
                     "children": Array [
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/dashboard2018/utils/amplitudeHelpers.ts",
                         "name": "utils/amplitudeHelpers.ts?",
                         "resourceBytes": 723,
                       },
@@ -1967,6 +1985,7 @@ Array [
               },
               Object {
                 "children": undefined,
+                "duplicatedNormalizedModuleName": "js/vendor/beefjs/dist/beef.js",
                 "name": "vendor/beefjs/dist/beef.js?",
                 "resourceBytes": 11949,
               },
@@ -2005,6 +2024,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/LayoutBundle/Resources/assets/js/vendor/jquery.ba-throttle-debounce.js",
                     "name": "vendor/jquery.ba-throttle-debounce.js",
                     "resourceBytes": 973,
                   },
@@ -2065,6 +2085,7 @@ Array [
               },
               Object {
                 "children": undefined,
+                "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/SearchBundle/Resources/assets/js/Smart/search.smart.widget.js",
                 "name": "SearchBundle/Resources/assets/js/Smart/search.smart.widget.js",
                 "resourceBytes": 10247,
               },
@@ -2130,6 +2151,7 @@ Array [
           },
           Object {
             "children": undefined,
+            "duplicatedNormalizedModuleName": "cdn/ajax/libs/angular.js/1.3.20/angular-route.min.js",
             "name": "cdn/ajax/libs/angular.js/1.3.20/angular-route.min.js",
             "resourceBytes": 4247,
           },
@@ -2408,6 +2430,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "Control/assets/js/analytics/global_tracking.js",
                     "name": "analytics/global_tracking.js",
                     "resourceBytes": 4531,
                   },
@@ -2423,6 +2446,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "Control/javascript/widgets/product-thumbnail-stats.js",
                     "name": "widgets/product-thumbnail-stats.js",
                     "resourceBytes": 3768,
                   },
@@ -2971,6 +2995,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "node_modules/extend/index.js",
                     "name": "extend/index.js?",
                     "resourceBytes": 829,
                   },
@@ -3029,11 +3054,13 @@ Array [
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/api/api-service.js",
                         "name": "api/api-service.js?",
                         "resourceBytes": 1284,
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "node_modules/beef-flux/build/action/actions.js",
                         "name": "action/actions.js?",
                         "resourceBytes": 1486,
                       },
@@ -3043,6 +3070,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "node_modules/reqwest/reqwest.js",
                     "name": "reqwest/reqwest.js?",
                     "resourceBytes": 9799,
                   },
@@ -3143,6 +3171,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "node_modules/process/browser.js",
                     "name": "process/browser.js?",
                     "resourceBytes": 1675,
                   },
@@ -3305,6 +3334,7 @@ Array [
                           },
                           Object {
                             "children": undefined,
+                            "duplicatedNormalizedModuleName": "js/src/common/component/button/button.tsx",
                             "name": "button/button.tsx?",
                             "resourceBytes": 1216,
                           },
@@ -3440,11 +3470,13 @@ Array [
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/common/service/content-item-service.ts",
                         "name": "service/content-item-service.ts?",
                         "resourceBytes": 1480,
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/common/actions/content-actions.ts",
                         "name": "actions/content-actions.ts?",
                         "resourceBytes": 918,
                       },
@@ -3452,6 +3484,7 @@ Array [
                         "children": Array [
                           Object {
                             "children": undefined,
+                            "duplicatedNormalizedModuleName": "js/src/common/store/model/content.ts",
                             "name": "model/content.ts?",
                             "resourceBytes": 7682,
                           },
@@ -3787,6 +3820,7 @@ Array [
                           },
                           Object {
                             "children": undefined,
+                            "duplicatedNormalizedModuleName": "js/src/search/2018/app/search-results.tsx",
                             "name": "app/search-results.tsx?",
                             "resourceBytes": 11160,
                           },
@@ -3885,6 +3919,7 @@ Array [
                               },
                               Object {
                                 "children": undefined,
+                                "duplicatedNormalizedModuleName": "js/src/search/results/store/item/resource-types.ts",
                                 "name": "item/resource-types.ts?",
                                 "resourceBytes": 783,
                               },
@@ -3920,6 +3955,7 @@ Array [
                           },
                           Object {
                             "children": undefined,
+                            "duplicatedNormalizedModuleName": "js/src/search/results/service/api/filter-api-service.ts",
                             "name": "service/api/filter-api-service.ts?",
                             "resourceBytes": 554,
                           },
@@ -4040,6 +4076,7 @@ Array [
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/user/service/api/user-api-service.ts",
                         "name": "service/api/user-api-service.ts?",
                         "resourceBytes": 1451,
                       },
@@ -4051,11 +4088,13 @@ Array [
                     "children": Array [
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/document/common/constant/upload-statuses.ts",
                         "name": "constant/upload-statuses.ts?",
                         "resourceBytes": 3528,
                       },
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/document/common/service/document-upload-service.ts",
                         "name": "service/document-upload-service.ts?",
                         "resourceBytes": 1356,
                       },
@@ -4067,6 +4106,7 @@ Array [
                     "children": Array [
                       Object {
                         "children": undefined,
+                        "duplicatedNormalizedModuleName": "js/src/dashboard2018/utils/amplitudeHelpers.ts",
                         "name": "utils/amplitudeHelpers.ts?",
                         "resourceBytes": 723,
                       },
@@ -4110,6 +4150,7 @@ Array [
               },
               Object {
                 "children": undefined,
+                "duplicatedNormalizedModuleName": "js/vendor/beefjs/dist/beef.js",
                 "name": "vendor/beefjs/dist/beef.js?",
                 "resourceBytes": 11949,
               },
@@ -4148,6 +4189,7 @@ Array [
                   },
                   Object {
                     "children": undefined,
+                    "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/LayoutBundle/Resources/assets/js/vendor/jquery.ba-throttle-debounce.js",
                     "name": "vendor/jquery.ba-throttle-debounce.js",
                     "resourceBytes": 973,
                   },
@@ -4208,6 +4250,7 @@ Array [
               },
               Object {
                 "children": undefined,
+                "duplicatedNormalizedModuleName": "Symfony/src/CourseHero/SearchBundle/Resources/assets/js/Smart/search.smart.widget.js",
                 "name": "SearchBundle/Resources/assets/js/Smart/search.smart.widget.js",
                 "resourceBytes": 10247,
               },
@@ -4273,6 +4316,7 @@ Array [
           },
           Object {
             "children": undefined,
+            "duplicatedNormalizedModuleName": "cdn/ajax/libs/angular.js/1.3.20/angular-route.min.js",
             "name": "cdn/ajax/libs/angular.js/1.3.20/angular-route.min.js",
             "resourceBytes": 4247,
           },

--- a/core/test/audits/script-treemap-data-test.js
+++ b/core/test/audits/script-treemap-data-test.js
@@ -127,12 +127,12 @@ describe('ScriptTreemapData audit', () => {
     });
 
     it('has nodes', () => {
-      expect(JSON.stringify(treemapData.nodes).length).toMatchInlineSnapshot(`70077`);
+      expect(JSON.stringify(treemapData.nodes).length).toMatchInlineSnapshot(`73749`);
       expect(treemapData.nodes).toMatchSnapshot();
     });
 
     it('finds duplicates', () => {
-      expect(JSON.stringify(treemapData.nodes).length).toMatchInlineSnapshot(`70077`);
+      expect(JSON.stringify(treemapData.nodes).length).toMatchInlineSnapshot(`73749`);
       // @ts-ignore all these children exist.
       const leafNode = treemapData.nodes[0].
         children[0].


### PR DESCRIPTION
This was mistakenly dropping many duplicate modules from the treemap data, example site: https://dupe-modules-lh-2.surge.sh/