### PR TITLE
tests: re-enable startTimespan api test

### DIFF
--- a/core/test/lib/url-utils-test.js
+++ b/core/test/lib/url-utils-test.js
@@ -18,7 +18,7 @@ describe('UrlUtils', () => {
     assert.doesNotThrow(_ => new URL(url));
   });
 
-  it.skip('handles URLs with multiple dashes', () => {
+  it('handles URLs with multiple dashes', () => {
     // from https://github.com/GoogleChrome/lighthouse/issues/1972
     const url = 'https://r15---sn-o097znl7.googlevideo.com/generate_204?conn2';
     assert.doesNotThrow(_ => new URL(url));

--- a/core/test/scenarios/api-test-pptr.js
+++ b/core/test/scenarios/api-test-pptr.js
@@ -168,9 +168,8 @@ describe('Individual modes API', function() {
       expect(erroredAudits).toHaveLength(0);
     });
 
-    // TODO: times out in CI.
     // eslint-disable-next-line max-len
-    it.skip('should know target type of network requests from frames created before timespan', async () => {
+    it('should know target type of network requests from frames created before timespan', async () => {
       const spy = jestMock.spyOn(TargetManager.prototype, '_onExecutionContextCreated');
       state.server.baseDir = `${LH_ROOT}/cli/test/fixtures`;
       const {page, serverBaseUrl} = state;


### PR DESCRIPTION
disabled in #16653. might be OK now.

Also unskipped an ancient url test that was accidentally skipped ever since it was written