### PR TITLE
core: set NetworkRequest.renderBlocking from CDP data

### DIFF
--- a/core/lib/network-request.js
+++ b/core/lib/network-request.js
@@ -66,6 +66,17 @@ const HEADER_TOTAL = 'X-TotalMs';
 const HEADER_FETCHED_SIZE = 'X-TotalFetchedSize';
 const HEADER_PROTOCOL_IS_H2 = 'X-ProtocolIsH2';
 
+// CDP uses PascalCase (M145+), Lantern uses snake_case.
+/** @type {Record<LH.Crdp.Network.RenderBlockingBehavior,
+ *   import('@paulirish/trace_engine/models/trace/types/TraceEvents.js').RenderBlocking>} */
+const CDP_TO_LANTERN_RENDER_BLOCKING = {
+  'NonBlocking': 'non_blocking',
+  'Blocking': 'blocking',
+  'InBodyParserBlocking': 'in_body_parser_blocking',
+  'PotentiallyBlocking': 'potentially_blocking',
+  'NonBlockingDynamic': 'dynamically_injected_non_blocking',
+};
+
 /**
  * @typedef HeaderEntry
  * @property {string} name
@@ -187,6 +198,8 @@ class NetworkRequest {
     this.sessionTargetType = undefined;
     this.fromWorker = false;
     this.isLinkPreload = false;
+    /** @type {import('@paulirish/trace_engine/models/trace/types/TraceEvents.js').RenderBlocking|undefined} */
+    this.renderBlocking = undefined;
   }
 
   /**
@@ -239,6 +252,11 @@ class NetworkRequest {
 
     this.frameId = data.frameId;
     this.isLinkPreload = data.initiator.type === 'preload' || !!data.request.isLinkPreload;
+    // M145+ provides renderBlockingBehavior in CDP
+    const renderBlockingBehavior = data.renderBlockingBehavior;
+    if (renderBlockingBehavior) {
+      this.renderBlocking = CDP_TO_LANTERN_RENDER_BLOCKING[renderBlockingBehavior];
+    }
     this.isValid = true;
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

**Summary**

This is a sibling PR to https://chromium-review.googlesource.com/c/chromium/src/+/7269488 and https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/7262577. It drills the `renderBlockingBehavior` flag introduced in the former, and makes it available to core Lantern login in the latter. 

The practical impact of this is that FCP and LCP start using more accurate render-blocking data (starting with M145).

**Related Issues/PRs**

https://github.com/GoogleChrome/lighthouse/issues/16539
