### PR TITLE
docs(a11y/insights): update accessibility scoring pointer and add insight audits guidance

### DIFF
--- a/core/audits/insights/README.md
+++ b/core/audits/insights/README.md
@@ -1,37 +1,83 @@
 # Insight audits
 
-Insight audits are a newer class of audits intended to provide targeted, diagnostic information and actionable examples to help developers understand and fix problems discovered by Lighthouse. They are typically displayed in the Performance category and are non-scored (weight 0) by default.
+Insight audits are a newer class of audits intended to provide
+targeted, diagnostic information and actionable examples to help
+developers understand and fix problems discovered by Lighthouse. They
+are typically displayed in the Performance category and are non-scored
+(weight 0) by default.
 
-When to use an insight audit
-- Use an insight audit when you want to surface prioritized, example-driven guidance rather than a single pass/fail rule.
-- Insight audits are useful for surfacing a table of problematic resources, a ranked list of offending nodes, or a short set of prioritized suggestions.
+## When to use an insight audit
 
-Generating insight audits
+- Use an insight audit when you want to surface prioritized,
+  example-driven guidance rather than a single pass/fail rule.
+
+- Insight audits are useful for surfacing a table of problematic
+  resources, a ranked list of offending nodes, or a short set of
+  prioritized suggestions.
+
+## Generating insight audits
+
 When adding new insight audits, you can start off by running:
 
 ```bash
 yarn generate-insight-audits
 ```
 
-This will scaffold lightweight audit files for any registered insight that doesn't yet have an implementation. The generator creates a standard audit module and wires a reference into the default config so the audit appears in reports.
+This will scaffold lightweight audit files for any registered insight
+that doesn't yet have an implementation. The generator creates a
+standard audit module and wires a reference into the default config so
+the audit appears in reports.
 
-Authoring guidance
-- Audit id and naming: use the `*-insight` suffix for insight audit ids (for example `image-delivery-insight`). This is used by report rendering and styles to present the audit appropriately.
-- scoreDisplayMode: insight audits are usually informational. Set `scoreDisplayMode: 'notApplicable'` or `'informative'` depending on whether the audit has a boolean pass state.
-- weight: insight audits are normally added with `weight: 0` in `core/config/default-config.js`. If you decide an insight should contribute to scoring, choose weights carefully and document the rationale.
-- Diagnostics and examples: supply a `details` object with a table, list, or node snapshot that demonstrates the issue. Tables are commonly used; ensure columns are well-labeled and limited to the most actionable fields (url, size, savings, reason).
-- Localization: add UI strings to the appropriate `UIStrings` file and use `str_()` when referencing them in the audit implementation.
+## Authoring guidance
+
+ - Audit id and naming: use the `*-insight` suffix for insight audit
+   ids (for example `image-delivery-insight`). This is used by report
+   rendering and styles to present the audit appropriately.
+
+ - scoreDisplayMode: insight audits are usually informational. Set
+   `scoreDisplayMode: 'notApplicable'` or `'informative'` depending on
+   whether the audit has a boolean pass state.
+
+ - weight: insight audits are normally added with `weight: 0` in
+   `core/config/default-config.js`. If you decide an insight should
+   contribute to scoring, choose weights carefully and document the
+   rationale.
+
+ - Diagnostics and examples: supply a `details` object with a table,
+   list, or node snapshot that demonstrates the issue. Tables are
+   commonly used; ensure columns are well-labeled and limited to the
+   most actionable fields (url, size, savings, reason).
+
+ - Localization: add UI strings to the appropriate `UIStrings` file and
+   use `str_()` when referencing them in the audit implementation.
 
 Examples
-- Table-style insight (common): return a `details.type === 'table'` with `headings` and `items` describing offending resources. The report renderer applies special table styling for `-insight` audits.
-- Node snapshot: return `details.type === 'node'` or `node`-based details to show a DOM snippet with an explanation.
+
+- Table-style insight (common): return a `details.type === 'table'`
+  with `headings` and `items` describing offending resources. The
+  report renderer applies special table styling for `-insight` audits.
+
+- Node snapshot: return `details.type === 'node'` or `node`-based
+  details to show a DOM snippet with an explanation.
 
 Testing and iteration
