### PR TITLE
core(timing-summary): suppress expected errors

### DIFF
--- a/core/computed/metrics/timing-summary.js
+++ b/core/computed/metrics/timing-summary.js
@@ -21,6 +21,7 @@ import {TotalBlockingTime} from './total-blocking-time.js';
 import {makeComputedArtifact} from '../computed-artifact.js';
 import {TimeToFirstByte} from './time-to-first-byte.js';
 import {LCPBreakdown} from './lcp-breakdown.js';
+import {isUnderTest} from '../../lib/lh-env.js';
 
 class TimingSummary {
   /**
@@ -46,7 +47,9 @@ class TimingSummary {
      */
     const requestOrUndefined = (Artifact, artifact) => {
       return Artifact.request(artifact, context).catch(err => {
-        log.error('lh:computed:TimingSummary', err);
+        if (isUnderTest) {
+          log.error('lh:computed:TimingSummary', err);
+        }
         return undefined;
       });
     };


### PR DESCRIPTION
I didn't realize in #16492 that this would log expected errors on most runs:

> LH:lh:computed:TimingSummary:error Error: FCP All Frames not implemented in lantern