### PR TITLE
core(baseline): add baseline compatibility audit to default config

### DIFF
--- a/build/build-bundle-mcp.js
+++ b/build/build-bundle-mcp.js
@@ -65,7 +65,7 @@ function getMcpRequiredGathererNames() {
   const bestPracticesArtifacts = [
     'DevtoolsLog', 'InspectorIssues', 'URL', 'ConsoleMessages', 'SourceMaps',
     'Scripts', 'Inputs', 'ImageElements', 'ViewportDimensions', 'Doctype',
-    'MainDocumentContent', 'MetaElements', 'Stacks',
+    'MainDocumentContent', 'MetaElements', 'Stacks', 'Trace',
   ];
   const a11yArtifacts = ['Accessibility'];
   for (const id of [...seoArtifacts, ...bestPracticesArtifacts, ...a11yArtifacts]) {

--- a/cli/test/fixtures/baseline.html
+++ b/cli/test/fixtures/baseline.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<!--
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+-->
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Baseline Test</title>
+  <style>
+    @media (forced-colors: active) {
+      body {
+        background-color: black;
+      }
+    }
+
+    .grid {
+      display: grid;
+    }
+
+    .flex {
+      display: flex;
+    }
+
+    /* newly available */
+    .has:has(.child) {
+      color: red;
+    }
+
+    /* limited availability */
+    .accent {
+      accent-color: auto;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Hello WebDX</h1>
+
+  <div class="grid">
+    <div class="flex has">
+      <div class="child">Item</div>
+    </div>
+  </div>
+
+  <dialog id="d">Dialog</dialog>
+
+  <!-- newly available: popover -->
+  <div popover id="p">Popover</div>
+  <button popovertarget="p">Toggle</button>
+
+  <!-- limited availability: accent-color -->
+  <input type="checkbox" class="accent" checked />
+
+  <script>
+    // Trigger dialog
+    document.getElementById('d').showModal();
+
+    // Trigger popover
+    document.getElementById('p').showPopover();
+
+    // Trigger AbortController
+    const controller = new AbortController();
+    controller.abort();
+
+    // Trigger Fetch and Promise
+    fetch('baseline.html').then(() => console.log('fetched'));
+
+    // Trigger limited: accelerometer
+    try { new Accelerometer(); } catch (e) { }
+  </script>
+</body>
+
+</html>

--- a/cli/test/smokehouse/core-tests.js
+++ b/cli/test/smokehouse/core-tests.js
@@ -5,6 +5,7 @@
  */
 
 import a11y from './test-definitions/a11y.js';
+import baseline from './test-definitions/baseline.js';
 import byteEfficiency from './test-definitions/byte-efficiency.js';
 import byteGzip from './test-definitions/byte-gzip.js';
 import clickjackingMissingHeaders from './test-definitions/clickjacking-missing-headers.js';
@@ -69,6 +70,7 @@ import trustedTypesDirectiveMissingDirective from './test-definitions/trusted-ty
 /** @type {ReadonlyArray<Smokehouse.TestDfn>} */
 const smokeTests = [
   a11y,
+  baseline,
   byteEfficiency,
   byteGzip,
   clickjackingMissingHeaders,

--- a/cli/test/smokehouse/test-definitions/baseline.js
+++ b/cli/test/smokehouse/test-definitions/baseline.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @type {LH.Config} */
+const config = {
+  extends: 'lighthouse:default',
+  audits: [
+    'baseline',
+  ],
+  categories: {
+    // @ts-expect-error: `title` is required in CategoryJson but we rely on the default config to provide it.
+    'best-practices': {
+      auditRefs: [
+        {id: 'baseline', weight: 0, group: 'best-practices-browser-compat'},
+      ],
+    },
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ * Expected Lighthouse audit values for baseline compatibility.
+ */
+const expectations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/baseline.html',
+    finalDisplayedUrl: 'http://localhost:10200/baseline.html',
+    audits: {
+      'baseline': {
+        _minChromiumVersion: '148',
+        score: '>=1',
+        details: {
+          items: {
+            _includes: [
+              {
+                featureId: {text: 'grid'},
+                displayStatus: /^Widely Available/,
+              },
+              {
+                featureId: {text: 'flexbox'},
+                displayStatus: /^Widely Available/,
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+};
+
+export default {
+  id: 'baseline',
+  expectations,
+  config,
+};
+

--- a/core/audits/baseline.js
+++ b/core/audits/baseline.js
@@ -11,10 +11,10 @@ import * as i18n from '../lib/i18n/i18n.js';
 
 const UIStrings = {
   /** Title of the Baseline audit. Shown when the page is compatible with the target baseline. */
-  title: 'Baseline',
+  title: 'Baseline Features',
   /** Description of the Baseline audit. */
   description:
-    'Returns a list of web features used on the page and their Baseline status.' +
+    'Lists web features used on the page and their Baseline status. ' +
     '[Learn more about Baseline](https://webstatus.dev/).',
   /** Label for the column displaying the feature ID. */
   columnFeature: 'Web-features',
@@ -58,8 +58,8 @@ class Baseline extends Audit {
     );
 
     for (const event of dxEvents) {
-      const key = `${event.args.feature}|${event.args.url ||
-          ''}|${event.args.lineNumber || ''}|${event.args.columnNumber || ''}`;
+      const key = `${event.args.feature}`;
+
       if (featuresMap.has(key)) continue;
 
       /** @type {LH.Audit.Details.SourceLocationValue | undefined} */
@@ -130,7 +130,43 @@ class Baseline extends Audit {
       },
     ];
 
-    const details = Audit.makeTableDetails(headings, baselineStatus);
+    /**
+     * Determines the sorting rank of a baseline status.
+     * @param {string} status The display status string.
+     * @return {number} The numerical rank (1 is the highest priority).
+     */
+    const getStatusRank = (status) => {
+      if (status.startsWith('Widely')) {
+        return 1;
+      }
+      if (status.startsWith('Newly')) {
+        return 2;
+      }
+      if (status.startsWith('Limited')) {
+        return 3;
+      }
+      return 4;
+    };
+
+    const sortedStatuses = baselineStatus.sort((featureA, featureB) => {
+      const rankA = getStatusRank(featureA.displayStatus);
+      const rankB = getStatusRank(featureB.displayStatus);
+
+      if (rankA !== rankB) {
+        return rankA - rankB;
+      }
+
+      const hasSourceA = !!featureA.source;
+      const hasSourceB = !!featureB.source;
+
+      if (hasSourceA !== hasSourceB) {
+        return hasSourceA ? -1 : 1;
+      }
+
+      return 0;
+    });
+
+    const details = Audit.makeTableDetails(headings, sortedStatuses);
 
     return {
       score: 1,

--- a/core/config/default-config.js
+++ b/core/config/default-config.js
@@ -266,6 +266,7 @@ const defaultConfig = {
     'dobetterweb/js-libraries',
     'dobetterweb/notification-on-start',
     'dobetterweb/paste-preventing-inputs',
+    'baseline',
     'seo/meta-description',
     'seo/http-status-code',
     'seo/link-text',
@@ -559,6 +560,7 @@ const defaultConfig = {
         // Browser Compatibility
         {id: 'doctype', weight: 1, group: 'best-practices-browser-compat'},
         {id: 'charset', weight: 1, group: 'best-practices-browser-compat'},
+        {id: 'baseline', weight: 0, group: 'best-practices-browser-compat'},
         // General Group
         {id: 'js-libraries', weight: 0, group: 'best-practices-general'},
         {id: 'deprecations', weight: 5, group: 'best-practices-general'},

--- a/core/test/audits/baseline-test.js
+++ b/core/test/audits/baseline-test.js
@@ -115,23 +115,6 @@ describe('Baseline Audit', () => {
     expect(result.details.items[2]).toEqual({
       featureId: {
         type: 'link',
-        text: 'accelerometer',
-        url: 'https://webstatus.dev/features/accelerometer',
-      },
-      displayStatus: 'Limited Availability',
-      source: {
-        type: 'source-location',
-        url: 'https://example.com/sensors.js',
-        urlProvider: 'network',
-        line: 9,
-        column: 1,
-        original: undefined,
-      },
-    });
-
-    expect(result.details.items[3]).toEqual({
-      featureId: {
-        type: 'link',
         text: 'abortsignal-any',
         url: 'https://webstatus.dev/features/abortsignal-any',
       },
@@ -142,6 +125,23 @@ describe('Baseline Audit', () => {
         urlProvider: 'network',
         line: 19,
         column: 7,
+        original: undefined,
+      },
+    });
+
+    expect(result.details.items[3]).toEqual({
+      featureId: {
+        type: 'link',
+        text: 'accelerometer',
+        url: 'https://webstatus.dev/features/accelerometer',
+      },
+      displayStatus: 'Limited Availability',
+      source: {
+        type: 'source-location',
+        url: 'https://example.com/sensors.js',
+        urlProvider: 'network',
+        line: 9,
+        column: 1,
         original: undefined,
       },
     });

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -2895,6 +2895,34 @@
               "items": []
             }
           },
+          "baseline": {
+            "id": "baseline",
+            "title": "Baseline Features",
+            "description": "Lists web features used on the page and their Baseline status. [Learn more about Baseline](https://webstatus.dev/).",
+            "score": 1,
+            "scoreDisplayMode": "informative",
+            "details": {
+              "type": "table",
+              "headings": [
+                {
+                  "key": "featureId",
+                  "valueType": "link",
+                  "label": "Web-features"
+                },
+                {
+                  "key": "displayStatus",
+                  "valueType": "text",
+                  "label": "Baseline Status"
+                },
+                {
+                  "key": "source",
+                  "valueType": "source-location",
+                  "label": "Source"
+                }
+              ],
+              "items": []
+            }
+          },
           "meta-description": {
             "id": "meta-description",
             "title": "Document has a meta description",
@@ -4118,6 +4146,11 @@
               {
                 "id": "charset",
                 "weight": 1,
+                "group": "best-practices-browser-compat"
+              },
+              {
+                "id": "baseline",
+                "weight": 0,
                 "group": "best-practices-browser-compat"
               },
               {
@@ -6081,168 +6114,174 @@
             },
             {
               "startTime": 206,
-              "name": "lh:audit:meta-description",
+              "name": "lh:audit:baseline",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 207,
-              "name": "lh:audit:http-status-code",
+              "name": "lh:audit:meta-description",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 208,
-              "name": "lh:audit:link-text",
+              "name": "lh:audit:http-status-code",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 209,
-              "name": "lh:audit:crawlable-anchors",
+              "name": "lh:audit:link-text",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 210,
-              "name": "lh:audit:is-crawlable",
+              "name": "lh:audit:crawlable-anchors",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 211,
-              "name": "lh:audit:robots-txt",
+              "name": "lh:audit:is-crawlable",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 212,
-              "name": "lh:audit:hreflang",
+              "name": "lh:audit:robots-txt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 213,
-              "name": "lh:audit:canonical",
+              "name": "lh:audit:hreflang",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 214,
-              "name": "lh:audit:structured-data",
+              "name": "lh:audit:canonical",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 215,
-              "name": "lh:audit:bf-cache",
+              "name": "lh:audit:structured-data",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 216,
-              "name": "lh:audit:cache-insight",
+              "name": "lh:audit:bf-cache",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 217,
-              "name": "lh:audit:cls-culprits-insight",
+              "name": "lh:audit:cache-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 218,
-              "name": "lh:audit:document-latency-insight",
+              "name": "lh:audit:cls-culprits-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 219,
-              "name": "lh:audit:dom-size-insight",
+              "name": "lh:audit:document-latency-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 220,
-              "name": "lh:audit:duplicated-javascript-insight",
+              "name": "lh:audit:dom-size-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 221,
-              "name": "lh:audit:font-display-insight",
+              "name": "lh:audit:duplicated-javascript-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 222,
-              "name": "lh:audit:forced-reflow-insight",
+              "name": "lh:audit:font-display-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 223,
-              "name": "lh:audit:image-delivery-insight",
+              "name": "lh:audit:forced-reflow-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 224,
-              "name": "lh:audit:inp-breakdown-insight",
+              "name": "lh:audit:image-delivery-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 225,
-              "name": "lh:audit:lcp-breakdown-insight",
+              "name": "lh:audit:inp-breakdown-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 226,
-              "name": "lh:audit:lcp-discovery-insight",
+              "name": "lh:audit:lcp-breakdown-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 227,
-              "name": "lh:audit:legacy-javascript-insight",
+              "name": "lh:audit:lcp-discovery-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 228,
-              "name": "lh:audit:network-dependency-tree-insight",
+              "name": "lh:audit:legacy-javascript-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 229,
-              "name": "lh:audit:render-blocking-insight",
+              "name": "lh:audit:network-dependency-tree-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 230,
-              "name": "lh:audit:third-parties-insight",
+              "name": "lh:audit:render-blocking-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 231,
-              "name": "lh:audit:viewport-insight",
+              "name": "lh:audit:third-parties-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 232,
+              "name": "lh:audit:viewport-insight",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 233,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 233
+          "total": 234
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -6605,7 +6644,8 @@
               "audits[errors-in-console].details.headings[0].label",
               "audits.deprecations.details.headings[1].label",
               "audits[geolocation-on-start].details.headings[0].label",
-              "audits[notification-on-start].details.headings[0].label"
+              "audits[notification-on-start].details.headings[0].label",
+              "audits.baseline.details.headings[2].label"
             ],
             "core/lib/i18n/i18n.js | columnDescription": [
               "audits[errors-in-console].details.headings[1].label",
@@ -7400,6 +7440,18 @@
             ],
             "core/audits/dobetterweb/paste-preventing-inputs.js | description": [
               "audits[paste-preventing-inputs].description"
+            ],
+            "core/audits/baseline.js | title": [
+              "audits.baseline.title"
+            ],
+            "core/audits/baseline.js | description": [
+              "audits.baseline.description"
+            ],
+            "core/audits/baseline.js | columnFeature": [
+              "audits.baseline.details.headings[0].label"
+            ],
+            "core/audits/baseline.js | columnStatus": [
+              "audits.baseline.details.headings[1].label"
             ],
             "core/audits/seo/meta-description.js | title": [
               "audits[meta-description].title"
@@ -9058,6 +9110,34 @@
               "items": []
             }
           },
+          "baseline": {
+            "id": "baseline",
+            "title": "Baseline Features",
+            "description": "Lists web features used on the page and their Baseline status. [Learn more about Baseline](https://webstatus.dev/).",
+            "score": 1,
+            "scoreDisplayMode": "informative",
+            "details": {
+              "type": "table",
+              "headings": [
+                {
+                  "key": "featureId",
+                  "valueType": "link",
+                  "label": "Web-features"
+                },
+                {
+                  "key": "displayStatus",
+                  "valueType": "text",
+                  "label": "Baseline Status"
+                },
+                {
+                  "key": "source",
+                  "valueType": "source-location",
+                  "label": "Source"
+                }
+              ],
+              "items": []
+            }
+          },
           "bf-cache": {
             "id": "bf-cache",
             "title": "Page didn't prevent back/forward cache restoration",
@@ -9513,6 +9593,11 @@
                 "id": "image-size-responsive",
                 "weight": 1,
                 "group": "best-practices-ux"
+              },
+              {
+                "id": "baseline",
+                "weight": 0,
+                "group": "best-practices-browser-compat"
               },
               {
                 "id": "deprecations",
@@ -10287,114 +10372,120 @@
             },
             {
               "startTime": 84,
-              "name": "lh:audit:bf-cache",
+              "name": "lh:audit:baseline",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 85,
-              "name": "lh:audit:cache-insight",
+              "name": "lh:audit:bf-cache",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 86,
-              "name": "lh:audit:cls-culprits-insight",
+              "name": "lh:audit:cache-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 87,
-              "name": "lh:audit:document-latency-insight",
+              "name": "lh:audit:cls-culprits-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 88,
-              "name": "lh:audit:dom-size-insight",
+              "name": "lh:audit:document-latency-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 89,
-              "name": "lh:audit:duplicated-javascript-insight",
+              "name": "lh:audit:dom-size-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 90,
-              "name": "lh:audit:font-display-insight",
+              "name": "lh:audit:duplicated-javascript-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 91,
-              "name": "lh:audit:forced-reflow-insight",
+              "name": "lh:audit:font-display-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 92,
-              "name": "lh:audit:image-delivery-insight",
+              "name": "lh:audit:forced-reflow-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 93,
-              "name": "lh:audit:inp-breakdown-insight",
+              "name": "lh:audit:image-delivery-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 94,
-              "name": "lh:audit:lcp-breakdown-insight",
+              "name": "lh:audit:inp-breakdown-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 95,
-              "name": "lh:audit:lcp-discovery-insight",
+              "name": "lh:audit:lcp-breakdown-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 96,
-              "name": "lh:audit:legacy-javascript-insight",
+              "name": "lh:audit:lcp-discovery-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 97,
-              "name": "lh:audit:network-dependency-tree-insight",
+              "name": "lh:audit:legacy-javascript-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 98,
-              "name": "lh:audit:render-blocking-insight",
+              "name": "lh:audit:network-dependency-tree-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 99,
-              "name": "lh:audit:third-parties-insight",
+              "name": "lh:audit:render-blocking-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 100,
-              "name": "lh:audit:viewport-insight",
+              "name": "lh:audit:third-parties-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 101,
+              "name": "lh:audit:viewport-insight",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 102,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 102
+          "total": 103
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -10688,7 +10779,8 @@
             ],
             "core/lib/i18n/i18n.js | columnSource": [
               "audits[errors-in-console].details.headings[0].label",
-              "audits.deprecations.details.headings[1].label"
+              "audits.deprecations.details.headings[1].label",
+              "audits.baseline.details.headings[2].label"
             ],
             "core/lib/i18n/i18n.js | columnDescription": [
               "audits[errors-in-console].details.headings[1].label"
@@ -10913,6 +11005,18 @@
             ],
             "core/audits/dobetterweb/inspector-issues.js | columnIssueType": [
               "audits[inspector-issues].details.headings[0].label"
+            ],
+            "core/audits/baseline.js | title": [
+              "audits.baseline.title"
+            ],
+            "core/audits/baseline.js | description": [
+              "audits.baseline.description"
+            ],
+            "core/audits/baseline.js | columnFeature": [
+              "audits.baseline.details.headings[0].label"
+            ],
+            "core/audits/baseline.js | columnStatus": [
+              "audits.baseline.details.headings[1].label"
             ],
             "core/audits/bf-cache.js | title": [
               "audits[bf-cache].title"
@@ -19797,6 +19901,34 @@
               "items": []
             }
           },
+          "baseline": {
+            "id": "baseline",
+            "title": "Baseline Features",
+            "description": "Lists web features used on the page and their Baseline status. [Learn more about Baseline](https://webstatus.dev/).",
+            "score": 1,
+            "scoreDisplayMode": "informative",
+            "details": {
+              "type": "table",
+              "headings": [
+                {
+                  "key": "featureId",
+                  "valueType": "link",
+                  "label": "Web-features"
+                },
+                {
+                  "key": "displayStatus",
+                  "valueType": "text",
+                  "label": "Baseline Status"
+                },
+                {
+                  "key": "source",
+                  "valueType": "source-location",
+                  "label": "Source"
+                }
+              ],
+              "items": []
+            }
+          },
           "meta-description": {
             "id": "meta-description",
             "title": "Document has a meta description",
@@ -21002,6 +21134,11 @@
               {
                 "id": "charset",
                 "weight": 1,
+                "group": "best-practices-browser-compat"
+              },
+              {
+                "id": "baseline",
+                "weight": 0,
                 "group": "best-practices-browser-compat"
               },
               {
@@ -23022,168 +23159,174 @@
             },
             {
               "startTime": 205,
-              "name": "lh:audit:meta-description",
+              "name": "lh:audit:baseline",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 206,
-              "name": "lh:audit:http-status-code",
+              "name": "lh:audit:meta-description",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 207,
-              "name": "lh:audit:link-text",
+              "name": "lh:audit:http-status-code",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 208,
-              "name": "lh:audit:crawlable-anchors",
+              "name": "lh:audit:link-text",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 209,
-              "name": "lh:audit:is-crawlable",
+              "name": "lh:audit:crawlable-anchors",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 210,
-              "name": "lh:audit:robots-txt",
+              "name": "lh:audit:is-crawlable",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 211,
-              "name": "lh:audit:hreflang",
+              "name": "lh:audit:robots-txt",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 212,
-              "name": "lh:audit:canonical",
+              "name": "lh:audit:hreflang",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 213,
-              "name": "lh:audit:structured-data",
+              "name": "lh:audit:canonical",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 214,
-              "name": "lh:audit:bf-cache",
+              "name": "lh:audit:structured-data",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 215,
-              "name": "lh:audit:cache-insight",
+              "name": "lh:audit:bf-cache",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 216,
-              "name": "lh:audit:cls-culprits-insight",
+              "name": "lh:audit:cache-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 217,
-              "name": "lh:audit:document-latency-insight",
+              "name": "lh:audit:cls-culprits-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 218,
-              "name": "lh:audit:dom-size-insight",
+              "name": "lh:audit:document-latency-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 219,
-              "name": "lh:audit:duplicated-javascript-insight",
+              "name": "lh:audit:dom-size-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 220,
-              "name": "lh:audit:font-display-insight",
+              "name": "lh:audit:duplicated-javascript-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 221,
-              "name": "lh:audit:forced-reflow-insight",
+              "name": "lh:audit:font-display-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 222,
-              "name": "lh:audit:image-delivery-insight",
+              "name": "lh:audit:forced-reflow-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 223,
-              "name": "lh:audit:inp-breakdown-insight",
+              "name": "lh:audit:image-delivery-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 224,
-              "name": "lh:audit:lcp-breakdown-insight",
+              "name": "lh:audit:inp-breakdown-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 225,
-              "name": "lh:audit:lcp-discovery-insight",
+              "name": "lh:audit:lcp-breakdown-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 226,
-              "name": "lh:audit:legacy-javascript-insight",
+              "name": "lh:audit:lcp-discovery-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 227,
-              "name": "lh:audit:network-dependency-tree-insight",
+              "name": "lh:audit:legacy-javascript-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 228,
-              "name": "lh:audit:render-blocking-insight",
+              "name": "lh:audit:network-dependency-tree-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 229,
-              "name": "lh:audit:third-parties-insight",
+              "name": "lh:audit:render-blocking-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 230,
-              "name": "lh:audit:viewport-insight",
+              "name": "lh:audit:third-parties-insight",
               "duration": 1,
               "entryType": "measure"
             },
             {
               "startTime": 231,
+              "name": "lh:audit:viewport-insight",
+              "duration": 1,
+              "entryType": "measure"
+            },
+            {
+              "startTime": 232,
               "name": "lh:runner:generate",
               "duration": 1,
               "entryType": "measure"
             }
           ],
-          "total": 232
+          "total": 233
         },
         "i18n": {
           "rendererFormattedStrings": {
@@ -23546,7 +23689,8 @@
               "audits[errors-in-console].details.headings[0].label",
               "audits.deprecations.details.headings[1].label",
               "audits[geolocation-on-start].details.headings[0].label",
-              "audits[notification-on-start].details.headings[0].label"
+              "audits[notification-on-start].details.headings[0].label",
+              "audits.baseline.details.headings[2].label"
             ],
             "core/lib/i18n/i18n.js | columnDescription": [
               "audits[errors-in-console].details.headings[1].label",
@@ -24341,6 +24485,18 @@
             ],
             "core/audits/dobetterweb/paste-preventing-inputs.js | description": [
               "audits[paste-preventing-inputs].description"
+            ],
+            "core/audits/baseline.js | title": [
+              "audits.baseline.title"
+            ],
+            "core/audits/baseline.js | description": [
+              "audits.baseline.description"
+            ],
+            "core/audits/baseline.js | columnFeature": [
+              "audits.baseline.details.headings[0].label"
+            ],
+            "core/audits/baseline.js | columnStatus": [
+              "audits.baseline.details.headings[1].label"
             ],
             "core/audits/seo/meta-description.js | title": [
               "audits[meta-description].title"

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -4387,6 +4387,105 @@
         ]
       }
     },
+    "baseline": {
+      "id": "baseline",
+      "title": "Baseline Features",
+      "description": "Lists web features used on the page and their Baseline status. [Learn more about Baseline](https://webstatus.dev/).",
+      "score": 1,
+      "scoreDisplayMode": "informative",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "featureId",
+            "valueType": "link",
+            "label": "Web-features"
+          },
+          {
+            "key": "displayStatus",
+            "valueType": "text",
+            "label": "Baseline Status"
+          },
+          {
+            "key": "source",
+            "valueType": "source-location",
+            "label": "Source"
+          }
+        ],
+        "items": [
+          {
+            "featureId": {
+              "type": "link",
+              "text": "request-animation-frame",
+              "url": "https://webstatus.dev/features/request-animation-frame"
+            },
+            "displayStatus": "Widely Available (2015-07-29)",
+            "source": {
+              "type": "source-location",
+              "url": "http://localhost:10200/dobetterweb/dbw_tester.html",
+              "urlProvider": "network",
+              "line": 412,
+              "column": 2
+            }
+          },
+          {
+            "featureId": {
+              "type": "link",
+              "text": "intersection-observer",
+              "url": "https://webstatus.dev/features/intersection-observer"
+            },
+            "displayStatus": "Widely Available (2019-03-25)",
+            "source": {
+              "type": "source-location",
+              "url": "http://localhost:10200/dobetterweb/third_party/aggressive-promise-polyfill.js",
+              "urlProvider": "network",
+              "line": 969,
+              "column": 23
+            }
+          },
+          {
+            "featureId": {
+              "type": "link",
+              "text": "template",
+              "url": "https://webstatus.dev/features/template"
+            },
+            "displayStatus": "Widely Available (2015-11-12)"
+          },
+          {
+            "featureId": {
+              "type": "link",
+              "text": "js-modules",
+              "url": "https://webstatus.dev/features/js-modules"
+            },
+            "displayStatus": "Widely Available (2018-05-09)"
+          },
+          {
+            "featureId": {
+              "type": "link",
+              "text": "slot",
+              "url": "https://webstatus.dev/features/slot"
+            },
+            "displayStatus": "Widely Available (2020-01-15)"
+          },
+          {
+            "featureId": {
+              "type": "link",
+              "text": "not",
+              "url": "https://webstatus.dev/features/not"
+            },
+            "displayStatus": "Widely Available (2021-01-21)"
+          },
+          {
+            "featureId": {
+              "type": "link",
+              "text": "fetch-priority",
+              "url": "https://webstatus.dev/features/fetch-priority"
+            },
+            "displayStatus": "Newly Available (2024-10-29)"
+          }
+        ]
+      }
+    },
     "meta-description": {
       "id": "meta-description",
       "title": "Document does not have a meta description",
@@ -6600,6 +6699,11 @@
         {
           "id": "charset",
           "weight": 1,
+          "group": "best-practices-browser-compat"
+        },
+        {
+          "id": "baseline",
+          "weight": 0,
           "group": "best-practices-browser-compat"
         },
         {
@@ -9541,6 +9645,12 @@
       },
       {
         "startTime": 0,
+        "name": "lh:audit:baseline",
+        "duration": 100,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 0,
         "name": "lh:audit:meta-description",
         "duration": 100,
         "entryType": "measure"
@@ -9914,6 +10024,7 @@
         "audits.deprecations.details.headings[1].label",
         "audits[geolocation-on-start].details.headings[0].label",
         "audits[notification-on-start].details.headings[0].label",
+        "audits.baseline.details.headings[2].label",
         "audits[forced-reflow-insight].details.items[0].headings[0].label"
       ],
       "core/lib/i18n/i18n.js | columnDescription": [
@@ -10827,6 +10938,18 @@
       ],
       "core/audits/dobetterweb/paste-preventing-inputs.js | description": [
         "audits[paste-preventing-inputs].description"
+      ],
+      "core/audits/baseline.js | title": [
+        "audits.baseline.title"
+      ],
+      "core/audits/baseline.js | description": [
+        "audits.baseline.description"
+      ],
+      "core/audits/baseline.js | columnFeature": [
+        "audits.baseline.details.headings[0].label"
+      ],
+      "core/audits/baseline.js | columnStatus": [
+        "audits.baseline.details.headings[1].label"
       ],
       "core/audits/seo/meta-description.js | failureTitle": [
         "audits[meta-description].title"

--- a/core/test/scenarios/__snapshots__/api-test-pptr.js.snap
+++ b/core/test/scenarios/__snapshots__/api-test-pptr.js.snap
@@ -25,6 +25,7 @@ Array [
   "aria-treeitem-name",
   "aria-valid-attr",
   "aria-valid-attr-value",
+  "baseline",
   "bf-cache",
   "bootup-time",
   "button-name",
@@ -181,6 +182,7 @@ Array [
   "aria-treeitem-name",
   "aria-valid-attr",
   "aria-valid-attr-value",
+  "baseline",
   "bf-cache",
   "bootup-time",
   "button-name",
@@ -403,6 +405,7 @@ Array [
 
 exports[`Individual modes API startTimespan should compute ConsoleMessage results across a span of time 1`] = `
 Array [
+  "baseline",
   "bf-cache",
   "bootup-time",
   "cache-insight",
@@ -480,6 +483,7 @@ Array [
 
 exports[`Individual modes API startTimespan should compute results from timespan after page load 1`] = `
 Array [
+  "baseline",
   "bf-cache",
   "bootup-time",
   "cache-insight",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
     "typed-query-selector": "^2.12.0",
     "typescript": "5.8.2",
     "wait-for-expect": "^3.0.2",
-    "web-features": "^3.17.0",
     "webtreemap-cdt": "^3.2.1"
   },
   "dependencies": {
@@ -205,6 +204,7 @@
     "speedline-core": "^1.4.3",
     "third-party-web": "^0.27.0",
     "tldts-icann": "^7.0.17",
+    "web-features": "^3.21.0",
     "ws": "^7.0.0",
     "yargs": "^17.3.1",
     "yargs-parser": "^21.0.0"

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -603,10 +603,10 @@
     "message": "Baseline Status"
   },
   "core/audits/baseline.js | description": {
-    "message": "Returns a list of web features used on the page and their Baseline status.[Learn more about Baseline](https://webstatus.dev/)."
+    "message": "Lists web features used on the page and their Baseline status. [Learn more about Baseline](https://webstatus.dev/)."
   },
   "core/audits/baseline.js | title": {
-    "message": "Baseline"
+    "message": "Baseline Features"
   },
   "core/audits/bf-cache.js | actionableFailureType": {
     "message": "Actionable"
@@ -3492,4 +3492,3 @@
     "message": "Unused bytes"
   }
 }
-

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -603,10 +603,10 @@
     "message": "B̂áŝél̂ín̂é Ŝt́ât́ûś"
   },
   "core/audits/baseline.js | description": {
-    "message": "R̂ét̂úr̂ńŝ á l̂íŝt́ ôf́ ŵéb̂ f́êát̂úr̂éŝ úŝéd̂ ón̂ t́ĥé p̂áĝé âńd̂ t́ĥéîŕ B̂áŝél̂ín̂é ŝt́ât́ûś.[L̂éâŕn̂ ḿôŕê áb̂óût́ B̂áŝél̂ín̂é](https://webstatus.dev/)."
+    "message": "L̂íŝt́ŝ ẃêb́ f̂éât́ûŕêś ûśêd́ ôń t̂h́ê ṕâǵê án̂d́ t̂h́êír̂ B́âśêĺîńê śt̂át̂úŝ. [Ĺêár̂ń m̂ór̂é âb́ôút̂ B́âśêĺîńê](https://webstatus.dev/)."
   },
   "core/audits/baseline.js | title": {
-    "message": "B̂áŝél̂ín̂é"
+    "message": "B̂áŝél̂ín̂é F̂éât́ûŕêś"
   },
   "core/audits/bf-cache.js | actionableFailureType": {
     "message": "Âćt̂íôńâb́l̂é"
@@ -3492,4 +3492,3 @@
     "message": "Ûńûśêd́ b̂ýt̂éŝ"
   }
 }
-

--- a/third-party/devtools-tests/e2e/lighthouse/navigation.test.ts
+++ b/third-party/devtools-tests/e2e/lighthouse/navigation.test.ts
@@ -105,7 +105,7 @@ describe('Navigation', function() {
       });
 
       const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr, ['max-potential-fid']);
-      assert.lengthOf(auditResults, 151);
+      assert.lengthOf(auditResults, 152);
       assert.deepEqual(erroredAudits, []);
       assert.deepEqual(failedAudits.map(audit => audit.id), [
         'document-title',
@@ -198,7 +198,7 @@ describe('Navigation', function() {
       ];
 
       const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr, flakyAudits);
-      assert.lengthOf(auditResults, 151);
+      assert.lengthOf(auditResults, 152);
       assert.deepEqual(erroredAudits, []);
       assert.deepEqual(failedAudits.map(audit => audit.id), [
         'document-title',

--- a/third-party/devtools-tests/e2e/lighthouse/timespan.test.ts
+++ b/third-party/devtools-tests/e2e/lighthouse/timespan.test.ts
@@ -90,7 +90,7 @@ describe('Timespan', function() {
     assert.strictEqual(devicePixelRatio, 1);
 
     const {auditResults, erroredAudits, failedAudits} = getAuditsBreakdown(lhr);
-    assert.lengthOf(auditResults, 48);
+    assert.lengthOf(auditResults, 49);
     assert.deepEqual(erroredAudits, []);
     assert.deepEqual(failedAudits.map(audit => audit), []);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8119,10 +8119,10 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-web-features@^3.17.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/web-features/-/web-features-3.19.0.tgz#c948db265117dc520d504a53ec6955ea1b585f7c"
-  integrity sha512-csr7EVdiEdWev1RdDmNcDi+w6eg2234+oVgKOyJHNUgShYmC1w+XaDIxcg/gdYXut4Zuf7vIPzhdTgXk5U1ehA==
+web-features@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/web-features/-/web-features-3.21.0.tgz#e1e648e9d23ae104432b3eaeb1f2c987c5020d04"
+  integrity sha512-KfLWQivp9KjNSvL62+Cu83dAfhTqr4EsDTCZP87IKQfhMSpYqXJZxgXwKz4+RbH5UFIHdnKQoK7jMfdwTWOd/A==
 
 webdriver-bidi-protocol@0.3.6:
   version "0.3.6"


### PR DESCRIPTION
This PR adds the baseline-compatibility audit to the default Lighthouse configuration, enabling it by default. It also includes a new smoke test to verify the audit's functionality and updates relevant snapshots.
<img width="1110" height="1096" alt="baseline-audit-example" src="https://github.com/user-attachments/assets/eb7e5ef0-882e-4004-92f0-31f7b09dd21b" />
