### PR TITLE
fix(github-api): server-side request forgery `getGistFileContentAsJson`

### DIFF
--- a/viewer/app/src/github-api.js
+++ b/viewer/app/src/github-api.js
@@ -90,6 +90,10 @@ export class GithubApi {
    * @return {Promise<LH.Result>}
    */
   getGistFileContentAsJson(id) {
+    if (!/^[a-f0-9]{5,}$/.test(id)) {
+      throw new Error('Invalid gist ID format');
+    }
+
     logger.log('Fetching report from GitHub...', false);
 
     return this._auth.getAccessTokenIfLoggedIn().then(accessToken => {


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/blob/4a8406379aa49d1fb9f7f6eff8a7d37c8afd3203/viewer/app/src/github-api.js#L110-L110

https://github.com/GoogleChrome/lighthouse/blob/4a8406379aa49d1fb9f7f6eff8a7d37c8afd3203/viewer/app/src/github-api.js#L92-L92


Fix the issue need to validate the `id` parameter before using it in the `fetch` call. Specifically:
1. Ensure that the `id` matches the expected format for GitHub gist IDs (e.g., a hexadecimal string of a specific length).
2. Reject or sanitize any input that does not conform to this format.
3. Update the `getGistFileContentAsJson` method in `viewer/app/src/github-api.js` to include this validation step.

Additionally, we should ensure that the `loadFromGistUrl` method in `treemap/app/src/main.js` performs similar validation when extracting the `gistId` from the URL.


Directly incorporating user input in the URL of an outgoing HTTP request can enable a request forgery attack, in which the request is altered to target an unintended API endpoint or resource. If the server performing the request is connected to an internal network, this can give an attacker the means to bypass the network boundary and make requests against internal services. A forged request may perform an unintended action on behalf of the attacker, or cause information leak if redirected to an external server or if the request response is fed back to the user. It may also compromise the server making the request, if the request response is handled in an unsafe way.


---


