### PR TITLE
core (error-in-console): limit large JSON reports

### DIFF
--- a/core/audits/errors-in-console.js
+++ b/core/audits/errors-in-console.js
@@ -14,6 +14,10 @@ import log from 'lighthouse-logger';
 import {Audit} from './audit.js';
 import {JSBundles} from '../computed/js-bundles.js';
 import * as i18n from '../lib/i18n/i18n.js';
+import {Util} from '../../shared/util.js';
+
+const KB = 1024;
+const MAX_CONSOLE_ERRORS = 1000;
 
 const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on browser errors. This descriptive title is shown to users when no browser errors were logged into the devtools console. */
@@ -90,10 +94,10 @@ class ErrorLogs extends Audit {
         const bundle = bundles.find(bundle => bundle.script.scriptId === item.scriptId);
         return {
           source: item.source,
-          description: item.text,
+          description: item.text ? Util.truncate(item.text, 10 * KB) : undefined,
           sourceLocation: Audit.makeSourceLocationFromConsoleMessage(item, bundle),
         };
-      });
+      }).slice(0, MAX_CONSOLE_ERRORS);
 
     const tableRows = ErrorLogs.filterAccordingToOptions(consoleRows, auditOptions)
       .sort((a, b) => (a.description || '').localeCompare(b.description || ''));

--- a/core/test/audits/errors-in-console-test.js
+++ b/core/test/audits/errors-in-console-test.js
@@ -177,23 +177,6 @@ describe('ConsoleMessages error logs audit', () => {
       expect(result.details.items).toHaveLength(1);
     });
 
-    it('does nothing with an empty description', async () => {
-      const options = {ignoredPatterns: 'pattern'};
-      const context = {options, computedCache: new Map()};
-      const result = await ErrorLogsAudit.audit({
-        ConsoleMessages: [
-          {
-            level: 'error',
-          },
-        ],
-        SourceMaps: [],
-        Scripts: [],
-      }, context);
-
-      expect(result.score).toBe(0);
-      expect(result.details.items).toHaveLength(1);
-    });
-
     it('filters console messages as a string', async () => {
       const options = {ignoredPatterns: ['simple']};
       const context = {options, computedCache: new Map()};

--- a/core/test/audits/errors-in-console-test.js
+++ b/core/test/audits/errors-in-console-test.js
@@ -180,15 +180,14 @@ describe('ConsoleMessages error logs audit', () => {
       expect(result.details.items).toHaveLength(1);
     });
 
-    it('should return 1000 console errors', async () => {
-      const options = {ignoredPatterns: ['simple']};
-      const context = {options, computedCache: new Map()};
+    it('should limit console errors length to 1000', async () => {
+      const context = {options: {}, computedCache: new Map()};
 
       const result = await ErrorLogsAudit.audit({
-        ConsoleMessages: Array.from({length: MAX_CONSOLE_ERRORS * 2}, (_, i) => ({
+        ConsoleMessages: Array.from({length: MAX_CONSOLE_ERRORS * 2}, () => ({
         level: 'error',
         source: 'network',
-        text: `Error message ${i + 1}`,
+        text: `Error message`,
       })),
         SourceMaps: [],
         Scripts: [],

--- a/core/test/audits/errors-in-console-test.js
+++ b/core/test/audits/errors-in-console-test.js
@@ -204,7 +204,7 @@ describe('ConsoleMessages error logs audit', () => {
           {
             level: 'error',
             source: 'network',
-            text: `Error message`.repeat(20 * KB),
+            text: `Error message`.repeat(KB),
           },
         ],
         SourceMaps: [],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
<!-- What kind of change does this PR introduce? -->
This is a feature request for https://github.com/GoogleChrome/lighthouse/issues/13817

<!-- Is this a bugfix, feature, refactoring, build related change, etc? -->
<!-- Describe the need for this change -->
To limit descriptions and the number of console errors

<!-- Link any documentation or information that would help understand this change -->
https://github.com/GoogleChrome/lighthouse/issues/13817#issuecomment-2937471757
<!-- **Related Issues/PRs** -->
<!-- Provide any additional information we might need to understand the pull request -->