-- Add unit tests under `core/audits/insights/` or `report/test/renderer` to validate rendering and diagnostic contents.
-- Use smokehouse fixtures or the `test/` helpers to run the audit against example pages and verify the produced LHR contains the expected details.
+
+- Add unit tests under `core/audits/insights/` or
+  `report/test/renderer` to validate rendering and diagnostic
+  contents.
+
+- Use smokehouse fixtures or the `test/` helpers to run the audit
+  against example pages and verify the produced LHR contains the
+  expected details.
 
 References
-- `core/scripts/generate-insight-audits.js` — generator used to scaffold insight audits.
-- `core/config/default-config.js` — where insight audit refs are listed (they live in the Performance category by default).
 
-If you have questions about design or placement of a new insight audit, open a discussion or PR describing the proposed UX and example output so the team can review.
+- `core/scripts/generate-insight-audits.js` — generator used to
+  scaffold insight audits.
+
+- `core/config/default-config.js` — where insight audit refs are
+  listed (they live in the Performance category by default).
+
+If you have questions about design or placement of a new insight
+audit, open a discussion or PR describing the proposed UX and example
+output so the team can review.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,16 +1,19 @@
+# Lighthouse docs
+
 This directory contains useful documentation, examples (keep reading),
 and [recipes](./recipes/) to get you started. For an overview of Lighthouse's
 internals, see [Lighthouse Architecture](architecture.md).
 
 ## Important docs
 
-- Accessibility scoring — for the canonical, up-to-date explanation of how Lighthouse computes the Accessibility category score see `docs/scoring.md` (and the live guide on developer.chrome.com):
+- Accessibility scoring — for the canonical, up-to-date explanation of
+  how Lighthouse computes the Accessibility category score see
+  `docs/scoring.md` (and the live guide on developer.chrome.com):
 
-  https://developer.chrome.com/docs/lighthouse/accessibility/scoring
+  [Lighthouse Accessibility Scoring on developer.chrome.com](https://developer.chrome.com/docs/lighthouse/accessibility/scoring)
 
-- Insight audits — guidance for authors and examples for `*-insight` audits is in:
-
-  `core/audits/insights/README.md`
+- Insight audits — guidance for authors and examples for `*-insight`
+  audits is in `core/audits/insights/README.md`
 
 ## Using programmatically
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -15,16 +15,26 @@ All audits in the SEO category are [equally weighted](https://github.com/GoogleC
 
 ## How is the accessibility score calculated?
 
-<!-- To regnerate score weights, run `node core/scripts/print-a11y-scoring.js`-->
+<!-- To regenerate score weights, run `node core/scripts/print-a11y-scoring.js` -->
 
-The accessibility score is a weighted average. Lighthouse's accessibility scoring and weights can change between major versions as audits are added, removed, or re-weighted. For the most up-to-date explanation of how accessibility scoring works, and the canonical list of audit weights, see the Lighthouse Accessibility Scoring guide on developer.chrome.com:
+The accessibility score is a weighted average. Lighthouse's
+accessibility scoring and weights can change between major versions as
+audits are added, removed, or re-weighted. For the most up-to-date
+explanation of how accessibility scoring works, and the canonical list
+of audit weights, see the Lighthouse Accessibility Scoring guide on
+developer.chrome.com:
 
-https://developer.chrome.com/docs/lighthouse/accessibility/scoring
+[Lighthouse Accessibility Scoring on developer.chrome.com](https://developer.chrome.com/docs/lighthouse/accessibility/scoring)
 
-If you need the weights for a specific release of Lighthouse you can also generate them locally from the configuration with:
+If you need the weights for a specific release of Lighthouse, you can
+also generate them locally from the configuration with:
 
 ```bash
 node core/scripts/print-a11y-scoring.js
 ```
 
-Each audit is a pass/fail check for the page under test. That means a single audit contributes its full weight if it passes on the current page, or zero if it fails. For example, if an audit's weight is 4% and the audit fails for the inspected page, the page loses that 4 points from the accessibility category score.
+Each audit is a pass/fail check for the page under test. That means a
+single audit contributes its full weight if it passes on the current
+page, or zero if it fails. For example, if an audit's weight is 4% and
+the audit fails for the inspected page, the page loses that 4 points
+from the accessibility category score.


### PR DESCRIPTION
Update accessibility scoring doc to point to the canonical developer.chrome.com guide and add instructions to generate local a11y weights.\n\nAdd authoring guidance for insight audits in core/audits/insights/README.md and expose links from docs/readme.md so docs are discoverable.\n\nFiles changed: docs/scoring.md, core/audits/insights/README.md, docs/readme.md