### PR TITLE
core(insights): implement `use-cache-insight`

### DIFF
--- a/core/audits/insights/use-cache-insight.js
+++ b/core/audits/insights/use-cache-insight.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */ // TODO: remove once implemented.
-
 /**
  * @license
  * Copyright 2025 Google LLC
@@ -10,7 +8,7 @@ import {UIStrings} from '@paulirish/trace_engine/models/trace/insights/UseCache.
 
 import {Audit} from '../audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
-import {adaptInsightToAuditProduct, makeNodeItemForNodeId} from './insight-audit.js';
+import {adaptInsightToAuditProduct} from './insight-audit.js';
 
 // eslint-disable-next-line max-len
 const str_ = i18n.createIcuMessageFn('node_modules/@paulirish/trace_engine/models/trace/insights/UseCache.js', UIStrings);
@@ -25,8 +23,9 @@ class UseCacheInsight extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.title),
       description: str_(UIStrings.description),
-      guidanceLevel: 3, // TODO: confirm/change.
-      requiredArtifacts: ['traces', 'TraceElements', 'SourceMaps'],
+      guidanceLevel: 3,
+      requiredArtifacts: ['traces', 'SourceMaps'],
+      replacesAudits: ['uses-long-cache-ttl'],
     };
   }
 
@@ -36,17 +35,25 @@ class UseCacheInsight extends Audit {
    * @return {Promise<LH.Audit.Product>}
    */
   static async audit(artifacts, context) {
-    // TODO: implement.
     return adaptInsightToAuditProduct(artifacts, context, 'UseCache', (insight) => {
       /** @type {LH.Audit.Details.Table['headings']} */
       const headings = [
         /* eslint-disable max-len */
+        {key: 'url', valueType: 'url', label: str_(UIStrings.requestColumn)},
+        {key: 'cacheLifetimeMs', valueType: 'ms', label: str_(UIStrings.cacheTTL), displayUnit: 'duration'},
+        {key: 'totalBytes', valueType: 'bytes', label: str_(i18n.UIStrings.columnTransferSize), displayUnit: 'kb', granularity: 1},
         /* eslint-enable max-len */
       ];
       /** @type {LH.Audit.Details.Table['items']} */
-      const items = [
-      ];
-      return Audit.makeTableDetails(headings, items);
+      const items = insight.requests.map(request => ({
+        url: request.request.args.data.url,
+        cacheLifetimeMs: request.ttl * 1000,
+        totalBytes: request.request.args.data.encodedDataLength,
+      }));
+      return Audit.makeTableDetails(headings, items, {
+        sortedBy: ['totalBytes'],
+        skipSumming: ['cacheLifetimeMs'],
+      });
     });
   }
 }

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -4323,7 +4323,10 @@
             "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://web.dev/uses-long-cache-ttl/).",
             "score": null,
             "scoreDisplayMode": "notApplicable",
