### PR TITLE
core(source-maps): guard against out-of-bounds sourceIndex

### DIFF
--- a/build/build-cdt-lib.js
+++ b/build/build-cdt-lib.js
@@ -57,6 +57,8 @@ const modifications = [
       // eslint-disable-next-line max-len
       'Root.Runtime.experiments.isEnabled(Root.Runtime.ExperimentName.USE_SOURCE_MAP_SCOPES)': 'false',
       'Common.Base64.BASE64_CODES': 'BASE64_CODES',
+      // Guard against out-of-bounds sourceIndex when source maps have empty/malformed sources.
+      'this.#sourceInfos[sourceIndex].sourceURL': 'this.#sourceInfos[sourceIndex]?.sourceURL',
       '* Implements Source Map V3 model.': [
         '* @param {string} compiledURL',
         '* @param {string} sourceMappingURL',
@@ -160,7 +162,7 @@ function doModification(modification) {
   // First pass - do raw string replacements.
   let modifiedCode = code;
   for (const [code, replacement] of Object.entries(rawCodeToReplace)) {
-    modifiedCode = modifiedCode.replace(code, replacement);
+    modifiedCode = modifiedCode.replaceAll(code, replacement);
   }
 
   const codeTranspiledToCommonJS = ts.transpileModule(modifiedCode, {

--- a/core/lib/cdt/generated/SourceMap.js
+++ b/core/lib/cdt/generated/SourceMap.js
@@ -381,7 +381,7 @@ class SourceMap {
         let nameIndex = 0;
         const names = map.names ?? [];
         const tokenIter = new TokenIterator(map.mappings);
-        let sourceURL = this.#sourceInfos[sourceIndex].sourceURL;
+        let sourceURL = this.#sourceInfos[sourceIndex]?.sourceURL;
         while (true) {
             if (tokenIter.peek() === ',') {
                 tokenIter.next();
@@ -404,7 +404,7 @@ class SourceMap {
             const sourceIndexDelta = tokenIter.nextVLQ();
             if (sourceIndexDelta) {
                 sourceIndex += sourceIndexDelta;
-                sourceURL = this.#sourceInfos[sourceIndex].sourceURL;
+                sourceURL = this.#sourceInfos[sourceIndex]?.sourceURL;
             }
             sourceLineNumber += tokenIter.nextVLQ();
             sourceColumnNumber += tokenIter.nextVLQ();


### PR DESCRIPTION
## Summary

When a source map has an empty or malformed `sources` array, `this.#sourceInfos[sourceIndex]` is `undefined`, causing:

```
TypeError: Cannot read properties of undefined (reading 'sourceURL')
    at SourceMap.parseMap (SourceMap.js:384:56)
```

This crash is caught by the `try/catch` in `#ensureMappingsProcessed`, so the scan continues — but it logs a noisy error and prevents the `DuplicatedJavaScript` insight from running for the affected page.

### Changes

- **`core/lib/cdt/generated/SourceMap.js`**: Add optional chaining (`?.`) to both `this.#sourceInfos[sourceIndex].sourceURL` access sites in `parseMap` (lines 384 and 407).
- **`build/build-cdt-lib.js`**:
  - Add a `rawCodeToReplace` entry so the fix survives CDT source re-rolls.
  - Use `replaceAll` instead of `replace` in the raw-code replacement loop to ensure all occurrences of a pattern are substituted (previously only the first match was replaced).

### Reproduction

Run Lighthouse on any page that serves a source map with an empty `sources` array or where the VLQ-decoded source index exceeds the bounds of the `sources` array.