### PR TITLE
core(insights): fix TypeError regression after trace_engine upgrade

### DIFF
--- a/core/audits/insights/insight-audit.js
+++ b/core/audits/insights/insight-audit.js
@@ -58,7 +58,7 @@ async function adaptInsightToAuditProduct(artifacts, context, insightName, creat
     };
   }
 
-  const error = insights.modelErrors[insightName];
+  const error = insights.modelErrors?.[insightName];
   if (error) {
     return {
       errorMessage: error.message,


### PR DESCRIPTION
Use optional to prevent a TypeError when modelErrors is undefined. This can be missing in some trace results, which was causing crashes in tests like api-test-pptr.js after the recent trace_engine upgrade.