-            "guidanceLevel": 3
+            "guidanceLevel": 3,
+            "replacesAudits": [
+              "uses-long-cache-ttl"
+            ]
           },
           "viewport-insight": {
             "id": "viewport-insight",
@@ -12110,9 +12113,88 @@
             "id": "use-cache-insight",
             "title": "Use efficient cache lifetimes",
             "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://web.dev/uses-long-cache-ttl/).",
-            "score": null,
-            "scoreDisplayMode": "notApplicable",
-            "guidanceLevel": 3
+            "score": 0,
+            "scoreDisplayMode": "numeric",
+            "details": {
+              "type": "table",
+              "headings": [
+                {
+                  "key": "url",
+                  "valueType": "url",
+                  "label": "Request"
+                },
+                {
+                  "key": "cacheLifetimeMs",
+                  "valueType": "ms",
+                  "label": "Cache TTL",
+                  "displayUnit": "duration"
+                },
+                {
+                  "key": "totalBytes",
+                  "valueType": "bytes",
+                  "label": "Transfer Size",
+                  "displayUnit": "kb",
+                  "granularity": 1
+                }
+              ],
+              "items": [
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s8/e13/128w/f5c5012a2afa2ac6b190dcd68306dbac.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 4708
+                },
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s9/e9/128w/558dc2f7d9c947e5445fb3f1838cb62c.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 3957
+                },
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s7/e11/128w/5d1df07b1741f4c3e66ed20ef00265f5.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 3886
+                },
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s8/e3/128w/08b3049589ca7ae688b0f771f9730caf.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 3744
+                },
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s9/e9/128w/5fbc916d0fffb01af1225d4ec2ab001d.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 3635
+                },
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s3/e3/128w/9b3031eb3988ba363fe946929a79e016.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 3495
+                },
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s8/e13/128w/b997cdb40263ff124e2a245c5e86a9a3.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 3598
+                },
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s8/e13/128w/81d89db1bf3d43b5b21f813d2f2a9777.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 3019
+                },
+                {
+                  "url": "https://cdn.mikescerealshack.co/frames/s3/e3/128w/793a408ca63a660b5d7aa1a41ac126ca.jpg",
+                  "cacheLifetimeMs": 14400000,
+                  "totalBytes": 2663
+                }
+              ],
+              "sortedBy": [
+                "totalBytes"
+              ],
+              "skipSumming": [
+                "cacheLifetimeMs"
+              ]
+            },
+            "guidanceLevel": 3,
+            "replacesAudits": [
+              "uses-long-cache-ttl"
+            ]
           },
           "viewport-insight": {
             "id": "viewport-insight",
@@ -14024,7 +14106,8 @@
               "audits[resource-summary].details.headings[2].label",
               "audits[third-party-summary].details.headings[1].label",
               "audits[uses-long-cache-ttl].details.headings[2].label",
-              "audits[total-byte-weight].details.headings[1].label"
+              "audits[total-byte-weight].details.headings[1].label",
+              "audits[use-cache-insight].details.headings[2].label"
             ],
             "core/lib/i18n/i18n.js | total": [
               "audits[resource-summary].details.items[0].label",
@@ -14143,7 +14226,8 @@
               }
             ],
             "core/lib/i18n/i18n.js | columnCacheTTL": [
-              "audits[uses-long-cache-ttl].details.headings[1].label"
+              "audits[uses-long-cache-ttl].details.headings[1].label",
+              "audits[use-cache-insight].details.headings[1].label"
             ],
             "core/audits/byte-efficiency/total-byte-weight.js | title": [
               "audits[total-byte-weight].title"
@@ -14404,6 +14488,9 @@
             ],
             "node_modules/@paulirish/trace_engine/models/trace/insights/UseCache.js | description": [
               "audits[use-cache-insight].description"
+            ],
+            "node_modules/@paulirish/trace_engine/models/trace/insights/UseCache.js | requestColumn": [
+              "audits[use-cache-insight].details.headings[0].label"
             ],
             "node_modules/@paulirish/trace_engine/models/trace/insights/Viewport.js | title": [
               "audits[viewport-insight].title"
@@ -24418,7 +24505,10 @@
             "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://web.dev/uses-long-cache-ttl/).",
             "score": null,
             "scoreDisplayMode": "notApplicable",
-            "guidanceLevel": 3
+            "guidanceLevel": 3,
+            "replacesAudits": [
+              "uses-long-cache-ttl"
+            ]
           },
           "viewport-insight": {
             "id": "viewport-insight",

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -6364,9 +6364,147 @@
       "id": "use-cache-insight",
       "title": "Use efficient cache lifetimes",
       "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://web.dev/uses-long-cache-ttl/).",
-      "score": null,
-      "scoreDisplayMode": "notApplicable",
-      "guidanceLevel": 3
+      "score": 0,
+      "scoreDisplayMode": "metricSavings",
+      "metricSavings": {
+        "FCP": 0,
+        "LCP": 3250
+      },
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "url",
+            "valueType": "url",
+            "label": "Request"
+          },
+          {
+            "key": "cacheLifetimeMs",
+            "valueType": "ms",
+            "label": "Cache TTL",
+            "displayUnit": "duration"
+          },
+          {
+            "key": "totalBytes",
+            "valueType": "bytes",
+            "label": "Transfer Size",
+            "displayUnit": "kb",
+            "granularity": 1
+          }
+        ],
+        "items": [
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-rotating.gif",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 934513
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 166576
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-1024x680.jpg?iar1",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 112939
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-1024x680.jpg?isr2",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 112939
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-1024x680.jpg?isr3",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 112939
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-1024x680.jpg",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 112939
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-1024x680.jpg?redirected-lcp",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 112939
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-1024x680.jpg?iar2",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 112939
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?isr1",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 24848
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/lighthouse-480x318.jpg?async",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 24848
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_disabled.css?delay=200&isdisabled",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 700
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=100",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 665
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 665
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 665
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=2000&async=true",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 665
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&async=true",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 665
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.css?scriptActivated&delay=200",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 665
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/dbw_tester.js",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 486
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/empty.css",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 233
+          },
+          {
+            "url": "http://localhost:10200/dobetterweb/empty_module.js?delay=500",
+            "cacheLifetimeMs": 0,
+            "totalBytes": 247
+          }
+        ],
+        "sortedBy": [
+          "totalBytes"
+        ],
+        "skipSumming": [
+          "cacheLifetimeMs"
+        ]
+      },
+      "guidanceLevel": 3,
+      "replacesAudits": [
+        "uses-long-cache-ttl"
+      ]
     },
     "viewport-insight": {
       "id": "viewport-insight",
@@ -10415,7 +10553,8 @@
         "audits[unminified-javascript].details.headings[1].label",
         "audits[unused-javascript].details.headings[1].label",
         "audits[uses-text-compression].details.headings[1].label",
-        "audits[render-blocking-insight].details.headings[1].label"
+        "audits[render-blocking-insight].details.headings[1].label",
+        "audits[use-cache-insight].details.headings[2].label"
       ],
       "core/lib/i18n/i18n.js | total": [
         "audits[resource-summary].details.items[0].label",
@@ -11076,7 +11215,8 @@
         }
       ],
       "core/lib/i18n/i18n.js | columnCacheTTL": [
-        "audits[uses-long-cache-ttl].details.headings[1].label"
+        "audits[uses-long-cache-ttl].details.headings[1].label",
+        "audits[use-cache-insight].details.headings[1].label"
       ],
       "core/audits/byte-efficiency/total-byte-weight.js | title": [
         "audits[total-byte-weight].title"
@@ -11608,6 +11748,9 @@
       ],
       "node_modules/@paulirish/trace_engine/models/trace/insights/UseCache.js | description": [
         "audits[use-cache-insight].description"
+      ],
+      "node_modules/@paulirish/trace_engine/models/trace/insights/UseCache.js | requestColumn": [
+        "audits[use-cache-insight].details.headings[0].label"
       ],
       "node_modules/@paulirish/trace_engine/models/trace/insights/Viewport.js | title": [
         "audits[viewport-insight].title"


### PR DESCRIPTION
This adds a transfer size column that isn't present in RPP but is present in the `uses-long-cache-ttl` audit. I think it's a good addition here that is hard to add in RPP due to space constraints.

ref https://github.com/GoogleChrome/lighthouse/issues/16323