### PR TITLE
core(gather): deprecate executionContext.evaluateAsync

### DIFF
--- a/core/gather/driver/execution-context.js
+++ b/core/gather/driver/execution-context.js
@@ -151,11 +151,13 @@ class ExecutionContext {
   }
 
   /**
-   * Note: Prefer `evaluate` instead.
    * Evaluate an expression in the context of the current page. If useIsolation is true, the expression
    * will be evaluated in a content script that has access to the page's DOM but whose JavaScript state
    * is completely separate.
    * Returns a promise that resolves on the expression's value.
+   *
+   * @deprecated Use `evaluate` instead! It has a better API, and unlike `evaluateAsync` doesn't sometimes
+   * execute invalid code.
    * @param {string} expression
    * @param {{useIsolation?: boolean}=} options
    * @return {Promise<*>}

--- a/core/gather/gatherers/css-usage.js
+++ b/core/gather/gatherers/css-usage.js
@@ -30,7 +30,10 @@ class CSSUsage extends BaseGatherer {
 
     // Force style to recompute.
     // Doesn't appear to be necessary in newer versions of Chrome.
-    await executionContext.evaluateAsync('getComputedStyle(document.body)');
+    /* global window, document */
+    await executionContext.evaluate(() => window.getComputedStyle(document.body), {
+      args: [],
+    });
 
     const {ruleUsage} = await session.sendCommand('CSS.stopRuleUsageTracking');
     await session.sendCommand('CSS.disable');

--- a/core/gather/gatherers/stylesheets.js
+++ b/core/gather/gatherers/stylesheets.js
@@ -74,7 +74,10 @@ class Stylesheets extends BaseGatherer {
 
     // Force style to recompute.
     // Doesn't appear to be necessary in newer versions of Chrome.
-    await executionContext.evaluateAsync('getComputedStyle(document.body)');
+    /* global window, document */
+    await executionContext.evaluate(() => window.getComputedStyle(document.body), {
+      args: [],
+    });
 
     session.off('CSS.styleSheetAdded', this._onStylesheetAdded);
 


### PR DESCRIPTION
closes #16372