### PR TITLE
core(trace-elements): handle shadow roots

### DIFF
--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -35,7 +35,12 @@ const MAX_LAYOUT_SHIFTS = 15;
  */
 /* c8 ignore start */
 function getNodeDetailsData() {
-  const elem = this.nodeType === document.ELEMENT_NODE ? this : this.parentElement;
+  /** @type {Element|null} */
+  let elem = this.nodeType === document.ELEMENT_NODE ? this : this.parentElement;
+  if (!elem && this instanceof ShadowRoot) {
+    elem = this.host;
+  }
+
   let traceElement;
   if (elem) {
     // @ts-expect-error - getNodeDetails put into scope via stringification


### PR DESCRIPTION
I noticed that for dbw tester, the dom-size-insight max children field was not getting a node element. There was a node id, but it pointed at the document fragment inside a shadow tree. The TraceElements saw it was not an element node, so it went to the parentElement. But since it's a shadow root, there is no parent element, and thus no node reference was created.

Instead, check if the element is a shadow root. If so, use its host.