### PR TITLE
core(legacy-javascript): rework/revert some unminified bundle detection

### DIFF
--- a/core/lib/legacy-javascript/legacy-javascript.js
+++ b/core/lib/legacy-javascript/legacy-javascript.js
@@ -105,8 +105,6 @@ class CodePatternMatcher {
 function buildPolyfillExpression(object, property, coreJs3Module) {
   const qt = (/** @type {string} */ token) =>
     `['"]${token}['"]`; // don't worry about matching string delims
-  const kebabCaseToCamelCase = (/** @type {string} */ str) =>
-    str.replace(/(-\w)/g, m => m[1].toUpperCase());
 
   let expression = '';
 
@@ -158,12 +156,7 @@ function buildPolyfillExpression(object, property, coreJs3Module) {
 
   // Un-minified code may have module names.
   // core-js/modules/es.object.is-frozen
-  expression += `|core-js/modules/${coreJs3Module}(?:\\.js)?"`;
-  // rollup unminified output for commonjs modules.
-  // ex: es.reflect.own-keys -> function requireEs_reflect_ownKeys ()
-  let rollupSlug = kebabCaseToCamelCase(coreJs3Module).replaceAll('.', '_');
-  rollupSlug = rollupSlug[0].toUpperCase() + rollupSlug.slice(1);
-  expression += `|require${rollupSlug} \\(`;
+  expression += `|${coreJs3Module.replaceAll('.', '\\.')}(?:\\.js)?"`;
 
   return expression;
 }

--- a/core/scripts/legacy-javascript/run.js
+++ b/core/scripts/legacy-javascript/run.js
@@ -185,7 +185,9 @@ async function processVariant(options) {
       'main.bundle.browserify.min.js',
       'main.bundle.esbuild.js',
       'main.bundle.esbuild.min.js',
-      'main.bundle.rollup.js',
+      // This could be detected, but it too greatly hurts performance.
+      // See: https://github.com/GoogleChrome/lighthouse/pull/16394
+      // 'main.bundle.rollup.js',
       'main.bundle.rollup.min.js',
     ];
     for (const bundle of bundles) {

--- a/core/scripts/legacy-javascript/summary-signals-nomaps.json
+++ b/core/scripts/legacy-javascript/summary-signals-nomaps.json
@@ -1,5 +1,5 @@
 {
-  "totalSignals": 1385,
+  "totalSignals": 1210,
   "variantsMissingSignals": [
     "baseline_true_bugfixes_false",
     "baseline_true_bugfixes_true"
@@ -384,100 +384,6 @@
     {
       "group": "all-legacy-polyfills",
       "name": "all-legacy-polyfills-core-js-3",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
-      "signals": [
-        "Array.from",
-        "Array.isArray",
-        "Array.of",
-        "Array.prototype.at",
-        "Array.prototype.concat",
-        "Array.prototype.copyWithin",
-        "Array.prototype.every",
-        "Array.prototype.fill",
-        "Array.prototype.filter",
-        "Array.prototype.find",
-        "Array.prototype.findIndex",
-        "Array.prototype.findLast",
-        "Array.prototype.findLastIndex",
-        "Array.prototype.flat",
-        "Array.prototype.flatMap",
-        "Array.prototype.forEach",
-        "Array.prototype.includes",
-        "Array.prototype.indexOf",
-        "Array.prototype.join",
-        "Array.prototype.map",
-        "Array.prototype.slice",
-        "Array.prototype.some",
-        "Array.prototype.sort",
-        "Array.prototype.unshift",
-        "Math.acosh",
-        "Math.asinh",
-        "Math.atanh",
-        "Math.cbrt",
-        "Math.clz32",
-        "Math.cosh",
-        "Math.expm1",
-        "Math.fround",
-        "Math.hypot",
-        "Math.imul",
-        "Math.log10",
-        "Math.log1p",
-        "Math.log2",
-        "Math.sign",
-        "Math.sinh",
-        "Math.tanh",
-        "Math.trunc",
-        "Object.assign",
-        "Object.create",
-        "Object.entries",
-        "Object.freeze",
-        "Object.fromEntries",
-        "Object.getOwnPropertyDescriptor",
-        "Object.getOwnPropertyDescriptors",
-        "Object.getPrototypeOf",
-        "Object.hasOwn",
-        "Object.is",
-        "Object.isExtensible",
-        "Object.isFrozen",
-        "Object.isSealed",
-        "Object.keys",
-        "Object.preventExtensions",
-        "Object.seal",
-        "Object.setPrototypeOf",
-        "Object.values",
-        "Promise.allSettled",
-        "Promise.any",
-        "Reflect.apply",
-        "Reflect.construct",
-        "Reflect.deleteProperty",
-        "Reflect.get",
-        "Reflect.getOwnPropertyDescriptor",
-        "Reflect.getPrototypeOf",
-        "Reflect.has",
-        "Reflect.isExtensible",
-        "Reflect.ownKeys",
-        "Reflect.preventExtensions",
-        "Reflect.setPrototypeOf",
-        "String.fromCodePoint",
-        "String.prototype.codePointAt",
-        "String.prototype.endsWith",
-        "String.prototype.includes",
-        "String.prototype.link",
-        "String.prototype.matchAll",
-        "String.prototype.repeat",
-        "String.prototype.replaceAll",
-        "String.prototype.startsWith",
-        "String.prototype.substr",
-        "String.prototype.trim",
-        "String.prototype.trimEnd",
-        "String.prototype.trimStart",
-        "String.raw"
-      ]
-    },
-    {
-      "group": "all-legacy-polyfills",
-      "name": "all-legacy-polyfills-core-js-3",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
       "signals": [
@@ -608,15 +514,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.from",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-from",
-      "signals": [
-        "Array.from"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.from",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-from",
       "signals": [
@@ -662,15 +559,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.isArray",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-isArray",
-      "signals": [
-        "Array.isArray"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.isArray",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-isArray",
       "signals": [
@@ -716,15 +604,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.of",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-of",
-      "signals": [
-        "Array.of"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.of",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-of",
       "signals": [
@@ -770,15 +649,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.at",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-at",
-      "signals": [
-        "Array.prototype.at"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.at",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-at",
       "signals": [
@@ -824,15 +694,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.concat",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-concat",
-      "signals": [
-        "Array.prototype.concat"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.concat",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-concat",
       "signals": [
@@ -878,15 +739,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.copyWithin",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
-      "signals": [
-        "Array.prototype.copyWithin"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.copyWithin",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
       "signals": [
@@ -932,15 +784,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.every",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-every",
-      "signals": [
-        "Array.prototype.every"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.every",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-every",
       "signals": [
@@ -986,15 +829,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.fill",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-fill",
-      "signals": [
-        "Array.prototype.fill"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.fill",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-fill",
       "signals": [
@@ -1040,15 +874,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.filter",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-filter",
-      "signals": [
-        "Array.prototype.filter"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.filter",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-filter",
       "signals": [
@@ -1094,15 +919,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.find",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-find",
-      "signals": [
-        "Array.prototype.find"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.find",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-find",
       "signals": [
@@ -1148,15 +964,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findIndex",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
-      "signals": [
-        "Array.prototype.findIndex"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.findIndex",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
       "signals": [
@@ -1202,15 +1009,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findLast",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
-      "signals": [
-        "Array.prototype.findLast"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.findLast",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
       "signals": [
@@ -1256,15 +1054,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findLastIndex",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
-      "signals": [
-        "Array.prototype.findLastIndex"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.findLastIndex",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
       "signals": [
@@ -1310,15 +1099,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.flat",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-flat",
-      "signals": [
-        "Array.prototype.flat"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.flat",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-flat",
       "signals": [
@@ -1364,15 +1144,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.flatMap",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
-      "signals": [
-        "Array.prototype.flatMap"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.flatMap",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
       "signals": [
@@ -1418,15 +1189,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.forEach",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
-      "signals": [
-        "Array.prototype.forEach"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.forEach",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
       "signals": [
@@ -1472,15 +1234,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.includes",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-includes",
-      "signals": [
-        "Array.prototype.includes"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.includes",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-includes",
       "signals": [
@@ -1526,15 +1279,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.indexOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
-      "signals": [
-        "Array.prototype.indexOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.indexOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
       "signals": [
@@ -1580,15 +1324,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.join",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-join",
-      "signals": [
-        "Array.prototype.join"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.join",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-join",
       "signals": [
@@ -1634,15 +1369,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.map",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-map",
-      "signals": [
-        "Array.prototype.map"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.map",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-map",
       "signals": [
@@ -1688,15 +1414,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.slice",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-slice",
-      "signals": [
-        "Array.prototype.slice"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.slice",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-slice",
       "signals": [
@@ -1742,15 +1459,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.some",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-some",
-      "signals": [
-        "Array.prototype.some"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.some",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-some",
       "signals": [
@@ -1796,15 +1504,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.sort",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-sort",
-      "signals": [
-        "Array.prototype.sort"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.sort",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-sort",
       "signals": [
@@ -1850,15 +1549,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.unshift",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
-      "signals": [
-        "Array.prototype.unshift"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.unshift",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
       "signals": [
@@ -1904,15 +1594,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.acosh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-acosh",
-      "signals": [
-        "Math.acosh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.acosh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-acosh",
       "signals": [
@@ -1958,15 +1639,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.asinh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-asinh",
-      "signals": [
-        "Math.asinh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.asinh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-asinh",
       "signals": [
@@ -2012,15 +1684,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.atanh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-atanh",
-      "signals": [
-        "Math.atanh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.atanh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-atanh",
       "signals": [
@@ -2066,15 +1729,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.cbrt",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-cbrt",
-      "signals": [
-        "Math.cbrt"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.cbrt",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-cbrt",
       "signals": [
@@ -2120,15 +1774,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.clz32",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-clz32",
-      "signals": [
-        "Math.clz32"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.clz32",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-clz32",
       "signals": [
@@ -2174,15 +1819,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.cosh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-cosh",
-      "signals": [
-        "Math.cosh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.cosh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-cosh",
       "signals": [
@@ -2228,15 +1864,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.expm1",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-expm1",
-      "signals": [
-        "Math.expm1"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.expm1",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-expm1",
       "signals": [
@@ -2282,15 +1909,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.fround",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-fround",
-      "signals": [
-        "Math.fround"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.fround",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-fround",
       "signals": [
@@ -2336,15 +1954,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.hypot",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-hypot",
-      "signals": [
-        "Math.hypot"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.hypot",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-hypot",
       "signals": [
@@ -2390,15 +1999,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.imul",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-imul",
-      "signals": [
-        "Math.imul"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.imul",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-imul",
       "signals": [
@@ -2444,15 +2044,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.log10",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-log10",
-      "signals": [
-        "Math.log10"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.log10",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-log10",
       "signals": [
@@ -2498,15 +2089,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.log1p",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-log1p",
-      "signals": [
-        "Math.log1p"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.log1p",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-log1p",
       "signals": [
@@ -2552,15 +2134,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.log2",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-log2",
-      "signals": [
-        "Math.log2"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.log2",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-log2",
       "signals": [
@@ -2606,15 +2179,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.sign",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-sign",
-      "signals": [
-        "Math.sign"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.sign",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-sign",
       "signals": [
@@ -2660,15 +2224,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.sinh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-sinh",
-      "signals": [
-        "Math.sinh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.sinh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-sinh",
       "signals": [
@@ -2714,15 +2269,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.tanh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-tanh",
-      "signals": [
-        "Math.tanh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.tanh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-tanh",
       "signals": [
@@ -2768,15 +2314,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.trunc",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-trunc",
-      "signals": [
-        "Math.trunc"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.trunc",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-trunc",
       "signals": [
@@ -2822,15 +2359,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.assign",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-assign",
-      "signals": [
-        "Object.assign"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.assign",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-assign",
       "signals": [
@@ -2876,15 +2404,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.create",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-create",
-      "signals": [
-        "Object.create"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.create",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-create",
       "signals": [
@@ -2930,15 +2449,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.entries",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-entries",
-      "signals": [
-        "Object.entries"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.entries",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-entries",
       "signals": [
@@ -2984,15 +2494,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.freeze",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-freeze",
-      "signals": [
-        "Object.freeze"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.freeze",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-freeze",
       "signals": [
@@ -3038,15 +2539,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.fromEntries",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-fromEntries",
-      "signals": [
-        "Object.fromEntries"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.fromEntries",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-fromEntries",
       "signals": [
@@ -3092,15 +2584,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.getOwnPropertyDescriptor",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
-      "signals": [
-        "Object.getOwnPropertyDescriptor"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.getOwnPropertyDescriptor",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
       "signals": [
@@ -3146,15 +2629,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.getOwnPropertyDescriptors",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
-      "signals": [
-        "Object.getOwnPropertyDescriptors"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.getOwnPropertyDescriptors",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
       "signals": [
@@ -3200,15 +2674,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.getPrototypeOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
-      "signals": [
-        "Object.getPrototypeOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.getPrototypeOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
       "signals": [
@@ -3254,15 +2719,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.hasOwn",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-hasOwn",
-      "signals": [
-        "Object.hasOwn"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.hasOwn",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-hasOwn",
       "signals": [
@@ -3308,15 +2764,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.is",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-is",
-      "signals": [
-        "Object.is"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.is",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-is",
       "signals": [
@@ -3362,15 +2809,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.isExtensible",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-isExtensible",
-      "signals": [
-        "Object.isExtensible"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.isExtensible",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-isExtensible",
       "signals": [
@@ -3416,15 +2854,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.isFrozen",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-isFrozen",
-      "signals": [
-        "Object.isFrozen"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.isFrozen",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-isFrozen",
       "signals": [
@@ -3470,15 +2899,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.isSealed",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-isSealed",
-      "signals": [
-        "Object.isSealed"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.isSealed",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-isSealed",
       "signals": [
@@ -3524,15 +2944,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.keys",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-keys",
-      "signals": [
-        "Object.keys"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.keys",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-keys",
       "signals": [
@@ -3578,15 +2989,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.preventExtensions",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-preventExtensions",
-      "signals": [
-        "Object.preventExtensions"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.preventExtensions",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-preventExtensions",
       "signals": [
@@ -3632,15 +3034,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.seal",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-seal",
-      "signals": [
-        "Object.seal"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.seal",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-seal",
       "signals": [
@@ -3686,15 +3079,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.setPrototypeOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
-      "signals": [
-        "Object.setPrototypeOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.setPrototypeOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
       "signals": [
@@ -3740,15 +3124,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.values",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-values",
-      "signals": [
-        "Object.values"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.values",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-values",
       "signals": [
@@ -3794,15 +3169,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Promise.allSettled",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Promise-allSettled",
-      "signals": [
-        "Promise.allSettled"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Promise.allSettled",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Promise-allSettled",
       "signals": [
@@ -3848,15 +3214,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Promise.any",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Promise-any",
-      "signals": [
-        "Promise.any"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Promise.any",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Promise-any",
       "signals": [
@@ -3902,15 +3259,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.apply",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-apply",
-      "signals": [
-        "Reflect.apply"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.apply",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-apply",
       "signals": [
@@ -3956,15 +3304,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.construct",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-construct",
-      "signals": [
-        "Reflect.construct"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.construct",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-construct",
       "signals": [
@@ -4010,15 +3349,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.deleteProperty",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
-      "signals": [
-        "Reflect.deleteProperty"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.deleteProperty",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
       "signals": [
@@ -4064,15 +3394,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.get",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-get",
-      "signals": [
-        "Reflect.get"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.get",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-get",
       "signals": [
@@ -4118,15 +3439,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.getOwnPropertyDescriptor",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
-      "signals": [
-        "Reflect.getOwnPropertyDescriptor"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.getOwnPropertyDescriptor",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
       "signals": [
@@ -4172,15 +3484,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.getPrototypeOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
-      "signals": [
-        "Reflect.getPrototypeOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.getPrototypeOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
       "signals": [
@@ -4226,15 +3529,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.has",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-has",
-      "signals": [
-        "Reflect.has"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.has",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-has",
       "signals": [
@@ -4280,15 +3574,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.isExtensible",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
-      "signals": [
-        "Reflect.isExtensible"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.isExtensible",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
       "signals": [
@@ -4334,15 +3619,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.ownKeys",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
-      "signals": [
-        "Reflect.ownKeys"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.ownKeys",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
       "signals": [
@@ -4388,15 +3664,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.preventExtensions",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
-      "signals": [
-        "Reflect.preventExtensions"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.preventExtensions",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
       "signals": [
@@ -4442,15 +3709,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.setPrototypeOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
-      "signals": [
-        "Reflect.setPrototypeOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.setPrototypeOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
       "signals": [
@@ -4496,15 +3754,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.fromCodePoint",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-fromCodePoint",
-      "signals": [
-        "String.fromCodePoint"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.fromCodePoint",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-fromCodePoint",
       "signals": [
@@ -4550,15 +3799,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.codePointAt",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
-      "signals": [
-        "String.prototype.codePointAt"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.codePointAt",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
       "signals": [
@@ -4604,15 +3844,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.endsWith",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
-      "signals": [
-        "String.prototype.endsWith"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.endsWith",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
       "signals": [
@@ -4658,15 +3889,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.includes",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-includes",
-      "signals": [
-        "String.prototype.includes"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.includes",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-includes",
       "signals": [
@@ -4712,15 +3934,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.link",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-link",
-      "signals": [
-        "String.prototype.link"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.link",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-link",
       "signals": [
@@ -4766,15 +3979,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.matchAll",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
-      "signals": [
-        "String.prototype.matchAll"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.matchAll",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
       "signals": [
@@ -4820,15 +4024,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.repeat",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-repeat",
-      "signals": [
-        "String.prototype.repeat"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.repeat",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-repeat",
       "signals": [
@@ -4874,15 +4069,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.replaceAll",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
-      "signals": [
-        "String.prototype.replaceAll"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.replaceAll",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
       "signals": [
@@ -4928,15 +4114,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.startsWith",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
-      "signals": [
-        "String.prototype.startsWith"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.startsWith",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
       "signals": [
@@ -4982,15 +4159,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.substr",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-substr",
-      "signals": [
-        "String.prototype.substr"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.substr",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-substr",
       "signals": [
@@ -5036,15 +4204,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trim",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-trim",
-      "signals": [
-        "String.prototype.trim"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.trim",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trim",
       "signals": [
@@ -5090,15 +4249,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trimEnd",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
-      "signals": [
-        "String.prototype.trimEnd"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.trimEnd",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
       "signals": [
@@ -5144,15 +4294,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trimStart",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
-      "signals": [
-        "String.prototype.trimStart"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.trimStart",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
       "signals": [
@@ -5198,15 +4339,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.raw",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-raw",
-      "signals": [
-        "String.raw"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.raw",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-raw",
       "signals": [
@@ -5277,6 +4409,7 @@
         "Object.setPrototypeOf",
         "Object.values",
         "Promise.allSettled",
+        "Promise.any",
         "Reflect.apply",
         "Reflect.construct",
         "Reflect.deleteProperty",
@@ -5293,7 +4426,9 @@
         "String.prototype.endsWith",
         "String.prototype.includes",
         "String.prototype.link",
+        "String.prototype.matchAll",
         "String.prototype.repeat",
+        "String.prototype.replaceAll",
         "String.prototype.startsWith",
         "String.prototype.trim",
         "String.prototype.trimEnd",
@@ -5577,17 +4712,6 @@
     {
       "group": "core-js-3-preset-env",
       "name": "baseline_false_bugfixes_false",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
-      "signals": [
-        "@babel/plugin-transform-classes",
-        "@babel/plugin-transform-regenerator",
-        "@babel/plugin-transform-spread"
-      ]
-    },
-    {
-      "group": "core-js-3-preset-env",
-      "name": "baseline_false_bugfixes_false",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
       "signals": [
@@ -5627,13 +4751,6 @@
     {
       "group": "core-js-3-preset-env",
       "name": "baseline_true_bugfixes_false",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
-      "signals": []
-    },
-    {
-      "group": "core-js-3-preset-env",
-      "name": "baseline_true_bugfixes_false",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
       "signals": []
@@ -5669,13 +4786,6 @@
     {
       "group": "core-js-3-preset-env",
       "name": "baseline_true_bugfixes_true",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
-      "signals": []
-    },
-    {
-      "group": "core-js-3-preset-env",
-      "name": "baseline_true_bugfixes_true",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
       "signals": []
@@ -5719,15 +4829,6 @@
     {
       "group": "only-plugin",
       "name": "@babel/plugin-transform-classes",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "only-plugin/-babel-plugin-transform-classes",
-      "signals": [
-        "@babel/plugin-transform-classes"
-      ]
-    },
-    {
-      "group": "only-plugin",
-      "name": "@babel/plugin-transform-classes",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "only-plugin/-babel-plugin-transform-classes",
       "signals": [
@@ -5773,15 +4874,6 @@
     {
       "group": "only-plugin",
       "name": "@babel/plugin-transform-regenerator",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "only-plugin/-babel-plugin-transform-regenerator",
-      "signals": [
-        "@babel/plugin-transform-regenerator"
-      ]
-    },
-    {
-      "group": "only-plugin",
-      "name": "@babel/plugin-transform-regenerator",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "only-plugin/-babel-plugin-transform-regenerator",
       "signals": [
@@ -5819,15 +4911,6 @@
       "group": "only-plugin",
       "name": "@babel/plugin-transform-spread",
       "bundle": "main.bundle.esbuild.min.js",
-      "dir": "only-plugin/-babel-plugin-transform-spread",
-      "signals": [
-        "@babel/plugin-transform-spread"
-      ]
-    },
-    {
-      "group": "only-plugin",
-      "name": "@babel/plugin-transform-spread",
-      "bundle": "main.bundle.rollup.js",
       "dir": "only-plugin/-babel-plugin-transform-spread",
       "signals": [
         "@babel/plugin-transform-spread"

--- a/core/scripts/legacy-javascript/summary-signals.json
+++ b/core/scripts/legacy-javascript/summary-signals.json
@@ -1,5 +1,5 @@
 {
-  "totalSignals": 1130,
+  "totalSignals": 952,
   "variantsMissingSignals": [
     "baseline_true_bugfixes_false",
     "baseline_true_bugfixes_true"
@@ -290,100 +290,6 @@
     {
       "group": "all-legacy-polyfills",
       "name": "all-legacy-polyfills-core-js-3",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
-      "signals": [
-        "Array.from",
-        "Array.isArray",
-        "Array.of",
-        "Array.prototype.at",
-        "Array.prototype.concat",
-        "Array.prototype.copyWithin",
-        "Array.prototype.every",
-        "Array.prototype.fill",
-        "Array.prototype.filter",
-        "Array.prototype.find",
-        "Array.prototype.findIndex",
-        "Array.prototype.findLast",
-        "Array.prototype.findLastIndex",
-        "Array.prototype.flat",
-        "Array.prototype.flatMap",
-        "Array.prototype.forEach",
-        "Array.prototype.includes",
-        "Array.prototype.indexOf",
-        "Array.prototype.join",
-        "Array.prototype.map",
-        "Array.prototype.slice",
-        "Array.prototype.some",
-        "Array.prototype.sort",
-        "Array.prototype.unshift",
-        "Math.acosh",
-        "Math.asinh",
-        "Math.atanh",
-        "Math.cbrt",
-        "Math.clz32",
-        "Math.cosh",
-        "Math.expm1",
-        "Math.fround",
-        "Math.hypot",
-        "Math.imul",
-        "Math.log10",
-        "Math.log1p",
-        "Math.log2",
-        "Math.sign",
-        "Math.sinh",
-        "Math.tanh",
-        "Math.trunc",
-        "Object.assign",
-        "Object.create",
-        "Object.entries",
-        "Object.freeze",
-        "Object.fromEntries",
-        "Object.getOwnPropertyDescriptor",
-        "Object.getOwnPropertyDescriptors",
-        "Object.getPrototypeOf",
-        "Object.hasOwn",
-        "Object.is",
-        "Object.isExtensible",
-        "Object.isFrozen",
-        "Object.isSealed",
-        "Object.keys",
-        "Object.preventExtensions",
-        "Object.seal",
-        "Object.setPrototypeOf",
-        "Object.values",
-        "Promise.allSettled",
-        "Promise.any",
-        "Reflect.apply",
-        "Reflect.construct",
-        "Reflect.deleteProperty",
-        "Reflect.get",
-        "Reflect.getOwnPropertyDescriptor",
-        "Reflect.getPrototypeOf",
-        "Reflect.has",
-        "Reflect.isExtensible",
-        "Reflect.ownKeys",
-        "Reflect.preventExtensions",
-        "Reflect.setPrototypeOf",
-        "String.fromCodePoint",
-        "String.prototype.codePointAt",
-        "String.prototype.endsWith",
-        "String.prototype.includes",
-        "String.prototype.link",
-        "String.prototype.matchAll",
-        "String.prototype.repeat",
-        "String.prototype.replaceAll",
-        "String.prototype.startsWith",
-        "String.prototype.substr",
-        "String.prototype.trim",
-        "String.prototype.trimEnd",
-        "String.prototype.trimStart",
-        "String.raw"
-      ]
-    },
-    {
-      "group": "all-legacy-polyfills",
-      "name": "all-legacy-polyfills-core-js-3",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "all-legacy-polyfills/all-legacy-polyfills-core-js-3",
       "signals": [
@@ -505,15 +411,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.from",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-from",
-      "signals": [
-        "Array.from"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.from",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-from",
       "signals": [
@@ -550,15 +447,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.isArray",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-isArray",
-      "signals": [
-        "Array.isArray"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.isArray",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-isArray",
       "signals": [
@@ -595,15 +483,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.of",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-of",
-      "signals": [
-        "Array.of"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.of",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-of",
       "signals": [
@@ -640,15 +519,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.at",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-at",
-      "signals": [
-        "Array.prototype.at"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.at",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-at",
       "signals": [
@@ -685,15 +555,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.concat",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-concat",
-      "signals": [
-        "Array.prototype.concat"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.concat",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-concat",
       "signals": [
@@ -730,15 +591,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.copyWithin",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
-      "signals": [
-        "Array.prototype.copyWithin"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.copyWithin",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-copyWithin",
       "signals": [
@@ -775,15 +627,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.every",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-every",
-      "signals": [
-        "Array.prototype.every"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.every",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-every",
       "signals": [
@@ -820,15 +663,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.fill",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-fill",
-      "signals": [
-        "Array.prototype.fill"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.fill",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-fill",
       "signals": [
@@ -865,15 +699,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.filter",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-filter",
-      "signals": [
-        "Array.prototype.filter"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.filter",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-filter",
       "signals": [
@@ -910,15 +735,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.find",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-find",
-      "signals": [
-        "Array.prototype.find"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.find",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-find",
       "signals": [
@@ -955,15 +771,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findIndex",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
-      "signals": [
-        "Array.prototype.findIndex"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.findIndex",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findIndex",
       "signals": [
@@ -1000,15 +807,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findLast",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
-      "signals": [
-        "Array.prototype.findLast"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.findLast",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findLast",
       "signals": [
@@ -1045,15 +843,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.findLastIndex",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
-      "signals": [
-        "Array.prototype.findLastIndex"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.findLastIndex",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-findLastIndex",
       "signals": [
@@ -1090,15 +879,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.flat",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-flat",
-      "signals": [
-        "Array.prototype.flat"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.flat",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-flat",
       "signals": [
@@ -1135,15 +915,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.flatMap",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
-      "signals": [
-        "Array.prototype.flatMap"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.flatMap",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-flatMap",
       "signals": [
@@ -1180,15 +951,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.forEach",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
-      "signals": [
-        "Array.prototype.forEach"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.forEach",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-forEach",
       "signals": [
@@ -1225,15 +987,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.includes",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-includes",
-      "signals": [
-        "Array.prototype.includes"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.includes",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-includes",
       "signals": [
@@ -1270,15 +1023,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.indexOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
-      "signals": [
-        "Array.prototype.indexOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.indexOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-indexOf",
       "signals": [
@@ -1315,15 +1059,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.join",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-join",
-      "signals": [
-        "Array.prototype.join"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.join",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-join",
       "signals": [
@@ -1360,15 +1095,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.map",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-map",
-      "signals": [
-        "Array.prototype.map"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.map",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-map",
       "signals": [
@@ -1405,15 +1131,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.slice",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-slice",
-      "signals": [
-        "Array.prototype.slice"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.slice",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-slice",
       "signals": [
@@ -1450,15 +1167,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.some",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-some",
-      "signals": [
-        "Array.prototype.some"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.some",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-some",
       "signals": [
@@ -1495,15 +1203,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.sort",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-sort",
-      "signals": [
-        "Array.prototype.sort"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.sort",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-sort",
       "signals": [
@@ -1540,15 +1239,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Array.prototype.unshift",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
-      "signals": [
-        "Array.prototype.unshift"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Array.prototype.unshift",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Array-prototype-unshift",
       "signals": [
@@ -1585,15 +1275,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.acosh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-acosh",
-      "signals": [
-        "Math.acosh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.acosh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-acosh",
       "signals": [
@@ -1630,15 +1311,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.asinh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-asinh",
-      "signals": [
-        "Math.asinh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.asinh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-asinh",
       "signals": [
@@ -1675,15 +1347,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.atanh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-atanh",
-      "signals": [
-        "Math.atanh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.atanh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-atanh",
       "signals": [
@@ -1720,15 +1383,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.cbrt",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-cbrt",
-      "signals": [
-        "Math.cbrt"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.cbrt",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-cbrt",
       "signals": [
@@ -1765,15 +1419,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.clz32",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-clz32",
-      "signals": [
-        "Math.clz32"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.clz32",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-clz32",
       "signals": [
@@ -1810,15 +1455,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.cosh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-cosh",
-      "signals": [
-        "Math.cosh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.cosh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-cosh",
       "signals": [
@@ -1855,15 +1491,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.expm1",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-expm1",
-      "signals": [
-        "Math.expm1"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.expm1",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-expm1",
       "signals": [
@@ -1900,15 +1527,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.fround",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-fround",
-      "signals": [
-        "Math.fround"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.fround",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-fround",
       "signals": [
@@ -1945,15 +1563,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.hypot",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-hypot",
-      "signals": [
-        "Math.hypot"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.hypot",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-hypot",
       "signals": [
@@ -1990,15 +1599,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.imul",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-imul",
-      "signals": [
-        "Math.imul"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.imul",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-imul",
       "signals": [
@@ -2035,15 +1635,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.log10",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-log10",
-      "signals": [
-        "Math.log10"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.log10",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-log10",
       "signals": [
@@ -2080,15 +1671,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.log1p",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-log1p",
-      "signals": [
-        "Math.log1p"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.log1p",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-log1p",
       "signals": [
@@ -2125,15 +1707,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.log2",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-log2",
-      "signals": [
-        "Math.log2"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.log2",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-log2",
       "signals": [
@@ -2170,15 +1743,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.sign",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-sign",
-      "signals": [
-        "Math.sign"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.sign",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-sign",
       "signals": [
@@ -2215,15 +1779,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.sinh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-sinh",
-      "signals": [
-        "Math.sinh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.sinh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-sinh",
       "signals": [
@@ -2260,15 +1815,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.tanh",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-tanh",
-      "signals": [
-        "Math.tanh"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.tanh",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-tanh",
       "signals": [
@@ -2305,15 +1851,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Math.trunc",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Math-trunc",
-      "signals": [
-        "Math.trunc"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Math.trunc",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Math-trunc",
       "signals": [
@@ -2350,15 +1887,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.assign",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-assign",
-      "signals": [
-        "Object.assign"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.assign",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-assign",
       "signals": [
@@ -2395,15 +1923,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.create",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-create",
-      "signals": [
-        "Object.create"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.create",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-create",
       "signals": [
@@ -2440,15 +1959,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.entries",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-entries",
-      "signals": [
-        "Object.entries"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.entries",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-entries",
       "signals": [
@@ -2485,15 +1995,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.freeze",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-freeze",
-      "signals": [
-        "Object.freeze"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.freeze",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-freeze",
       "signals": [
@@ -2530,15 +2031,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.fromEntries",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-fromEntries",
-      "signals": [
-        "Object.fromEntries"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.fromEntries",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-fromEntries",
       "signals": [
@@ -2575,15 +2067,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.getOwnPropertyDescriptor",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
-      "signals": [
-        "Object.getOwnPropertyDescriptor"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.getOwnPropertyDescriptor",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptor",
       "signals": [
@@ -2620,15 +2103,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.getOwnPropertyDescriptors",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
-      "signals": [
-        "Object.getOwnPropertyDescriptors"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.getOwnPropertyDescriptors",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-getOwnPropertyDescriptors",
       "signals": [
@@ -2665,15 +2139,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.getPrototypeOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
-      "signals": [
-        "Object.getPrototypeOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.getPrototypeOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-getPrototypeOf",
       "signals": [
@@ -2710,15 +2175,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.hasOwn",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-hasOwn",
-      "signals": [
-        "Object.hasOwn"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.hasOwn",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-hasOwn",
       "signals": [
@@ -2755,15 +2211,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.is",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-is",
-      "signals": [
-        "Object.is"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.is",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-is",
       "signals": [
@@ -2800,15 +2247,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.isExtensible",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-isExtensible",
-      "signals": [
-        "Object.isExtensible"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.isExtensible",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-isExtensible",
       "signals": [
@@ -2845,15 +2283,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.isFrozen",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-isFrozen",
-      "signals": [
-        "Object.isFrozen"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.isFrozen",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-isFrozen",
       "signals": [
@@ -2890,15 +2319,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.isSealed",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-isSealed",
-      "signals": [
-        "Object.isSealed"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.isSealed",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-isSealed",
       "signals": [
@@ -2935,15 +2355,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.keys",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-keys",
-      "signals": [
-        "Object.keys"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.keys",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-keys",
       "signals": [
@@ -2980,15 +2391,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.preventExtensions",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-preventExtensions",
-      "signals": [
-        "Object.preventExtensions"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.preventExtensions",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-preventExtensions",
       "signals": [
@@ -3025,15 +2427,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.seal",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-seal",
-      "signals": [
-        "Object.seal"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.seal",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-seal",
       "signals": [
@@ -3070,15 +2463,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.setPrototypeOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
-      "signals": [
-        "Object.setPrototypeOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.setPrototypeOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-setPrototypeOf",
       "signals": [
@@ -3115,15 +2499,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Object.values",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Object-values",
-      "signals": [
-        "Object.values"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Object.values",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Object-values",
       "signals": [
@@ -3160,15 +2535,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Promise.allSettled",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Promise-allSettled",
-      "signals": [
-        "Promise.allSettled"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Promise.allSettled",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Promise-allSettled",
       "signals": [
@@ -3205,15 +2571,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Promise.any",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Promise-any",
-      "signals": [
-        "Promise.any"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Promise.any",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Promise-any",
       "signals": [
@@ -3250,15 +2607,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.apply",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-apply",
-      "signals": [
-        "Reflect.apply"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.apply",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-apply",
       "signals": [
@@ -3295,15 +2643,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.construct",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-construct",
-      "signals": [
-        "Reflect.construct"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.construct",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-construct",
       "signals": [
@@ -3340,15 +2679,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.deleteProperty",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
-      "signals": [
-        "Reflect.deleteProperty"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.deleteProperty",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-deleteProperty",
       "signals": [
@@ -3385,15 +2715,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.get",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-get",
-      "signals": [
-        "Reflect.get"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.get",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-get",
       "signals": [
@@ -3430,15 +2751,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.getOwnPropertyDescriptor",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
-      "signals": [
-        "Reflect.getOwnPropertyDescriptor"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.getOwnPropertyDescriptor",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-getOwnPropertyDescriptor",
       "signals": [
@@ -3475,15 +2787,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.getPrototypeOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
-      "signals": [
-        "Reflect.getPrototypeOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.getPrototypeOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-getPrototypeOf",
       "signals": [
@@ -3520,15 +2823,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.has",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-has",
-      "signals": [
-        "Reflect.has"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.has",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-has",
       "signals": [
@@ -3565,15 +2859,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.isExtensible",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
-      "signals": [
-        "Reflect.isExtensible"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.isExtensible",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-isExtensible",
       "signals": [
@@ -3610,15 +2895,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.ownKeys",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
-      "signals": [
-        "Reflect.ownKeys"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.ownKeys",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-ownKeys",
       "signals": [
@@ -3655,15 +2931,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.preventExtensions",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
-      "signals": [
-        "Reflect.preventExtensions"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.preventExtensions",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-preventExtensions",
       "signals": [
@@ -3700,15 +2967,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "Reflect.setPrototypeOf",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
-      "signals": [
-        "Reflect.setPrototypeOf"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "Reflect.setPrototypeOf",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/Reflect-setPrototypeOf",
       "signals": [
@@ -3745,15 +3003,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.fromCodePoint",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-fromCodePoint",
-      "signals": [
-        "String.fromCodePoint"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.fromCodePoint",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-fromCodePoint",
       "signals": [
@@ -3790,15 +3039,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.codePointAt",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
-      "signals": [
-        "String.prototype.codePointAt"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.codePointAt",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-codePointAt",
       "signals": [
@@ -3835,15 +3075,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.endsWith",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
-      "signals": [
-        "String.prototype.endsWith"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.endsWith",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-endsWith",
       "signals": [
@@ -3880,15 +3111,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.includes",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-includes",
-      "signals": [
-        "String.prototype.includes"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.includes",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-includes",
       "signals": [
@@ -3925,15 +3147,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.link",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-link",
-      "signals": [
-        "String.prototype.link"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.link",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-link",
       "signals": [
@@ -3970,15 +3183,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.matchAll",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
-      "signals": [
-        "String.prototype.matchAll"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.matchAll",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-matchAll",
       "signals": [
@@ -4015,15 +3219,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.repeat",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-repeat",
-      "signals": [
-        "String.prototype.repeat"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.repeat",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-repeat",
       "signals": [
@@ -4060,15 +3255,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.replaceAll",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
-      "signals": [
-        "String.prototype.replaceAll"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.replaceAll",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-replaceAll",
       "signals": [
@@ -4105,15 +3291,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.startsWith",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
-      "signals": [
-        "String.prototype.startsWith"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.startsWith",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-startsWith",
       "signals": [
@@ -4150,15 +3327,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.substr",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-substr",
-      "signals": [
-        "String.prototype.substr"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.substr",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-substr",
       "signals": [
@@ -4195,15 +3363,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trim",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-trim",
-      "signals": [
-        "String.prototype.trim"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.trim",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trim",
       "signals": [
@@ -4240,15 +3399,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trimEnd",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
-      "signals": [
-        "String.prototype.trimEnd"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.trimEnd",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trimEnd",
       "signals": [
@@ -4285,15 +3435,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.prototype.trimStart",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
-      "signals": [
-        "String.prototype.trimStart"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.prototype.trimStart",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-prototype-trimStart",
       "signals": [
@@ -4330,15 +3471,6 @@
     {
       "group": "core-js-3-only-polyfill",
       "name": "String.raw",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-only-polyfill/String-raw",
-      "signals": [
-        "String.raw"
-      ]
-    },
-    {
-      "group": "core-js-3-only-polyfill",
-      "name": "String.raw",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-only-polyfill/String-raw",
       "signals": [
@@ -4621,17 +3753,6 @@
     {
       "group": "core-js-3-preset-env",
       "name": "baseline_false_bugfixes_false",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
-      "signals": [
-        "@babel/plugin-transform-classes",
-        "@babel/plugin-transform-regenerator",
-        "@babel/plugin-transform-spread"
-      ]
-    },
-    {
-      "group": "core-js-3-preset-env",
-      "name": "baseline_false_bugfixes_false",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-preset-env/baseline-false-bugfixes-false",
       "signals": [
@@ -4664,13 +3785,6 @@
     {
       "group": "core-js-3-preset-env",
       "name": "baseline_true_bugfixes_false",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
-      "signals": []
-    },
-    {
-      "group": "core-js-3-preset-env",
-      "name": "baseline_true_bugfixes_false",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-preset-env/baseline-true-bugfixes-false",
       "signals": []
@@ -4699,13 +3813,6 @@
     {
       "group": "core-js-3-preset-env",
       "name": "baseline_true_bugfixes_true",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
-      "signals": []
-    },
-    {
-      "group": "core-js-3-preset-env",
-      "name": "baseline_true_bugfixes_true",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "core-js-3-preset-env/baseline-true-bugfixes-true",
       "signals": []
@@ -4740,15 +3847,6 @@
     {
       "group": "only-plugin",
       "name": "@babel/plugin-transform-classes",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "only-plugin/-babel-plugin-transform-classes",
-      "signals": [
-        "@babel/plugin-transform-classes"
-      ]
-    },
-    {
-      "group": "only-plugin",
-      "name": "@babel/plugin-transform-classes",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "only-plugin/-babel-plugin-transform-classes",
       "signals": [
@@ -4785,15 +3883,6 @@
     {
       "group": "only-plugin",
       "name": "@babel/plugin-transform-regenerator",
-      "bundle": "main.bundle.rollup.js",
-      "dir": "only-plugin/-babel-plugin-transform-regenerator",
-      "signals": [
-        "@babel/plugin-transform-regenerator"
-      ]
-    },
-    {
-      "group": "only-plugin",
-      "name": "@babel/plugin-transform-regenerator",
       "bundle": "main.bundle.rollup.min.js",
       "dir": "only-plugin/-babel-plugin-transform-regenerator",
       "signals": [
@@ -4822,15 +3911,6 @@
       "group": "only-plugin",
       "name": "@babel/plugin-transform-spread",
       "bundle": "main.bundle.esbuild.min.js",
-      "dir": "only-plugin/-babel-plugin-transform-spread",
-      "signals": [
-        "@babel/plugin-transform-spread"
-      ]
-    },
-    {
-      "group": "only-plugin",
-      "name": "@babel/plugin-transform-spread",
-      "bundle": "main.bundle.rollup.js",
       "dir": "only-plugin/-babel-plugin-transform-spread",
       "signals": [
         "@babel/plugin-transform-spread"


### PR DESCRIPTION
I noticed that running on cnn.com had exploded from taking ~600ms to run the audit to ~15s. The culprits:

* the prefix on the core-js module path pattern was somehow problematic - educated guess is that too many common prefix matches had the regex engine doing too much work
* the unminifed detection for rollup (each module gets added as a named function) also had very bad performance. I tried a similiar "cut out the common prefix" but it made things _way worse_. so... let's drop.