### PR TITLE
core(plugins): support scoped npm packages

### DIFF
--- a/core/config/validation.js
+++ b/core/config/validation.js
@@ -36,6 +36,10 @@ function isValidArtifactDependency(dependent, dependency) {
  * @param {string} pluginName
  */
 function assertValidPluginName(config, pluginName) {
+  const parts = pluginName.split('/');
+  if (parts.length === 2) {
+    pluginName = parts[1];
+  }
   if (!pluginName.startsWith('lighthouse-plugin-')) {
     throw new Error(`plugin name '${pluginName}' does not start with 'lighthouse-plugin-'`);
   }

--- a/core/test/config/validation-test.js
+++ b/core/test/config/validation-test.js
@@ -61,6 +61,18 @@ describe('Config Validation', () => {
       expect(invocation).toThrow(/does not start with.*lighthouse-plugin/);
     });
 
+    it('should not throw if plugin starts with lighthouse-plugin', () => {
+      const invocation = () =>
+        validation.assertValidPluginName(defaultConfig, 'lighthouse-plugin-test');
+      expect(invocation).not.toThrow();
+    });
+
+    it('should not throw if plugin starts with @xxx/lighthouse-plugin', () => {
+      const invocation = () =>
+        validation.assertValidPluginName(defaultConfig, '@org/lighthouse-plugin-test');
+      expect(invocation).not.toThrow();
+    });
+
     it('should throw if category already exists in config', () => {
       const config = {...defaultConfig};
       const category = {title: 'Test Plugin', auditRefs: [{id: 'viewport', weight: 1}]};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
currently we can't use plugins that are namespaced, e.g. @myorg/lighthouse-plugin-blabla
<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->

<!-- Describe the need for this change -->
im simply splitting on / and checking if the second part starts with the correct prefix.
<!-- Link any documentation or information that would help understand this change -->

**Related Issues/PRs**
<!-- Provide any additional information we might need to understand the pull request -->
