### PR TITLE
misc(treemap): restructure header to match new design

### DIFF
--- a/treemap/app/index.html
+++ b/treemap/app/index.html
@@ -41,38 +41,30 @@ SPDX-License-Identifier: Apache-2.0
   <input id="hidden-file-input" type="file" hidden accept="application/json">
 
   <main class="hidden lh-main lh-main--show-table">
-    <div class="lh-settings">
-      <header>
-        <div class="lh-header--section">
-          <span class="lh-logotitle">
-            <!-- Lighthouse logo. Stolen from templates.html -->
-            <svg role="img" class="lh-topbar__logo" title="Lighthouse logo" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
-              <path d="m14 7 10-7 10 7v10h5v7h-5l5 24H9l5-24H9v-7h5V7Z" fill="#F63"/>
-              <path d="M31.561 24H14l-1.689 8.105L31.561 24ZM18.983 48H9l1.022-4.907L35.723 32.27l1.663 7.98L18.983 48Z" fill="#FFA385"/>
-              <path fill="#FF3" d="M20.5 10h7v7h-7z"/>
-            </svg>
+    <header class="lh-header">
+      <div class="lh-header__logotitle">
+        <!-- Lighthouse logo. Stolen from templates.html -->
+        <svg role="img" class="lh-topbar__logo" title="Lighthouse logo" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+          <path d="m14 7 10-7 10 7v10h5v7h-5l5 24H9l5-24H9v-7h5V7Z" fill="#F63"/>
+          <path d="M31.561 24H14l-1.689 8.105L31.561 24ZM18.983 48H9l1.022-4.907L35.723 32.27l1.663 7.98L18.983 48Z" fill="#FFA385"/>
+          <path fill="#FF3" d="M20.5 10h7v7h-7z"/>
+        </svg>
 
-            <span class="lh-header--title lh-text-dim">Lighthouse Treemap</span>
-          </span>
+        <span class="lh-header--title lh-text-dim">Lighthouse Treemap</span>
+      </div>
 
-          <span class="lh-header__inputs">
-            <select class="bundle-selector"></select>
-            <button data-i18n="toggleTableButtonLabel" class="lh-button lh-button--active lh-button--toggle-table"></button>
-          </span>
-        </div>
+      <div class="lh-header__url">
+        <span class="lh-header--url-and-size">
+          <a href="" class="lh-header--url" target="_blank" rel="noopener"></a> <span class="lh-header--url-bytes lh-text-dim"></span></span>
+        </span>
+      </div>
 
-        <div class="lh-header--section">
-          <span class="lh-header--url-and-size">
-            <a href="" class="lh-header--url" target="_blank" rel="noopener"></a> <span class="lh-text-dim"></span></span>
-          </span>
-          <div class="lh-mode-wrapper">
-            <div class="lh-modes">
-              <!-- View modes go here -->
-            </div>
-          </div>
-        </div>
-      </header>
-    </div>
+      <div class="lh-header__inputs">
+        <select class="view-mode-selector"></select>
+        <select class="bundle-selector"></select>
+        <button data-i18n="toggleTableButtonLabel" class="lh-button lh-button--active lh-button--toggle-table"></button>
+      </div>
+    </header>
 
     <div class="lh-treemap">
       <!-- treemap goes here -->

--- a/treemap/app/styles/treemap.css
+++ b/treemap/app/styles/treemap.css
@@ -47,26 +47,35 @@ body {
 .lh-main {
   display: grid;
   height: 100vh;
-  grid-template-rows: 0.1fr 1fr 0fr;
+  grid-template-rows: auto 1fr 0fr;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
   transition: grid-template-rows 0.2s;
   animation: 0.7s curtain cubic-bezier(0.86, 0, 0.07, 1) 0.4s both;
 }
 .lh-main--show-table {
-  grid-template-rows: 0.1fr 1fr 0.3fr;
+  grid-template-rows: auto 1fr 0.3fr;
 }
 
-/* TODO: BEM is backwards here and many other places */
-.lh-header--section {
+.lh-header {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
 }
-.lh-header--section:nth-of-type(2) {
-  font-size: 20px;
+.lh-header > div {
+  flex: 1;
 }
+.lh-header > div:first-child {
+  margin-right: auto;
+}
+.lh-header > div:last-child {
+  margin-left: auto;
+}
+
+.lh-header__url {
+  text-align: center;
+}
+
 .lh-header--url {
   font-weight: bold;
   text-decoration: none;
@@ -78,21 +87,15 @@ body {
   display: flex;
   justify-content: flex-end;
 }
-
-.lh-logotitle {
-  display: flex;
-  align-items: center;
-}
-
-.bundle-selector {
-  flex: 1;
+.lh-header__inputs select {
+  width: 10vw;
   padding: 2px;
   margin: 2px;
 }
 
-.bundle-selector {
-  width: 50%;
-  padding: 2px;
+.lh-header__logotitle {
+  display: flex;
+  align-items: center;
 }
 
 .lh-topbar__logo {
@@ -100,10 +103,6 @@ body {
   height: 24px;
   user-select: none;
   flex: none;
-}
-
-.lh-modes {
-  display: flex;
 }
 
 .lh-treemap {

--- a/treemap/test/treemap-test-pptr.js
+++ b/treemap/test/treemap-test-pptr.js
@@ -177,7 +177,7 @@ describe('Lighthouse Treemap', () => {
         timeout: 30000,
       });
 
-      await page.click('#view-mode--unused-bytes');
+      await page.select('.view-mode-selector', '1'); // unused bytes
       await page.waitForSelector('.lh-treemap--view-mode--unused-bytes');
 
       // Identify the JS data.


### PR DESCRIPTION
ref #16400

Restructures the header to more closely match the new designs. Also change the view mode selector to a select element rather than buttons.

This is an incremental refactor. Ignore that the UX isn't matching the new design.

![image](https://github.com/user-attachments/assets/f0454c8b-2387-4f66-aa01-8fd5ddac8bcd)
