### PR TITLE
report: fix 3p filter checkbox for insight audits

### DIFF
--- a/report/renderer/dom.js
+++ b/report/renderer/dom.js
@@ -30,6 +30,7 @@ export class DOM {
     this.rootEl = rootEl;
     /** @type {WeakMap<Element, Element>} */
     this._swappableSections = new WeakMap();
+    this._onSwap = () => {};
   }
 
   /**
@@ -354,5 +355,6 @@ export class DOM {
 
     parent.insertBefore(newSection, section);
     section.remove();
+    this._onSwap();
   }
 }


### PR DESCRIPTION
These audits are conditionally added to the DOM after `initFeatures` runs, so they were being missed by the 3p checkbox setup. Now that setup code runs every time a section is swapped.