### PR TITLE
misc(ci): clear devtools build cache

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -52,8 +52,8 @@ jobs:
         # 3) every change to file in Lighthouse repo important to running these tests.
         #
         # The number is how many times this hash key was manually updated to break the cache.
-        key: ${{ runner.os }}-13-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
-        restore-keys: ${{ runner.os }}-13
+        key: ${{ runner.os }}-14-${{ env.WEEK_OF_THE_YEAR }}-${{ hashFiles('cdt-test-hash.txt') }}
+        restore-keys: ${{ runner.os }}-14
     - name: Set GHA_DEVTOOLS_CACHE_HIT
       if: steps.devtools-cache.outputs.cache-hit == 'true'
       run: echo "GHA_DEVTOOLS_CACHE_HIT=1" >> $GITHUB_ENV

--- a/third-party/chromium-synchronization/inspector-issueAdded-types-test.js
+++ b/third-party/chromium-synchronization/inspector-issueAdded-types-test.js
@@ -56,6 +56,7 @@ Array [
   "sharedDictionaryIssueDetails",
   "sriMessageSignatureIssueDetails",
   "stylesheetLoadingIssueDetails",
+  "unencodedDigestIssueDetails",
   "userReidentificationIssueDetails",
 ]
 `);


### PR DESCRIPTION
autoninja -> siso upgrade caught up to us, which required a manual gn clean to address. so just bump the cache key.