### PR TITLE
core(preload-fonts): add Stylesheets to required artifacts

### DIFF
--- a/core/test/devtools-tests/download-depot-tools.sh
+++ b/core/test/devtools-tests/download-depot-tools.sh
@@ -18,8 +18,5 @@ fi
 
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "$DEPOT_TOOLS_PATH"
 
-echo  "$DEPOT_TOOLS_PATH"
-ls "$DEPOT_TOOLS_PATH"
-
-echo  "$DEPOT_TOOLS_PATH/python-bin"
-ls "$DEPOT_TOOLS_PATH/python-bin"
+cd "$DEPOT_TOOLS_PATH"
+bash update_depot_tools

--- a/core/test/devtools-tests/run-e2e-tests.sh
+++ b/core/test/devtools-tests/run-e2e-tests.sh
@@ -15,5 +15,4 @@ export LH_ROOT="$SCRIPT_DIR/../../.."
 cd "$DEVTOOLS_PATH"
 
 TEST_PATTERN="${1:-test/e2e/lighthouse/*}"
-which vpython3
 vpython3 third_party/node/node.py --output scripts/run_on_target.mjs gen/test/run.js "$TEST_PATTERN" --target=$BUILD_FOLDER


### PR DESCRIPTION
This audit is only in the experimental config, but it's been broken for awhile.

maybe regressed in #15952, but I did not verify that.

----

unrelated to this change, but this PR also fixes an issue w/ depot_tools not having python3 setup in our CI.