### PR TITLE
core(stacks): correctly identify angular

### DIFF
--- a/core/lib/stack-packs.js
+++ b/core/lib/stack-packs.js
@@ -69,7 +69,7 @@ const stackPacksToInclude = [
   },
   {
     packId: 'angular',
-    requiredStacks: ['js:@angular/core'],
+    requiredStacks: ['js:angular'],
   },
   {
     packId: 'react',


### PR DESCRIPTION
I believe we have never been identifying Angular due to this bug.

https://github.com/johnmichel/Library-Detector-for-Chrome/blame/3cf4e62d657eb96a39c1d60f676bf63986ef961b/library/libraries.js#L1155

initially added: https://github.com/GoogleChrome/lighthouse/pull/9797