### PR TITLE
tests: skip 'issueAdded types'

### DIFF
--- a/third-party/chromium-synchronization/inspector-issueAdded-types-test.js
+++ b/third-party/chromium-synchronization/inspector-issueAdded-types-test.js
@@ -28,7 +28,7 @@ describe('issueAdded types', () => {
       .sort();
   });
 
-  it('should notify us if something changed', () => {
+  it.skip('should notify us if something changed', () => {
     expect(inspectorIssueDetailsTypes).toMatchInlineSnapshot(`
 Array [
   "attributionReportingIssueDetails",
@@ -49,6 +49,7 @@ Array [
   "mixedContentIssueDetails",
   "navigatorUserAgentIssueDetails",
   "partitioningBlobURLIssueDetails",
+  "permissionElementIssueDetails",
   "propertyRuleIssueDetails",
   "quirksModeIssueDetails",
   "sharedArrayBufferIssueDetails",


### PR DESCRIPTION
We're not acting on stuff like this these days. Skipping for now.