### PR TITLE
tests: fix a few tests failing with `INTERNAL_LANTERN_USE_TRACE`

### DIFF
--- a/cli/test/smokehouse/test-definitions/oopif-requests.js
+++ b/cli/test/smokehouse/test-definitions/oopif-requests.js
@@ -64,8 +64,6 @@ const expectations = {
 
               // Disqus iframe (OOPIF)
               {url: /^https:\/\/disqus\.com\/embed\/comments\//, finished: true, statusCode: 200, resourceType: 'Document'},
-              // Disqus subframe (that's a new OOPIF)
-              {url: 'https://accounts.google.com/o/oauth2/iframe', finished: true, statusCode: 200, resourceType: 'Document'},
             ],
           },
         },

--- a/core/test/computed/tbt-impact-tasks-test.js
+++ b/core/test/computed/tbt-impact-tasks-test.js
@@ -270,7 +270,7 @@ describe('TBTImpactTasks', () => {
       expect(tasksWithNoChildren).toEqual(tasksWithAllSelfImpact);
 
       const totalSelfImpact = tasksImpactingTbt.reduce((sum, t) => sum += t.selfTbtImpact, 0);
-      expect(totalSelfImpact).toMatchInlineSnapshot(`2819.9999999999545`);
+      expect(totalSelfImpact).toBeCloseTo(2820, 6);
 
       // Total self blocking time is just the total self impact without factoring in the TBT
       // bounds, so it should always be greater than or equal to the total TBT self impact.

--- a/core/test/computed/tbt-impact-tasks-test.js
+++ b/core/test/computed/tbt-impact-tasks-test.js
@@ -11,6 +11,7 @@ import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
 import {createTestTrace, rootFrame} from '../create-test-trace.js';
 import {networkRecordsToDevtoolsLog} from '../network-records-to-devtools-log.js';
 import {MainThreadTasks} from '../../computed/main-thread-tasks.js';
+import {NetworkRequest} from '../../lib/network-request.js';
 
 const trace = readJson('../fixtures/artifacts/cnn/trace.json.gz', import.meta);
 const devtoolsLog = readJson('../fixtures/artifacts/cnn/devtoolslog.json.gz', import.meta);
@@ -32,25 +33,28 @@ describe('TBTImpactTasks', () => {
     let metricComputationData;
 
     beforeEach(() => {
+      /** @type {Partial<LH.Artifacts.NetworkRequest>} */
+      const mainDocumentRequest = {
+        requestId: '1',
+        priority: 'High',
+        networkRequestTime: 0,
+        networkEndTime: 500,
+        transferSize: 400,
+        url: mainDocumentUrl,
+        frameId: rootFrame,
+      };
       metricComputationData = {
         trace: createTestTrace({
           largestContentfulPaint: 15,
           traceEnd: 10_000,
           frameUrl: mainDocumentUrl,
+          networkRecords: [Object.assign(new NetworkRequest(), mainDocumentRequest)],
           topLevelTasks: [
             // Add long task to defer TTI
             {ts: 1000, duration: 1000},
           ],
         }),
-        devtoolsLog: networkRecordsToDevtoolsLog([{
-          requestId: '1',
-          priority: 'High',
-          networkRequestTime: 0,
-          networkEndTime: 500,
-          transferSize: 400,
-          url: mainDocumentUrl,
-          frameId: rootFrame,
-        }]),
+        devtoolsLog: networkRecordsToDevtoolsLog([mainDocumentRequest]),
         URL: {
           requestedUrl: mainDocumentUrl,
           mainDocumentUrl,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!
See CONTRIBUTING.MD for help in getting a change landed.
  https://github.com/GoogleChrome/lighthouse/blob/main/CONTRIBUTING.md
-->

This PR takes a tiny stab at https://github.com/GoogleChrome/lighthouse/issues/16805. It doesn’t actually fix any of the tests which have `if (process.env.INTERNAL_LANTERN_USE_TRACE)` in them, but it does fix a few which were nonetheless failing with `INTERNAL_LANTERN_USE_TRACE=1`.

Why a tiny stab? I started fixing the tests. But then I submitted https://github.com/GoogleChrome/lighthouse/pull/16869, which made switching to `INTERNAL_LANTERN_USE_TRACE` much less pressing. So I decided to not pursue fixing further. Still, I figured the changes I made so far would still be useful, so I’m PRing them.