### PR TITLE
core(legacy-javascript): support esbuild bundles

### DIFF
--- a/core/audits/byte-efficiency/legacy-javascript.js
+++ b/core/audits/byte-efficiency/legacy-javascript.js
@@ -190,7 +190,7 @@ class LegacyJavascript extends ByteEfficiencyAudit {
 
     // Un-minified code may have module names.
     // core-js/modules/es.object.is-frozen
-    expression += `|core-js/modules/${coreJs3Module}"`;
+    expression += `|core-js/modules/${coreJs3Module}(?:\\.js)?"`;
 
     return expression;
   }

--- a/core/scripts/legacy-javascript/package.json
+++ b/core/scripts/legacy-javascript/package.json
@@ -8,6 +8,7 @@
     "browserify": "^16.5.0",
     "caniuse-lite": "^1.0.30001704",
     "core-js-compat": "^3.41.0",
+    "esbuild": "^0.25.1",
     "glob": "^7.1.6",
     "terser": "^5.38.2"
   },

--- a/core/scripts/legacy-javascript/run.js
+++ b/core/scripts/legacy-javascript/run.js
@@ -116,6 +116,8 @@ async function processVariant(options) {
       fs.writeFileSync(`${dir}/babel-stderr.txt`, babelOutputBuffer.stderr.toString());
     }
 
