### PR TITLE
fix(download-content-shell): shell command built from environment values `child_process.spawnSync`

### DIFF
--- a/third-party/download-content-shell/download-content-shell.js
+++ b/third-party/download-content-shell/download-content-shell.js
@@ -154,7 +154,7 @@ function extractContentShell(contentShellZipPath) {
   console.log(`Extracting content shell zip: ${contentShellZipPath}`);
   const src = contentShellZipPath;
   const dest = path.resolve(path.dirname(src), 'out');
-  shell(`unzip ${src} -d ${dest}`);
+  shell('unzip', [src, '-d', dest]);
   fs.unlinkSync(src);
   const originalDirPath = path.resolve(dest, 'content-shell');
   const newDirPath = path.resolve(dest, TARGET);


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/blob/814627f65fa1585f87792bb8f686e318ced4e04d/third-party/download-content-shell/download-content-shell.js#L22-L22

https://github.com/GoogleChrome/lighthouse/blob/814627f65fa1585f87792bb8f686e318ced4e04d/third-party/download-content-shell/download-content-shell.js#L157-L157

Fix the issue the shell command should avoid dynamic string construction and instead use `child_process.execFileSync` or `child_process.spawnSync`, which allow passing arguments as an array. This approach ensures that the shell does not interpret special characters in the paths.

Specifically:
1. Replace the dynamic shell command `shell(\`unzip ${src} -d ${dest}\`)` with a call to `execFileSync` or `spawnSync`, passing `src` and `dest` as arguments.
2. Ensure that the `unzip` command and its arguments are passed as separate elements in an array, preventing unintended shell interpretation.

---


