### PR TITLE
deps: bump chrome-launcher to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "@paulirish/trace_engine": "0.0.52",
     "@sentry/node": "^7.0.0",
     "axe-core": "^4.10.3",
-    "chrome-launcher": "^1.1.2",
+    "chrome-launcher": "^1.2.0",
     "configstore": "^5.0.1",
     "csp_evaluator": "1.1.5",
     "devtools-protocol": "0.0.1445099",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2358,10 +2358,10 @@ chrome-devtools-frontend@1.0.1445635:
   resolved "https://registry.yarnpkg.com/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.1445635.tgz#1c8c9be3dc9e11fc1ed7ff25ae88beaf8ec4162d"
   integrity sha512-tEaXomzTnPF55Zi1vafP3CYP1reFH8eoqzDNiZVvNuUW5B+sTuE21Rln/BLIGcz35lvIcvhRrsuZzA0GqXZuMA==
 
-chrome-launcher@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-1.1.2.tgz#52eff6b3fd7f24b65192b2624a108dadbcca4b9d"
-  integrity sha512-YclTJey34KUm5jB1aEJCq807bSievi7Nb/TU4Gu504fUYi3jw3KCIaH6L7nFWQhdEgH3V+wCh+kKD1P5cXnfxw==
+chrome-launcher@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-1.2.0.tgz#bba61f558f450aef70bbda1f011c83c31c129302"
+  integrity sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==
   dependencies:
     "@types/node" "*"
     escape-string-regexp "^4.0.0"


### PR DESCRIPTION
https://github.com/GoogleChrome/chrome-launcher/releases/tag/v1.2.0

Mostly rolling to fix the security concerns in dependabot bumps.