### PR TITLE
tests: fix local mocha tests not properly setting isUnderTest

### DIFF
--- a/core/test/test-env/mocha-setup.js
+++ b/core/test/test-env/mocha-setup.js
@@ -35,7 +35,7 @@ const {SnapshotState, toMatchSnapshot, toMatchInlineSnapshot} = jestSnapshot;
 process.env.TZ = 'UTC';
 
 // Expected to be set by lh-env.js
-process.env.NODE_TEST = 'test';
+process.env.NODE_ENV = 'test';
 
 global.expect = expect;
 


### PR DESCRIPTION
oops - this was setting the wrong env variable.

Local smoke tests not impacted, nor was CI. Only impacted local mocha unit tests.