### PR TITLE
misc: use structuredClone instead of lodash cloneDeep

### DIFF
--- a/cli/test/smokehouse/frontends/lib.js
+++ b/cli/test/smokehouse/frontends/lib.js
@@ -10,8 +10,6 @@
  * Supports skipping and modifiying expectations to match the environment.
  */
 
-import {cloneDeep} from 'lodash-es';
-
 import smokeTests from '../core-tests.js';
 import {runSmokehouse, getShardedDefinitions} from '../smokehouse.js';
 
@@ -21,7 +19,7 @@ import {runSmokehouse, getShardedDefinitions} from '../smokehouse.js';
 async function smokehouse(options) {
   const {urlFilterRegex, skip, modify, shardArg, ...smokehouseOptions} = options;
 
-  const clonedTests = cloneDeep(smokeTests);
+  const clonedTests = structuredClone(smokeTests);
   const modifiedTests = [];
   for (const test of clonedTests) {
     if (urlFilterRegex && !test.expectations.lhr.requestedUrl.match(urlFilterRegex)) {

--- a/cli/test/smokehouse/frontends/smokehouse-bin.js
+++ b/cli/test/smokehouse/frontends/smokehouse-bin.js
@@ -14,7 +14,6 @@ import path from 'path';
 import fs from 'fs';
 import url from 'url';
 
-import {cloneDeep} from 'lodash-es';
 import yargs from 'yargs';
 import * as yargsHelpers from 'yargs/helpers';
 import log from 'lighthouse-logger';
@@ -92,7 +91,7 @@ function getDefinitionsToRun(allTestDefns, requestedIds, excludedTests) {
 function pruneExpectedNetworkRequests(testDefns, takeNetworkRequestUrls) {
   const pruneNetworkRequests = !takeNetworkRequestUrls;
 
-  const clonedDefns = cloneDeep(testDefns);
+  const clonedDefns = structuredClone(testDefns);
   for (const {id, expectations, runSerially} of clonedDefns) {
     if (!runSerially && expectations.networkRequests) {
       throw new Error(`'${id}' must be set to 'runSerially: true' to assert 'networkRequests'`);

--- a/cli/test/smokehouse/report-assert.js
+++ b/cli/test/smokehouse/report-assert.js
@@ -9,7 +9,6 @@
  * against the results actually collected from Lighthouse.
  */
 
-import {cloneDeep} from 'lodash-es';
 import log from 'lighthouse-logger';
 
 import {LocalConsole} from './lib/local-console.js';
@@ -317,7 +316,7 @@ function pruneExpectations(localConsole, lhr, expected, reportOptions) {
     delete obj._excludeRunner;
   }
 
-  const cloned = cloneDeep(expected);
+  const cloned = structuredClone(expected);
 
   pruneRecursively(cloned);
   return cloned;


### PR DESCRIPTION
wanted to remove the entire package but we have a couple non-trivial usages of it still. So I just got rid of these easy ones.