### PR TITLE
misc(treemap): vary colors within bundle, update fonts

### DIFF
--- a/treemap/app/index.html
+++ b/treemap/app/index.html
@@ -50,7 +50,7 @@ SPDX-License-Identifier: Apache-2.0
           <path fill="#FF3" d="M20.5 10h7v7h-7z"/>
         </svg>
 
-        <span class="lh-header--title lh-text-dim">Lighthouse Treemap</span>
+        <span class="lh-header--title lh-text-bold">Lighthouse Treemap</span>
       </div>
 
       <div class="lh-header__url">

--- a/treemap/app/styles/treemap.css
+++ b/treemap/app/styles/treemap.css
@@ -11,7 +11,8 @@
   --color-gray-900: #212121;
 
   --control-background-color: #e7f1fe;
-  --text-color-secondary: var(--color-gray-600);
+  --text-color-secondary: #474747;
+
   --text-color: var(--color-gray-900);
   --text-color-active: #2a67ce;
   --text-color-active-secondary: #4484f3c7;
@@ -42,6 +43,11 @@ body {
 
 .lh-text-dim {
   color: var(--text-color-secondary);
+  font-weight: 400;
+}
+
+.lh-text-bold {
+  font-weight: 500;
 }
 
 .lh-main {
@@ -96,11 +102,12 @@ body {
 .lh-header__logotitle {
   display: flex;
   align-items: center;
+  font-size: 16px;
 }
 
 .lh-topbar__logo {
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   user-select: none;
   flex: none;
 }
@@ -211,6 +218,10 @@ header {
   outline: 2px solid black;
 }
 
+.lh-treemap--view-mode--all .webtreemap-node {
+  border: none;
+}
+
 .lh-treemap--view-mode--unused-bytes .webtreemap-node::before {
   position: absolute;
   top: 0;
@@ -232,6 +243,9 @@ header {
   font-size: 12px;
   text-align: center;
   word-break: break-word;
+}
+.webtreemap-caption span {
+  margin: 0 2px;
 }
 
 /* Copied from viewer.css */


### PR DESCRIPTION
ref #16400

* Uses a color of varying saturation/lightness based on depth within each bundle. This could be tweaked more, not perfect
* Applies some font styling to better match mocks
* Splits up captions into separate elements to style differently
* Removes root node caption for "All" scripts

![image](https://github.com/user-attachments/assets/cd60bbfe-d144-455d-b697-10d0d44de705)
![image](https://github.com/user-attachments/assets/1d07d8f6-cf12-49e0-8c71-60c8df830c9e)
![image](https://github.com/user-attachments/assets/9e3c10ed-d9c9-4162-80aa-496b0de661da)
