### PR TITLE
clients(lr): disable modern-http-insight

### DIFF
--- a/core/config/lr-desktop-config.js
+++ b/core/config/lr-desktop-config.js
@@ -19,6 +19,7 @@ const config = {
     skipAudits: [
       // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
       'uses-http2',
+      'modern-http-insight',
       // There are always bf-cache failures when testing in headless. Reenable when headless can give us realistic bf-cache insights.
       'bf-cache',
     ],

--- a/core/config/lr-mobile-config.js
+++ b/core/config/lr-mobile-config.js
@@ -18,6 +18,7 @@ const config = {
     skipAudits: [
       // Skip the h2 audit so it doesn't lie to us. See https://github.com/GoogleChrome/lighthouse/issues/6539
       'uses-http2',
+      'modern-http-insight',
       // There are always bf-cache failures when testing in headless. Reenable when headless can give us realistic bf-cache insights.
       'bf-cache',
     ],


### PR DESCRIPTION
Lightrider/PageSpeed Insights still has some issues with h1/2/3 instrumentation, so we should disable `modern-http-insight` just like we are still doing for `uses-http2`.

ref https://github.com/GoogleChrome/lighthouse/discussions/16462#discussioncomment-13001678 #11777