### PR TITLE
misc(logger): update debug dep to v4

### DIFF
--- a/lighthouse-logger/package.json
+++ b/lighthouse-logger/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.1",
   "license": "Apache-2.0",
   "main": "./index.js",
-  "repository": "GoogleChrome/lighthouse",
+  "repository": "https://github.com/GoogleChrome/lighthouse.git",
   "scripts": {
     "prepack": "yarn build-types",
     "build-types": "npx tsc index.js --allowJs --emitDeclarationOnly --declaration"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**

Update the debug dependency for `lighthouse-logger` to v4.
There don't seem to be any relevant breaking changes except for Node updates.
Apparently the supported colors are extended since `debug` v3, especially by adding `supports-color` as a dependency. So maybe it's possible to drop the custom `colors` definition in `lighthouse-logger/index.js`, but I don't fully understand why it was added that way years ago, thus I didn't touch it.

Hopefully allows for Vite to get less confused about multiple `debug` versions in my project (don't ask what's going on).


**Related Issues/PRs**

https://github.com/GoogleChrome/lighthouse/issues/13721#issuecomment-3094974379
