### PR TITLE
tests(smokehouse): fix baseline config to use onlyAudits

### DIFF
--- a/cli/test/smokehouse/test-definitions/baseline.js
+++ b/cli/test/smokehouse/test-definitions/baseline.js
@@ -7,9 +7,11 @@
 /** @type {LH.Config} */
 const config = {
   extends: 'lighthouse:default',
-  audits: [
-    'baseline',
-  ],
+  settings: {
+    onlyAudits: [
+      'baseline',
+    ],
+  },
   categories: {
     // @ts-expect-error: `title` is required in CategoryJson but we rely on the default config to provide it.
     'best-practices': {


### PR DESCRIPTION
  The Lightrider error `Failed to resolve module specifier 'baseline.js'` was likely caused by the test config using the audits array, which can trigger dynamic module resolution in Lighthouse's config system.

 This is more consistent with other smoke tests and probably avoids the resolution error in bundled environments.

cc @TravenReese 