### PR TITLE
tests: re-enable dom-size-insight node smoke test

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -452,8 +452,7 @@ const expectations = {
                 granularity: 1,
                 value: 100,
               },
-              // TODO(v13): why missing?
-              // node: {snippet: '<div id="shadow-root-container">'},
+              node: {snippet: '<div id="shadow-root-container">'},
             },
           ],
         },


### PR DESCRIPTION
I accidentally disabled this test even though I fixed it via #16718.