### PR TITLE
misc(strings): fix i18n README typo

### DIFF
--- a/core/lib/i18n/README.md
+++ b/core/lib/i18n/README.md
@@ -87,7 +87,7 @@ const UIStrings = {
 };
 ```
 
-For proper translation, **all** strings must be accompanied by a description, written as a preceeding comment.
+For proper translation, **all** strings must be accompanied by a description, written as a preceding comment.
 
 
 ### Replacements and primitive formatting


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**
fixed the typo "preceeding" → "preceding"

<!-- Describe the need for this change -->

<!-- Link any documentation or information that would help understand this change -->

<!-- Provide any additional information we might need to understand the pull request -->