+    // browserify
+
     // Transform any require statements (like for core-js) into a big bundle.
     await runCommand('yarn', [
       'browserify',
@@ -132,6 +134,23 @@ async function processVariant(options) {
       '-o', `${dir}/main.bundle.browserify.min.js`,
       '--source-map', 'content="inline",url="main.bundle.browserify.min.js.map"',
     ]);
+
+    // esbuild
+    await runCommand('yarn', [
+      'esbuild',
+      `${dir}/main.transpiled.js`,
+      `--outfile=${dir}/main.bundle.esbuild.js`,
+      '--bundle',
+      '--sourcemap',
+    ]);
+    await runCommand('yarn', [
+      'esbuild',
+      `${dir}/main.transpiled.js`,
+      `--outfile=${dir}/main.bundle.esbuild.min.js`,
+      '--bundle',
+      '--sourcemap',
+      '--minify',
+    ]);
   }
 
   if (STAGE === 'audit' || STAGE === 'all') {
@@ -141,6 +160,8 @@ async function processVariant(options) {
     const bundles = [
       'main.bundle.browserify.js',
       'main.bundle.browserify.min.js',
+      'main.bundle.esbuild.js',
+      'main.bundle.esbuild.min.js',
     ];
     for (const bundle of bundles) {
       const code = fs.readFileSync(`${dir}/${bundle}`, 'utf-8');

--- a/core/scripts/legacy-javascript/summary-signals-nomaps.json
+++ b/core/scripts/legacy-javascript/summary-signals-nomaps.json
@@ -1,5 +1,5 @@
 {
-  "totalSignals": 451,
+  "totalSignals": 1065,
   "variantsMissingSignals": [
     "baseline_true_bugfixes_false",
     "baseline_true_bugfixes_true"
@@ -200,6 +200,200 @@
       ]
     },
     {
+      "group": "all-legacy-polyfills",
+      "name": "all-legacy-polyfills-core-js-3",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
+      "signals": [
+        "Array.prototype.at",
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.findLast",
+        "Array.prototype.findLastIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Array.prototype.unshift",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.create",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.hasOwn",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Promise.any",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.matchAll",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.replaceAll",
+        "String.prototype.startsWith",
+        "String.prototype.substr",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled"
+      ]
+    },
+    {
+      "group": "all-legacy-polyfills",
+      "name": "all-legacy-polyfills-core-js-3",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
+      "signals": [
+        "Array.prototype.at",
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.findLast",
+        "Array.prototype.findLastIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Array.prototype.unshift",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.create",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.hasOwn",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Promise.any",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.matchAll",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.replaceAll",
+        "String.prototype.startsWith",
+        "String.prototype.substr",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled"
+      ]
+    },
+    {
       "group": "core-js-3-only-polyfill",
       "name": "Array.from",
       "bundle": "main.bundle.browserify.js",
@@ -212,6 +406,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.from",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-from",
+      "signals": [
+        "Array.from"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.from",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-from",
+      "signals": [
+        "Array.from"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.from",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-from",
       "signals": [
         "Array.from"
@@ -230,6 +442,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.isArray",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-isArray",
+      "signals": [
+        "Array.isArray"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.isArray",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-isArray",
+      "signals": [
+        "Array.isArray"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.isArray",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-isArray",
       "signals": [
         "Array.isArray"
@@ -248,6 +478,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.of",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-of",
+      "signals": [
+        "Array.of"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.of",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-of",
+      "signals": [
+        "Array.of"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.of",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-of",
       "signals": [
         "Array.of"
@@ -266,6 +514,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.at",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-at",
+      "signals": [
+        "Array.prototype.at"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.at",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-at",
+      "signals": [
+        "Array.prototype.at"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.at",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-at",
       "signals": [
         "Array.prototype.at"
@@ -284,6 +550,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.concat",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-concat",
+      "signals": [
+        "Array.prototype.concat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.concat",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-concat",
+      "signals": [
+        "Array.prototype.concat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.concat",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-concat",
       "signals": [
         "Array.prototype.concat"
@@ -302,6 +586,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.copyWithin",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
+      "signals": [
+        "Array.prototype.copyWithin"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.copyWithin",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
+      "signals": [
+        "Array.prototype.copyWithin"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.copyWithin",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
       "signals": [
         "Array.prototype.copyWithin"
@@ -320,6 +622,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.every",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-every",
+      "signals": [
+        "Array.prototype.every"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.every",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-every",
+      "signals": [
+        "Array.prototype.every"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.every",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-every",
       "signals": [
         "Array.prototype.every"
@@ -338,6 +658,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.fill",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-fill",
+      "signals": [
+        "Array.prototype.fill"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.fill",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-fill",
+      "signals": [
+        "Array.prototype.fill"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.fill",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-fill",
       "signals": [
         "Array.prototype.fill"
@@ -356,6 +694,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.filter",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-filter",
+      "signals": [
+        "Array.prototype.filter"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.filter",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-filter",
+      "signals": [
+        "Array.prototype.filter"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.filter",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-filter",
       "signals": [
         "Array.prototype.filter"
@@ -374,6 +730,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.find",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-find",
+      "signals": [
+        "Array.prototype.find"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.find",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-find",
+      "signals": [
+        "Array.prototype.find"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.find",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-find",
       "signals": [
         "Array.prototype.find"
@@ -392,6 +766,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findIndex",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
+      "signals": [
+        "Array.prototype.findIndex"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findIndex",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
+      "signals": [
+        "Array.prototype.findIndex"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findIndex",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
       "signals": [
         "Array.prototype.findIndex"
@@ -410,6 +802,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findLast",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
+      "signals": [
+        "Array.prototype.findLast"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findLast",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
+      "signals": [
+        "Array.prototype.findLast"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findLast",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
       "signals": [
         "Array.prototype.findLast"
@@ -428,6 +838,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findLastIndex",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
+      "signals": [
+        "Array.prototype.findLastIndex"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findLastIndex",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
+      "signals": [
+        "Array.prototype.findLastIndex"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findLastIndex",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
       "signals": [
         "Array.prototype.findLastIndex"
@@ -446,6 +874,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.flat",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-flat",
+      "signals": [
+        "Array.prototype.flat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.flat",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-flat",
+      "signals": [
+        "Array.prototype.flat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.flat",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-flat",
       "signals": [
         "Array.prototype.flat"
@@ -464,6 +910,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.flatMap",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
+      "signals": [
+        "Array.prototype.flatMap"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.flatMap",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
+      "signals": [
+        "Array.prototype.flatMap"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.flatMap",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
       "signals": [
         "Array.prototype.flatMap"
@@ -482,6 +946,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.forEach",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
+      "signals": [
+        "Array.prototype.forEach"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.forEach",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
+      "signals": [
+        "Array.prototype.forEach"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.forEach",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
       "signals": [
         "Array.prototype.forEach"
@@ -500,6 +982,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.includes",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-includes",
+      "signals": [
+        "Array.prototype.includes"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.includes",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-includes",
+      "signals": [
+        "Array.prototype.includes"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.includes",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-includes",
       "signals": [
         "Array.prototype.includes"
@@ -518,6 +1018,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.indexOf",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
+      "signals": [
+        "Array.prototype.indexOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.indexOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
+      "signals": [
+        "Array.prototype.indexOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.indexOf",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
       "signals": [
         "Array.prototype.indexOf"
@@ -536,6 +1054,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.join",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-join",
+      "signals": [
+        "Array.prototype.join"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.join",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-join",
+      "signals": [
+        "Array.prototype.join"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.join",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-join",
       "signals": [
         "Array.prototype.join"
@@ -554,6 +1090,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.map",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-map",
+      "signals": [
+        "Array.prototype.map"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.map",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-map",
+      "signals": [
+        "Array.prototype.map"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.map",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-map",
       "signals": [
         "Array.prototype.map"
@@ -572,6 +1126,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.slice",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-slice",
+      "signals": [
+        "Array.prototype.slice"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.slice",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-slice",
+      "signals": [
+        "Array.prototype.slice"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.slice",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-slice",
       "signals": [
         "Array.prototype.slice"
@@ -590,6 +1162,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.some",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-some",
+      "signals": [
+        "Array.prototype.some"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.some",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-some",
+      "signals": [
+        "Array.prototype.some"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.some",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-some",
       "signals": [
         "Array.prototype.some"
@@ -608,6 +1198,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.sort",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-sort",
+      "signals": [
+        "Array.prototype.sort"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.sort",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-sort",
+      "signals": [
+        "Array.prototype.sort"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.sort",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-sort",
       "signals": [
         "Array.prototype.sort"
@@ -626,6 +1234,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.unshift",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
+      "signals": [
+        "Array.prototype.unshift"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.unshift",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
+      "signals": [
+        "Array.prototype.unshift"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.unshift",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
       "signals": [
         "Array.prototype.unshift"
@@ -644,6 +1270,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.acosh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-acosh",
+      "signals": [
+        "Math.acosh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.acosh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-acosh",
+      "signals": [
+        "Math.acosh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.acosh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-acosh",
       "signals": [
         "Math.acosh"
@@ -662,6 +1306,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.asinh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-asinh",
+      "signals": [
+        "Math.asinh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.asinh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-asinh",
+      "signals": [
+        "Math.asinh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.asinh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-asinh",
       "signals": [
         "Math.asinh"
@@ -680,6 +1342,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.atanh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-atanh",
+      "signals": [
+        "Math.atanh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.atanh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-atanh",
+      "signals": [
+        "Math.atanh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.atanh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-atanh",
       "signals": [
         "Math.atanh"
@@ -698,6 +1378,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.cbrt",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-cbrt",
+      "signals": [
+        "Math.cbrt"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.cbrt",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-cbrt",
+      "signals": [
+        "Math.cbrt"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.cbrt",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-cbrt",
       "signals": [
         "Math.cbrt"
@@ -716,6 +1414,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.clz32",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-clz32",
+      "signals": [
+        "Math.clz32"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.clz32",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-clz32",
+      "signals": [
+        "Math.clz32"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.clz32",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-clz32",
       "signals": [
         "Math.clz32"
@@ -734,6 +1450,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.cosh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-cosh",
+      "signals": [
+        "Math.cosh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.cosh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-cosh",
+      "signals": [
+        "Math.cosh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.cosh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-cosh",
       "signals": [
         "Math.cosh"
@@ -752,6 +1486,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.expm1",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-expm1",
+      "signals": [
+        "Math.expm1"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.expm1",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-expm1",
+      "signals": [
+        "Math.expm1"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.expm1",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-expm1",
       "signals": [
         "Math.expm1"
@@ -770,6 +1522,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.fround",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-fround",
+      "signals": [
+        "Math.fround"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.fround",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-fround",
+      "signals": [
+        "Math.fround"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.fround",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-fround",
       "signals": [
         "Math.fround"
@@ -788,6 +1558,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.hypot",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-hypot",
+      "signals": [
+        "Math.hypot"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.hypot",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-hypot",
+      "signals": [
+        "Math.hypot"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.hypot",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-hypot",
       "signals": [
         "Math.hypot"
@@ -806,6 +1594,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.imul",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-imul",
+      "signals": [
+        "Math.imul"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.imul",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-imul",
+      "signals": [
+        "Math.imul"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.imul",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-imul",
       "signals": [
         "Math.imul"
@@ -824,6 +1630,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.log10",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-log10",
+      "signals": [
+        "Math.log10"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log10",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-log10",
+      "signals": [
+        "Math.log10"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log10",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-log10",
       "signals": [
         "Math.log10"
@@ -842,6 +1666,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.log1p",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-log1p",
+      "signals": [
+        "Math.log1p"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log1p",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-log1p",
+      "signals": [
+        "Math.log1p"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log1p",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-log1p",
       "signals": [
         "Math.log1p"
@@ -860,6 +1702,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.log2",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-log2",
+      "signals": [
+        "Math.log2"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log2",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-log2",
+      "signals": [
+        "Math.log2"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log2",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-log2",
       "signals": [
         "Math.log2"
@@ -878,6 +1738,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.sign",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-sign",
+      "signals": [
+        "Math.sign"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.sign",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-sign",
+      "signals": [
+        "Math.sign"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.sign",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-sign",
       "signals": [
         "Math.sign"
@@ -896,6 +1774,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.sinh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-sinh",
+      "signals": [
+        "Math.sinh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.sinh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-sinh",
+      "signals": [
+        "Math.sinh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.sinh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-sinh",
       "signals": [
         "Math.sinh"
@@ -914,6 +1810,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.tanh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-tanh",
+      "signals": [
+        "Math.tanh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.tanh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-tanh",
+      "signals": [
+        "Math.tanh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.tanh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-tanh",
       "signals": [
         "Math.tanh"
@@ -932,6 +1846,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Math.trunc",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-trunc",
+      "signals": [
+        "Math.trunc"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.trunc",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-trunc",
+      "signals": [
+        "Math.trunc"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.trunc",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-trunc",
       "signals": [
         "Math.trunc"
@@ -950,6 +1882,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.assign",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-assign",
+      "signals": [
+        "Object.assign"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.assign",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-assign",
+      "signals": [
+        "Object.assign"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.assign",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-assign",
       "signals": [
         "Object.assign"
@@ -968,6 +1918,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.create",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-create",
+      "signals": [
+        "Object.create"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.create",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-create",
+      "signals": [
+        "Object.create"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.create",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-create",
       "signals": [
         "Object.create"
@@ -986,6 +1954,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.entries",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-entries",
+      "signals": [
+        "Object.entries"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.entries",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-entries",
+      "signals": [
+        "Object.entries"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.entries",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-entries",
       "signals": [
         "Object.entries"
@@ -1004,6 +1990,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.freeze",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-freeze",
+      "signals": [
+        "Object.freeze"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.freeze",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-freeze",
+      "signals": [
+        "Object.freeze"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.freeze",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-freeze",
       "signals": [
         "Object.freeze"
@@ -1022,6 +2026,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.fromEntries",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-fromEntries",
+      "signals": [
+        "Object.fromEntries"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.fromEntries",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-fromEntries",
+      "signals": [
+        "Object.fromEntries"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.fromEntries",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-fromEntries",
       "signals": [
         "Object.fromEntries"
@@ -1040,6 +2062,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.getOwnPropertyDescriptor",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
+      "signals": [
+        "Object.getOwnPropertyDescriptor"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getOwnPropertyDescriptor",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
+      "signals": [
+        "Object.getOwnPropertyDescriptor"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getOwnPropertyDescriptor",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
       "signals": [
         "Object.getOwnPropertyDescriptor"
@@ -1058,6 +2098,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.getOwnPropertyDescriptors",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
+      "signals": [
+        "Object.getOwnPropertyDescriptors"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getOwnPropertyDescriptors",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
+      "signals": [
+        "Object.getOwnPropertyDescriptors"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getOwnPropertyDescriptors",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
       "signals": [
         "Object.getOwnPropertyDescriptors"
@@ -1076,6 +2134,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.getPrototypeOf",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
+      "signals": [
+        "Object.getPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getPrototypeOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
+      "signals": [
+        "Object.getPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getPrototypeOf",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
       "signals": [
         "Object.getPrototypeOf"
@@ -1094,6 +2170,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.hasOwn",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-hasOwn",
+      "signals": [
+        "Object.hasOwn"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.hasOwn",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-hasOwn",
+      "signals": [
+        "Object.hasOwn"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.hasOwn",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-hasOwn",
       "signals": [
         "Object.hasOwn"
@@ -1112,6 +2206,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.is",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-is",
+      "signals": [
+        "Object.is"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.is",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-is",
+      "signals": [
+        "Object.is"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.is",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-is",
       "signals": [
         "Object.is"
@@ -1130,6 +2242,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.isExtensible",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-isExtensible",
+      "signals": [
+        "Object.isExtensible"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isExtensible",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-isExtensible",
+      "signals": [
+        "Object.isExtensible"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isExtensible",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-isExtensible",
       "signals": [
         "Object.isExtensible"
@@ -1148,6 +2278,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.isFrozen",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-isFrozen",
+      "signals": [
+        "Object.isFrozen"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isFrozen",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-isFrozen",
+      "signals": [
+        "Object.isFrozen"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isFrozen",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-isFrozen",
       "signals": [
         "Object.isFrozen"
@@ -1166,6 +2314,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.isSealed",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-isSealed",
+      "signals": [
+        "Object.isSealed"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isSealed",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-isSealed",
+      "signals": [
+        "Object.isSealed"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isSealed",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-isSealed",
       "signals": [
         "Object.isSealed"
@@ -1184,6 +2350,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.keys",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-keys",
+      "signals": [
+        "Object.keys"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.keys",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-keys",
+      "signals": [
+        "Object.keys"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.keys",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-keys",
       "signals": [
         "Object.keys"
@@ -1202,6 +2386,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.preventExtensions",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-preventExtensions",
+      "signals": [
+        "Object.preventExtensions"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.preventExtensions",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-preventExtensions",
+      "signals": [
+        "Object.preventExtensions"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.preventExtensions",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-preventExtensions",
       "signals": [
         "Object.preventExtensions"
@@ -1220,6 +2422,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.seal",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-seal",
+      "signals": [
+        "Object.seal"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.seal",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-seal",
+      "signals": [
+        "Object.seal"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.seal",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-seal",
       "signals": [
         "Object.seal"
@@ -1238,6 +2458,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.setPrototypeOf",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
+      "signals": [
+        "Object.setPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.setPrototypeOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
+      "signals": [
+        "Object.setPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.setPrototypeOf",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
       "signals": [
         "Object.setPrototypeOf"
@@ -1256,6 +2494,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Object.values",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-values",
+      "signals": [
+        "Object.values"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.values",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-values",
+      "signals": [
+        "Object.values"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.values",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-values",
       "signals": [
         "Object.values"
@@ -1274,6 +2530,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Promise.allSettled",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Promise-allSettled",
+      "signals": [
+        "Promise.allSettled"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Promise.allSettled",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Promise-allSettled",
+      "signals": [
+        "Promise.allSettled"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Promise.allSettled",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Promise-allSettled",
       "signals": [
         "Promise.allSettled"
@@ -1292,6 +2566,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Promise.any",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Promise-any",
+      "signals": [
+        "Promise.any"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Promise.any",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Promise-any",
+      "signals": [
+        "Promise.any"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Promise.any",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Promise-any",
       "signals": [
         "Promise.any"
@@ -1310,6 +2602,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.apply",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-apply",
+      "signals": [
+        "Reflect.apply"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.apply",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-apply",
+      "signals": [
+        "Reflect.apply"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.apply",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-apply",
       "signals": [
         "Reflect.apply"
@@ -1328,6 +2638,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.construct",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-construct",
+      "signals": [
+        "Reflect.construct"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.construct",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-construct",
+      "signals": [
+        "Reflect.construct"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.construct",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-construct",
       "signals": [
         "Reflect.construct"
@@ -1346,6 +2674,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.deleteProperty",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
+      "signals": [
+        "Reflect.deleteProperty"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.deleteProperty",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
+      "signals": [
+        "Reflect.deleteProperty"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.deleteProperty",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
       "signals": [
         "Reflect.deleteProperty"
@@ -1364,6 +2710,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.get",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-get",
+      "signals": [
+        "Reflect.get"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.get",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-get",
+      "signals": [
+        "Reflect.get"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.get",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-get",
       "signals": [
         "Reflect.get"
@@ -1382,6 +2746,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.getOwnPropertyDescriptor",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
+      "signals": [
+        "Reflect.getOwnPropertyDescriptor"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.getOwnPropertyDescriptor",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
+      "signals": [
+        "Reflect.getOwnPropertyDescriptor"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.getOwnPropertyDescriptor",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
       "signals": [
         "Reflect.getOwnPropertyDescriptor"
@@ -1400,6 +2782,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.getPrototypeOf",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
+      "signals": [
+        "Reflect.getPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.getPrototypeOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
+      "signals": [
+        "Reflect.getPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.getPrototypeOf",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
       "signals": [
         "Reflect.getPrototypeOf"
@@ -1418,6 +2818,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.has",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-has",
+      "signals": [
+        "Reflect.has"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.has",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-has",
+      "signals": [
+        "Reflect.has"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.has",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-has",
       "signals": [
         "Reflect.has"
@@ -1436,6 +2854,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.isExtensible",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
+      "signals": [
+        "Reflect.isExtensible"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.isExtensible",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
+      "signals": [
+        "Reflect.isExtensible"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.isExtensible",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
       "signals": [
         "Reflect.isExtensible"
@@ -1454,6 +2890,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.ownKeys",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
+      "signals": [
+        "Reflect.ownKeys"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.ownKeys",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
+      "signals": [
+        "Reflect.ownKeys"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.ownKeys",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
       "signals": [
         "Reflect.ownKeys"
@@ -1472,6 +2926,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.preventExtensions",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
+      "signals": [
+        "Reflect.preventExtensions"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.preventExtensions",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
+      "signals": [
+        "Reflect.preventExtensions"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.preventExtensions",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
       "signals": [
         "Reflect.preventExtensions"
@@ -1490,6 +2962,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.set",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-set",
+      "signals": [
+        "Reflect.set"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.set",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-set",
+      "signals": [
+        "Reflect.set"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.set",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-set",
       "signals": [
         "Reflect.set"
@@ -1508,6 +2998,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.setPrototypeOf",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
+      "signals": [
+        "Reflect.setPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.setPrototypeOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
+      "signals": [
+        "Reflect.setPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.setPrototypeOf",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
       "signals": [
         "Reflect.setPrototypeOf"
@@ -1526,6 +3034,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.fromCodePoint",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-fromCodePoint",
+      "signals": [
+        "String.fromCodePoint"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.fromCodePoint",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-fromCodePoint",
+      "signals": [
+        "String.fromCodePoint"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.fromCodePoint",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-fromCodePoint",
       "signals": [
         "String.fromCodePoint"
@@ -1544,6 +3070,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.codePointAt",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
+      "signals": [
+        "String.prototype.codePointAt"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.codePointAt",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
+      "signals": [
+        "String.prototype.codePointAt"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.codePointAt",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
       "signals": [
         "String.prototype.codePointAt"
@@ -1562,6 +3106,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.endsWith",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
+      "signals": [
+        "String.prototype.endsWith"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.endsWith",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
+      "signals": [
+        "String.prototype.endsWith"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.endsWith",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
       "signals": [
         "String.prototype.endsWith"
@@ -1580,6 +3142,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.includes",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-includes",
+      "signals": [
+        "String.prototype.includes"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.includes",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-includes",
+      "signals": [
+        "String.prototype.includes"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.includes",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-includes",
       "signals": [
         "String.prototype.includes"
@@ -1598,6 +3178,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.link",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-link",
+      "signals": [
+        "String.prototype.link"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.link",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-link",
+      "signals": [
+        "String.prototype.link"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.link",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-link",
       "signals": [
         "String.prototype.link"
@@ -1616,6 +3214,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.matchAll",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
+      "signals": [
+        "String.prototype.matchAll"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.matchAll",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
+      "signals": [
+        "String.prototype.matchAll"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.matchAll",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
       "signals": [
         "String.prototype.matchAll"
@@ -1634,6 +3250,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.padEnd",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-padEnd",
+      "signals": [
+        "String.prototype.padEnd"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.padEnd",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-padEnd",
+      "signals": [
+        "String.prototype.padEnd"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.padEnd",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-padEnd",
       "signals": [
         "String.prototype.padEnd"
@@ -1652,6 +3286,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.padStart",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-padStart",
+      "signals": [
+        "String.prototype.padStart"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.padStart",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-padStart",
+      "signals": [
+        "String.prototype.padStart"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.padStart",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-padStart",
       "signals": [
         "String.prototype.padStart"
@@ -1670,6 +3322,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.repeat",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-repeat",
+      "signals": [
+        "String.prototype.repeat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.repeat",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-repeat",
+      "signals": [
+        "String.prototype.repeat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.repeat",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-repeat",
       "signals": [
         "String.prototype.repeat"
@@ -1688,6 +3358,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.replaceAll",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
+      "signals": [
+        "String.prototype.replaceAll"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.replaceAll",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
+      "signals": [
+        "String.prototype.replaceAll"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.replaceAll",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
       "signals": [
         "String.prototype.replaceAll"
@@ -1706,6 +3394,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.startsWith",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
+      "signals": [
+        "String.prototype.startsWith"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.startsWith",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
+      "signals": [
+        "String.prototype.startsWith"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.startsWith",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
       "signals": [
         "String.prototype.startsWith"
@@ -1724,6 +3430,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.substr",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-substr",
+      "signals": [
+        "String.prototype.substr"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.substr",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-substr",
+      "signals": [
+        "String.prototype.substr"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.substr",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-substr",
       "signals": [
         "String.prototype.substr"
@@ -1742,6 +3466,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trim",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trim",
+      "signals": [
+        "String.prototype.trim"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trim",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trim",
+      "signals": [
+        "String.prototype.trim"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trim",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trim",
       "signals": [
         "String.prototype.trim"
@@ -1760,6 +3502,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trimEnd",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
+      "signals": [
+        "String.prototype.trimEnd"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trimEnd",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
+      "signals": [
+        "String.prototype.trimEnd"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trimEnd",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
       "signals": [
         "String.prototype.trimEnd"
@@ -1778,6 +3538,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trimStart",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
+      "signals": [
+        "String.prototype.trimStart"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trimStart",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
+      "signals": [
+        "String.prototype.trimStart"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trimStart",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
       "signals": [
         "String.prototype.trimStart"
@@ -1796,6 +3574,24 @@
       "group": "core-js-3-only-polyfill",
       "name": "String.raw",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-raw",
+      "signals": [
+        "String.raw"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.raw",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-raw",
+      "signals": [
+        "String.raw"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.raw",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-raw",
       "signals": [
         "String.raw"
@@ -1807,6 +3603,86 @@
       "bundle": "main.bundle.browserify.js",
       "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
       "signals": [
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.create",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.startsWith",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled",
         "@babel/plugin-transform-regenerator",
         "@babel/plugin-transform-spread",
         "@babel/plugin-transform-classes"
@@ -1908,6 +3784,194 @@
     },
     {
       "group": "core-js-3-preset-env",
+      "name": "baseline_false_bugfixes_false",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
+      "signals": [
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.create",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.startsWith",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled",
+        "Promise.any",
+        "String.prototype.matchAll",
+        "String.prototype.replaceAll",
+        "@babel/plugin-transform-regenerator",
+        "@babel/plugin-transform-spread",
+        "@babel/plugin-transform-classes"
+      ]
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_false_bugfixes_false",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
+      "signals": [
+        "Object.create",
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.startsWith",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled",
+        "Promise.any",
+        "String.prototype.matchAll",
+        "String.prototype.replaceAll",
+        "@babel/plugin-transform-regenerator",
+        "@babel/plugin-transform-spread",
+        "@babel/plugin-transform-classes"
+      ]
+    },
+    {
+      "group": "core-js-3-preset-env",
       "name": "baseline_true_bugfixes_false",
       "bundle": "main.bundle.browserify.js",
       "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
@@ -1917,6 +3981,20 @@
       "group": "core-js-3-preset-env",
       "name": "baseline_true_bugfixes_false",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
+      "signals": []
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_true_bugfixes_false",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
+      "signals": []
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_true_bugfixes_false",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
       "signals": []
     },
@@ -1931,6 +4009,20 @@
       "group": "core-js-3-preset-env",
       "name": "baseline_true_bugfixes_true",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
+      "signals": []
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_true_bugfixes_true",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
+      "signals": []
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_true_bugfixes_true",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
       "signals": []
     },
@@ -1947,6 +4039,24 @@
       "group": "only-plugin",
       "name": "@babel/plugin-transform-classes",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "only-plugin/-babel-plugin-transform-classes",
+      "signals": [
+        "@babel/plugin-transform-classes"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-classes",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "only-plugin/-babel-plugin-transform-classes",
+      "signals": [
+        "@babel/plugin-transform-classes"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-classes",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "only-plugin/-babel-plugin-transform-classes",
       "signals": [
         "@babel/plugin-transform-classes"
@@ -1965,6 +4075,24 @@
       "group": "only-plugin",
       "name": "@babel/plugin-transform-regenerator",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "only-plugin/-babel-plugin-transform-regenerator",
+      "signals": [
+        "@babel/plugin-transform-regenerator"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-regenerator",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "only-plugin/-babel-plugin-transform-regenerator",
+      "signals": [
+        "@babel/plugin-transform-regenerator"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-regenerator",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "only-plugin/-babel-plugin-transform-regenerator",
       "signals": [
         "@babel/plugin-transform-regenerator"
@@ -1983,6 +4111,24 @@
       "group": "only-plugin",
       "name": "@babel/plugin-transform-spread",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "only-plugin/-babel-plugin-transform-spread",
+      "signals": [
+        "@babel/plugin-transform-spread"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-spread",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "only-plugin/-babel-plugin-transform-spread",
+      "signals": [
+        "@babel/plugin-transform-spread"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-spread",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "only-plugin/-babel-plugin-transform-spread",
       "signals": [
         "@babel/plugin-transform-spread"

--- a/core/scripts/legacy-javascript/summary-signals.json
+++ b/core/scripts/legacy-javascript/summary-signals.json
@@ -1,5 +1,5 @@
 {
-  "totalSignals": 267,
+  "totalSignals": 801,
   "variantsMissingSignals": [
     "baseline_true_bugfixes_false",
     "baseline_true_bugfixes_true"
@@ -103,9 +103,221 @@
       ]
     },
     {
+      "group": "all-legacy-polyfills",
+      "name": "all-legacy-polyfills-core-js-3",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
+      "signals": [
+        "Array.prototype.at",
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.findLast",
+        "Array.prototype.findLastIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Array.prototype.unshift",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.create",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.hasOwn",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Promise.any",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.matchAll",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.replaceAll",
+        "String.prototype.startsWith",
+        "String.prototype.substr",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled"
+      ]
+    },
+    {
+      "group": "all-legacy-polyfills",
+      "name": "all-legacy-polyfills-core-js-3",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
+      "signals": [
+        "Array.prototype.at",
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.findLast",
+        "Array.prototype.findLastIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Array.prototype.unshift",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.create",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.hasOwn",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Promise.any",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.matchAll",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.replaceAll",
+        "String.prototype.startsWith",
+        "String.prototype.substr",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled"
+      ]
+    },
+    {
       "group": "core-js-3-only-polyfill",
       "name": "Array.from",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-from",
+      "signals": [
+        "Array.from"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.from",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-from",
+      "signals": [
+        "Array.from"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.from",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-from",
       "signals": [
         "Array.from"
@@ -122,8 +334,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.isArray",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-isArray",
+      "signals": [
+        "Array.isArray"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.isArray",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-isArray",
+      "signals": [
+        "Array.isArray"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.of",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-of",
+      "signals": [
+        "Array.of"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.of",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-of",
+      "signals": [
+        "Array.of"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.of",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-of",
       "signals": [
         "Array.of"
@@ -140,8 +388,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.at",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-at",
+      "signals": [
+        "Array.prototype.at"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.at",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-at",
+      "signals": [
+        "Array.prototype.at"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.concat",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-concat",
+      "signals": [
+        "Array.prototype.concat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.concat",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-concat",
+      "signals": [
+        "Array.prototype.concat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.concat",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-concat",
       "signals": [
         "Array.prototype.concat"
@@ -158,8 +442,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.copyWithin",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
+      "signals": [
+        "Array.prototype.copyWithin"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.copyWithin",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
+      "signals": [
+        "Array.prototype.copyWithin"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.every",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-every",
+      "signals": [
+        "Array.prototype.every"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.every",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-every",
+      "signals": [
+        "Array.prototype.every"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.every",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-every",
       "signals": [
         "Array.prototype.every"
@@ -176,8 +496,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.fill",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-fill",
+      "signals": [
+        "Array.prototype.fill"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.fill",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-fill",
+      "signals": [
+        "Array.prototype.fill"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.filter",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-filter",
+      "signals": [
+        "Array.prototype.filter"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.filter",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-filter",
+      "signals": [
+        "Array.prototype.filter"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.filter",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-filter",
       "signals": [
         "Array.prototype.filter"
@@ -194,8 +550,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.find",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-find",
+      "signals": [
+        "Array.prototype.find"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.find",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-find",
+      "signals": [
+        "Array.prototype.find"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findIndex",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
+      "signals": [
+        "Array.prototype.findIndex"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findIndex",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
+      "signals": [
+        "Array.prototype.findIndex"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findIndex",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
       "signals": [
         "Array.prototype.findIndex"
@@ -212,8 +604,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findLast",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
+      "signals": [
+        "Array.prototype.findLast"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findLast",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
+      "signals": [
+        "Array.prototype.findLast"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findLastIndex",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
+      "signals": [
+        "Array.prototype.findLastIndex"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findLastIndex",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
+      "signals": [
+        "Array.prototype.findLastIndex"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.findLastIndex",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
       "signals": [
         "Array.prototype.findLastIndex"
@@ -230,8 +658,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.flat",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-flat",
+      "signals": [
+        "Array.prototype.flat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.flat",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-flat",
+      "signals": [
+        "Array.prototype.flat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.flatMap",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
+      "signals": [
+        "Array.prototype.flatMap"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.flatMap",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
+      "signals": [
+        "Array.prototype.flatMap"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.flatMap",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
       "signals": [
         "Array.prototype.flatMap"
@@ -248,8 +712,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.forEach",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
+      "signals": [
+        "Array.prototype.forEach"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.forEach",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
+      "signals": [
+        "Array.prototype.forEach"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.includes",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-includes",
+      "signals": [
+        "Array.prototype.includes"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.includes",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-includes",
+      "signals": [
+        "Array.prototype.includes"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.includes",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-includes",
       "signals": [
         "Array.prototype.includes"
@@ -266,8 +766,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.indexOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
+      "signals": [
+        "Array.prototype.indexOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.indexOf",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
+      "signals": [
+        "Array.prototype.indexOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.join",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-join",
+      "signals": [
+        "Array.prototype.join"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.join",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-join",
+      "signals": [
+        "Array.prototype.join"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.join",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-join",
       "signals": [
         "Array.prototype.join"
@@ -284,8 +820,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.map",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-map",
+      "signals": [
+        "Array.prototype.map"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.map",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-map",
+      "signals": [
+        "Array.prototype.map"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.slice",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-slice",
+      "signals": [
+        "Array.prototype.slice"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.slice",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-slice",
+      "signals": [
+        "Array.prototype.slice"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.slice",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-slice",
       "signals": [
         "Array.prototype.slice"
@@ -302,8 +874,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.some",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-some",
+      "signals": [
+        "Array.prototype.some"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.some",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-some",
+      "signals": [
+        "Array.prototype.some"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.sort",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-sort",
+      "signals": [
+        "Array.prototype.sort"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.sort",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-sort",
+      "signals": [
+        "Array.prototype.sort"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.sort",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-sort",
       "signals": [
         "Array.prototype.sort"
@@ -320,8 +928,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.unshift",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
+      "signals": [
+        "Array.prototype.unshift"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Array.prototype.unshift",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
+      "signals": [
+        "Array.prototype.unshift"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.acosh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-acosh",
+      "signals": [
+        "Math.acosh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.acosh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-acosh",
+      "signals": [
+        "Math.acosh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.acosh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-acosh",
       "signals": [
         "Math.acosh"
@@ -338,8 +982,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Math.asinh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-asinh",
+      "signals": [
+        "Math.asinh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.asinh",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Math-asinh",
+      "signals": [
+        "Math.asinh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.atanh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-atanh",
+      "signals": [
+        "Math.atanh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.atanh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-atanh",
+      "signals": [
+        "Math.atanh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.atanh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-atanh",
       "signals": [
         "Math.atanh"
@@ -356,8 +1036,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Math.cbrt",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-cbrt",
+      "signals": [
+        "Math.cbrt"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.cbrt",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Math-cbrt",
+      "signals": [
+        "Math.cbrt"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.clz32",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-clz32",
+      "signals": [
+        "Math.clz32"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.clz32",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-clz32",
+      "signals": [
+        "Math.clz32"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.clz32",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-clz32",
       "signals": [
         "Math.clz32"
@@ -374,8 +1090,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Math.cosh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-cosh",
+      "signals": [
+        "Math.cosh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.cosh",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Math-cosh",
+      "signals": [
+        "Math.cosh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.expm1",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-expm1",
+      "signals": [
+        "Math.expm1"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.expm1",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-expm1",
+      "signals": [
+        "Math.expm1"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.expm1",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-expm1",
       "signals": [
         "Math.expm1"
@@ -392,8 +1144,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Math.fround",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-fround",
+      "signals": [
+        "Math.fround"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.fround",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Math-fround",
+      "signals": [
+        "Math.fround"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.hypot",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-hypot",
+      "signals": [
+        "Math.hypot"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.hypot",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-hypot",
+      "signals": [
+        "Math.hypot"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.hypot",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-hypot",
       "signals": [
         "Math.hypot"
@@ -410,8 +1198,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Math.imul",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-imul",
+      "signals": [
+        "Math.imul"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.imul",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Math-imul",
+      "signals": [
+        "Math.imul"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.log10",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-log10",
+      "signals": [
+        "Math.log10"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log10",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-log10",
+      "signals": [
+        "Math.log10"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log10",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-log10",
       "signals": [
         "Math.log10"
@@ -428,8 +1252,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Math.log1p",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-log1p",
+      "signals": [
+        "Math.log1p"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log1p",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Math-log1p",
+      "signals": [
+        "Math.log1p"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.log2",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-log2",
+      "signals": [
+        "Math.log2"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log2",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-log2",
+      "signals": [
+        "Math.log2"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.log2",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-log2",
       "signals": [
         "Math.log2"
@@ -446,8 +1306,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Math.sign",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-sign",
+      "signals": [
+        "Math.sign"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.sign",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Math-sign",
+      "signals": [
+        "Math.sign"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.sinh",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-sinh",
+      "signals": [
+        "Math.sinh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.sinh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-sinh",
+      "signals": [
+        "Math.sinh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.sinh",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-sinh",
       "signals": [
         "Math.sinh"
@@ -464,8 +1360,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Math.tanh",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-tanh",
+      "signals": [
+        "Math.tanh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.tanh",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Math-tanh",
+      "signals": [
+        "Math.tanh"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Math.trunc",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Math-trunc",
+      "signals": [
+        "Math.trunc"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.trunc",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Math-trunc",
+      "signals": [
+        "Math.trunc"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Math.trunc",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Math-trunc",
       "signals": [
         "Math.trunc"
@@ -482,8 +1414,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.assign",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-assign",
+      "signals": [
+        "Object.assign"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.assign",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-assign",
+      "signals": [
+        "Object.assign"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.create",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-create",
+      "signals": [
+        "Object.create"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.create",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-create",
+      "signals": [
+        "Object.create"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.create",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-create",
       "signals": [
         "Object.create"
@@ -500,8 +1468,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.entries",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-entries",
+      "signals": [
+        "Object.entries"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.entries",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-entries",
+      "signals": [
+        "Object.entries"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.freeze",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-freeze",
+      "signals": [
+        "Object.freeze"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.freeze",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-freeze",
+      "signals": [
+        "Object.freeze"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.freeze",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-freeze",
       "signals": [
         "Object.freeze"
@@ -518,8 +1522,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.fromEntries",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-fromEntries",
+      "signals": [
+        "Object.fromEntries"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.fromEntries",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-fromEntries",
+      "signals": [
+        "Object.fromEntries"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.getOwnPropertyDescriptor",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
+      "signals": [
+        "Object.getOwnPropertyDescriptor"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getOwnPropertyDescriptor",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
+      "signals": [
+        "Object.getOwnPropertyDescriptor"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getOwnPropertyDescriptor",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
       "signals": [
         "Object.getOwnPropertyDescriptor"
@@ -536,8 +1576,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.getOwnPropertyDescriptors",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
+      "signals": [
+        "Object.getOwnPropertyDescriptors"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getOwnPropertyDescriptors",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
+      "signals": [
+        "Object.getOwnPropertyDescriptors"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.getPrototypeOf",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
+      "signals": [
+        "Object.getPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getPrototypeOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
+      "signals": [
+        "Object.getPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.getPrototypeOf",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
       "signals": [
         "Object.getPrototypeOf"
@@ -554,8 +1630,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.hasOwn",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-hasOwn",
+      "signals": [
+        "Object.hasOwn"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.hasOwn",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-hasOwn",
+      "signals": [
+        "Object.hasOwn"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.is",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-is",
+      "signals": [
+        "Object.is"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.is",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-is",
+      "signals": [
+        "Object.is"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.is",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-is",
       "signals": [
         "Object.is"
@@ -572,8 +1684,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.isExtensible",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-isExtensible",
+      "signals": [
+        "Object.isExtensible"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isExtensible",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-isExtensible",
+      "signals": [
+        "Object.isExtensible"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.isFrozen",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-isFrozen",
+      "signals": [
+        "Object.isFrozen"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isFrozen",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-isFrozen",
+      "signals": [
+        "Object.isFrozen"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isFrozen",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-isFrozen",
       "signals": [
         "Object.isFrozen"
@@ -590,8 +1738,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.isSealed",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-isSealed",
+      "signals": [
+        "Object.isSealed"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.isSealed",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-isSealed",
+      "signals": [
+        "Object.isSealed"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.keys",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-keys",
+      "signals": [
+        "Object.keys"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.keys",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-keys",
+      "signals": [
+        "Object.keys"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.keys",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-keys",
       "signals": [
         "Object.keys"
@@ -608,8 +1792,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.preventExtensions",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-preventExtensions",
+      "signals": [
+        "Object.preventExtensions"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.preventExtensions",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-preventExtensions",
+      "signals": [
+        "Object.preventExtensions"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.seal",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-seal",
+      "signals": [
+        "Object.seal"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.seal",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-seal",
+      "signals": [
+        "Object.seal"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.seal",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-seal",
       "signals": [
         "Object.seal"
@@ -626,8 +1846,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Object.setPrototypeOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
+      "signals": [
+        "Object.setPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.setPrototypeOf",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
+      "signals": [
+        "Object.setPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Object.values",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Object-values",
+      "signals": [
+        "Object.values"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.values",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Object-values",
+      "signals": [
+        "Object.values"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Object.values",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Object-values",
       "signals": [
         "Object.values"
@@ -644,8 +1900,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Promise.allSettled",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Promise-allSettled",
+      "signals": [
+        "Promise.allSettled"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Promise.allSettled",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Promise-allSettled",
+      "signals": [
+        "Promise.allSettled"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Promise.any",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Promise-any",
+      "signals": [
+        "Promise.any"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Promise.any",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Promise-any",
+      "signals": [
+        "Promise.any"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Promise.any",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Promise-any",
       "signals": [
         "Promise.any"
@@ -662,8 +1954,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Reflect.apply",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-apply",
+      "signals": [
+        "Reflect.apply"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.apply",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-apply",
+      "signals": [
+        "Reflect.apply"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Reflect.construct",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-construct",
+      "signals": [
+        "Reflect.construct"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.construct",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-construct",
+      "signals": [
+        "Reflect.construct"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.construct",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-construct",
       "signals": [
         "Reflect.construct"
@@ -680,8 +2008,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Reflect.deleteProperty",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
+      "signals": [
+        "Reflect.deleteProperty"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.deleteProperty",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
+      "signals": [
+        "Reflect.deleteProperty"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Reflect.get",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-get",
+      "signals": [
+        "Reflect.get"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.get",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-get",
+      "signals": [
+        "Reflect.get"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.get",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-get",
       "signals": [
         "Reflect.get"
@@ -698,8 +2062,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Reflect.getOwnPropertyDescriptor",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
+      "signals": [
+        "Reflect.getOwnPropertyDescriptor"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.getOwnPropertyDescriptor",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
+      "signals": [
+        "Reflect.getOwnPropertyDescriptor"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Reflect.getPrototypeOf",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
+      "signals": [
+        "Reflect.getPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.getPrototypeOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
+      "signals": [
+        "Reflect.getPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.getPrototypeOf",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
       "signals": [
         "Reflect.getPrototypeOf"
@@ -716,8 +2116,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Reflect.has",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-has",
+      "signals": [
+        "Reflect.has"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.has",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-has",
+      "signals": [
+        "Reflect.has"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Reflect.isExtensible",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
+      "signals": [
+        "Reflect.isExtensible"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.isExtensible",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
+      "signals": [
+        "Reflect.isExtensible"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.isExtensible",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
       "signals": [
         "Reflect.isExtensible"
@@ -734,8 +2170,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Reflect.ownKeys",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
+      "signals": [
+        "Reflect.ownKeys"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.ownKeys",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
+      "signals": [
+        "Reflect.ownKeys"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Reflect.preventExtensions",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
+      "signals": [
+        "Reflect.preventExtensions"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.preventExtensions",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
+      "signals": [
+        "Reflect.preventExtensions"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.preventExtensions",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
       "signals": [
         "Reflect.preventExtensions"
@@ -752,8 +2224,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "Reflect.set",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-set",
+      "signals": [
+        "Reflect.set"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.set",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-set",
+      "signals": [
+        "Reflect.set"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "Reflect.setPrototypeOf",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
+      "signals": [
+        "Reflect.setPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.setPrototypeOf",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
+      "signals": [
+        "Reflect.setPrototypeOf"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "Reflect.setPrototypeOf",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
       "signals": [
         "Reflect.setPrototypeOf"
@@ -770,8 +2278,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "String.fromCodePoint",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-fromCodePoint",
+      "signals": [
+        "String.fromCodePoint"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.fromCodePoint",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/String-fromCodePoint",
+      "signals": [
+        "String.fromCodePoint"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "String.prototype.codePointAt",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
+      "signals": [
+        "String.prototype.codePointAt"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.codePointAt",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
+      "signals": [
+        "String.prototype.codePointAt"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.codePointAt",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
       "signals": [
         "String.prototype.codePointAt"
@@ -788,8 +2332,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.endsWith",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
+      "signals": [
+        "String.prototype.endsWith"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.endsWith",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
+      "signals": [
+        "String.prototype.endsWith"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "String.prototype.includes",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-includes",
+      "signals": [
+        "String.prototype.includes"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.includes",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-includes",
+      "signals": [
+        "String.prototype.includes"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.includes",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-includes",
       "signals": [
         "String.prototype.includes"
@@ -806,8 +2386,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.link",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-link",
+      "signals": [
+        "String.prototype.link"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.link",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-link",
+      "signals": [
+        "String.prototype.link"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "String.prototype.matchAll",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
+      "signals": [
+        "String.prototype.matchAll"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.matchAll",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
+      "signals": [
+        "String.prototype.matchAll"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.matchAll",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
       "signals": [
         "String.prototype.matchAll"
@@ -824,8 +2440,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.padEnd",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-padEnd",
+      "signals": [
+        "String.prototype.padEnd"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.padEnd",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-padEnd",
+      "signals": [
+        "String.prototype.padEnd"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "String.prototype.padStart",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-padStart",
+      "signals": [
+        "String.prototype.padStart"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.padStart",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-padStart",
+      "signals": [
+        "String.prototype.padStart"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.padStart",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-padStart",
       "signals": [
         "String.prototype.padStart"
@@ -842,8 +2494,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.repeat",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-repeat",
+      "signals": [
+        "String.prototype.repeat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.repeat",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-repeat",
+      "signals": [
+        "String.prototype.repeat"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "String.prototype.replaceAll",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
+      "signals": [
+        "String.prototype.replaceAll"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.replaceAll",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
+      "signals": [
+        "String.prototype.replaceAll"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.replaceAll",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
       "signals": [
         "String.prototype.replaceAll"
@@ -860,8 +2548,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.startsWith",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
+      "signals": [
+        "String.prototype.startsWith"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.startsWith",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
+      "signals": [
+        "String.prototype.startsWith"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "String.prototype.substr",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-substr",
+      "signals": [
+        "String.prototype.substr"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.substr",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-substr",
+      "signals": [
+        "String.prototype.substr"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.substr",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-substr",
       "signals": [
         "String.prototype.substr"
@@ -878,8 +2602,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trim",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trim",
+      "signals": [
+        "String.prototype.trim"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trim",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trim",
+      "signals": [
+        "String.prototype.trim"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trimEnd",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
+      "signals": [
+        "String.prototype.trimEnd"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trimEnd",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
+      "signals": [
+        "String.prototype.trimEnd"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trimEnd",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
       "signals": [
         "String.prototype.trimEnd"
@@ -896,8 +2656,44 @@
     },
     {
       "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trimStart",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
+      "signals": [
+        "String.prototype.trimStart"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.prototype.trimStart",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
+      "signals": [
+        "String.prototype.trimStart"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
       "name": "String.raw",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-only-polyfill/String-raw",
+      "signals": [
+        "String.raw"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.raw",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-only-polyfill/String-raw",
+      "signals": [
+        "String.raw"
+      ]
+    },
+    {
+      "group": "core-js-3-only-polyfill",
+      "name": "String.raw",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-only-polyfill/String-raw",
       "signals": [
         "String.raw"
@@ -999,8 +2795,210 @@
     },
     {
       "group": "core-js-3-preset-env",
+      "name": "baseline_false_bugfixes_false",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
+      "signals": [
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.create",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.startsWith",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled",
+        "Promise.any",
+        "String.prototype.matchAll",
+        "String.prototype.replaceAll",
+        "@babel/plugin-transform-regenerator",
+        "@babel/plugin-transform-spread",
+        "@babel/plugin-transform-classes"
+      ]
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_false_bugfixes_false",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
+      "signals": [
+        "Object.create",
+        "Array.prototype.concat",
+        "Array.prototype.copyWithin",
+        "Array.prototype.every",
+        "Array.prototype.fill",
+        "Array.prototype.filter",
+        "Array.prototype.find",
+        "Array.prototype.findIndex",
+        "Array.prototype.flat",
+        "Array.prototype.flatMap",
+        "Array.prototype.forEach",
+        "Array.from",
+        "Array.prototype.includes",
+        "Array.prototype.indexOf",
+        "Array.isArray",
+        "Array.prototype.join",
+        "Array.prototype.map",
+        "Array.of",
+        "Array.prototype.slice",
+        "Array.prototype.some",
+        "Array.prototype.sort",
+        "Math.acosh",
+        "Math.asinh",
+        "Math.atanh",
+        "Math.cbrt",
+        "Math.clz32",
+        "Math.cosh",
+        "Math.expm1",
+        "Math.fround",
+        "Math.hypot",
+        "Math.imul",
+        "Math.log10",
+        "Math.log1p",
+        "Math.log2",
+        "Math.sign",
+        "Math.sinh",
+        "Math.tanh",
+        "Math.trunc",
+        "Object.assign",
+        "Object.entries",
+        "Object.freeze",
+        "Object.fromEntries",
+        "Object.getOwnPropertyDescriptor",
+        "Object.getOwnPropertyDescriptors",
+        "Object.getPrototypeOf",
+        "Object.is",
+        "Object.isExtensible",
+        "Object.isFrozen",
+        "Object.isSealed",
+        "Object.keys",
+        "Object.preventExtensions",
+        "Object.seal",
+        "Object.setPrototypeOf",
+        "Object.values",
+        "Reflect.apply",
+        "Reflect.construct",
+        "Reflect.deleteProperty",
+        "Reflect.get",
+        "Reflect.getOwnPropertyDescriptor",
+        "Reflect.getPrototypeOf",
+        "Reflect.has",
+        "Reflect.isExtensible",
+        "Reflect.ownKeys",
+        "Reflect.preventExtensions",
+        "Reflect.set",
+        "Reflect.setPrototypeOf",
+        "String.prototype.codePointAt",
+        "String.prototype.endsWith",
+        "String.fromCodePoint",
+        "String.prototype.includes",
+        "String.prototype.padEnd",
+        "String.prototype.padStart",
+        "String.raw",
+        "String.prototype.repeat",
+        "String.prototype.startsWith",
+        "String.prototype.trim",
+        "String.prototype.trimEnd",
+        "String.prototype.trimStart",
+        "String.prototype.link",
+        "Promise.allSettled",
+        "Promise.any",
+        "String.prototype.matchAll",
+        "String.prototype.replaceAll",
+        "@babel/plugin-transform-regenerator",
+        "@babel/plugin-transform-spread",
+        "@babel/plugin-transform-classes"
+      ]
+    },
+    {
+      "group": "core-js-3-preset-env",
       "name": "baseline_true_bugfixes_false",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
+      "signals": []
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_true_bugfixes_false",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
+      "signals": []
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_true_bugfixes_false",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
       "signals": []
     },
@@ -1012,9 +3010,41 @@
       "signals": []
     },
     {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_true_bugfixes_true",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
+      "signals": []
+    },
+    {
+      "group": "core-js-3-preset-env",
+      "name": "baseline_true_bugfixes_true",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
+      "signals": []
+    },
+    {
       "group": "only-plugin",
       "name": "@babel/plugin-transform-classes",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "only-plugin/-babel-plugin-transform-classes",
+      "signals": [
+        "@babel/plugin-transform-classes"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-classes",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "only-plugin/-babel-plugin-transform-classes",
+      "signals": [
+        "@babel/plugin-transform-classes"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-classes",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "only-plugin/-babel-plugin-transform-classes",
       "signals": [
         "@babel/plugin-transform-classes"
@@ -1031,8 +3061,44 @@
     },
     {
       "group": "only-plugin",
+      "name": "@babel/plugin-transform-regenerator",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "only-plugin/-babel-plugin-transform-regenerator",
+      "signals": [
+        "@babel/plugin-transform-regenerator"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-regenerator",
+      "bundle": "main.bundle.esbuild.min.js",
+      "dir": "only-plugin/-babel-plugin-transform-regenerator",
+      "signals": [
+        "@babel/plugin-transform-regenerator"
+      ]
+    },
+    {
+      "group": "only-plugin",
       "name": "@babel/plugin-transform-spread",
       "bundle": "main.bundle.browserify.min.js",
+      "dir": "only-plugin/-babel-plugin-transform-spread",
+      "signals": [
+        "@babel/plugin-transform-spread"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-spread",
+      "bundle": "main.bundle.esbuild.js",
+      "dir": "only-plugin/-babel-plugin-transform-spread",
+      "signals": [
+        "@babel/plugin-transform-spread"
+      ]
+    },
+    {
+      "group": "only-plugin",
+      "name": "@babel/plugin-transform-spread",
+      "bundle": "main.bundle.esbuild.min.js",
       "dir": "only-plugin/-babel-plugin-transform-spread",
       "signals": [
         "@babel/plugin-transform-spread"

--- a/core/scripts/legacy-javascript/yarn.lock
+++ b/core/scripts/legacy-javascript/yarn.lock
@@ -858,6 +858,131 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@esbuild/aix-ppc64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz#c33cf6bbee34975626b01b80451cbb72b4c6c91d"
+  integrity sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==
+
+"@esbuild/android-arm64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz#ea766015c7d2655164f22100d33d7f0308a28d6d"
+  integrity sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==
+
+"@esbuild/android-arm@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.1.tgz#e84d2bf2fe2e6177a0facda3a575b2139fd3cb9c"
+  integrity sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==
+
+"@esbuild/android-x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.1.tgz#58337bee3bc6d78d10425e5500bd11370cfdfbed"
+  integrity sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==
+
+"@esbuild/darwin-arm64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz#a46805c1c585d451aa83be72500bd6e8495dd591"
+  integrity sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==
+
+"@esbuild/darwin-x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz#0643e003bb238c63fc93ddbee7d26a003be3cd98"
+  integrity sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==
+
+"@esbuild/freebsd-arm64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz#cff18da5469c09986b93e87979de5d6872fe8f8e"
+  integrity sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==
+
+"@esbuild/freebsd-x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz#362fc09c2de14987621c1878af19203c46365dde"
+  integrity sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==
+
+"@esbuild/linux-arm64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz#aa90d5b02efc97a271e124e6d1cea490634f7498"
+  integrity sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==
+
+"@esbuild/linux-arm@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz#dfcefcbac60a20918b19569b4b657844d39db35a"
+  integrity sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==
+
+"@esbuild/linux-ia32@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz#6f9527077ccb7953ed2af02e013d4bac69f13754"
+  integrity sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==
+
+"@esbuild/linux-loong64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz#287d2412a5456e5860c2839d42a4b51284d1697c"
+  integrity sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==
+
+"@esbuild/linux-mips64el@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz#530574b9e1bc5d20f7a4f44c5f045e26f3783d57"
+  integrity sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==
+
+"@esbuild/linux-ppc64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz#5d7e6b283a0b321ea42c6bc0abeb9eb99c1f5589"
+  integrity sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==
+
+"@esbuild/linux-riscv64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz#14fa0cd073c26b4ee2465d18cd1e18eea7859fa8"
+  integrity sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==
+
+"@esbuild/linux-s390x@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz#e677b4b9d1b384098752266ccaa0d52a420dc1aa"
+  integrity sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==
+
+"@esbuild/linux-x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz#f1c796b78fff5ce393658313e8c58613198d9954"
+  integrity sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==
+
+"@esbuild/netbsd-arm64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz#0d280b7dfe3973f111b02d5fe9f3063b92796d29"
+  integrity sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==
+
+"@esbuild/netbsd-x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz#be663893931a4bb3f3a009c5cc24fa9681cc71c0"
+  integrity sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==
+
+"@esbuild/openbsd-arm64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz#d9021b884233673a05dc1cc26de0bf325d824217"
+  integrity sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==
+
+"@esbuild/openbsd-x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz#9f1dc1786ed2e2938c404b06bcc48be9a13250de"
+  integrity sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==
+
+"@esbuild/sunos-x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz#89aac24a4b4115959b3f790192cf130396696c27"
+  integrity sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==
+
+"@esbuild/win32-arm64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz#354358647a6ea98ea6d243bf48bdd7a434999582"
+  integrity sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==
+
+"@esbuild/win32-ia32@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz#8cea7340f2647eba951a041dc95651e3908cd4cb"
+  integrity sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==
+
+"@esbuild/win32-x64@0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz#7d79922cb2d88f9048f06393dbf62d2e4accb584"
+  integrity sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
@@ -1455,6 +1580,37 @@ elliptic@^6.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+esbuild@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.1.tgz#a16b8d070b6ad4871935277bda6ccfe852e3fa2f"
+  integrity sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.25.1"
+    "@esbuild/android-arm" "0.25.1"
+    "@esbuild/android-arm64" "0.25.1"
+    "@esbuild/android-x64" "0.25.1"
+    "@esbuild/darwin-arm64" "0.25.1"
+    "@esbuild/darwin-x64" "0.25.1"
+    "@esbuild/freebsd-arm64" "0.25.1"
+    "@esbuild/freebsd-x64" "0.25.1"
+    "@esbuild/linux-arm" "0.25.1"
+    "@esbuild/linux-arm64" "0.25.1"
+    "@esbuild/linux-ia32" "0.25.1"
+    "@esbuild/linux-loong64" "0.25.1"
+    "@esbuild/linux-mips64el" "0.25.1"
+    "@esbuild/linux-ppc64" "0.25.1"
+    "@esbuild/linux-riscv64" "0.25.1"
+    "@esbuild/linux-s390x" "0.25.1"
+    "@esbuild/linux-x64" "0.25.1"
+    "@esbuild/netbsd-arm64" "0.25.1"
+    "@esbuild/netbsd-x64" "0.25.1"
+    "@esbuild/openbsd-arm64" "0.25.1"
+    "@esbuild/openbsd-x64" "0.25.1"
+    "@esbuild/sunos-x64" "0.25.1"
+    "@esbuild/win32-arm64" "0.25.1"
+    "@esbuild/win32-ia32" "0.25.1"
+    "@esbuild/win32-x64" "0.25.1"
 
 escalade@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
Adds esbuild to the test suite, and adjusts the regex to cover unminified esbuild bundles

note: esbuild has its own transforms it applies, but that is not covered here. only detecting core-js polyfills that esbuild has bundled.