### PR TITLE
deps: upgrade web-features to 3.24.0

### DIFF
--- a/core/scripts/upgrade-deps.sh
+++ b/core/scripts/upgrade-deps.sh
@@ -26,6 +26,7 @@ yarn upgrade --latest \
     speedline-core \
     third-party-web \
     tldts-icann \
+    web-features \
 
 node -e "
     const pkg = require('$LH_ROOT/package.json');

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "speedline-core": "^1.4.3",
     "third-party-web": "^0.29.0",
     "tldts-icann": "^7.0.27",
-    "web-features": "^3.21.0",
+    "web-features": "^3.24.0",
     "ws": "^7.0.0",
     "yargs": "^17.3.1",
     "yargs-parser": "^21.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8129,10 +8129,10 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-web-features@^3.21.0:
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/web-features/-/web-features-3.21.0.tgz#e1e648e9d23ae104432b3eaeb1f2c987c5020d04"
-  integrity sha512-KfLWQivp9KjNSvL62+Cu83dAfhTqr4EsDTCZP87IKQfhMSpYqXJZxgXwKz4+RbH5UFIHdnKQoK7jMfdwTWOd/A==
+web-features@^3.24.0:
+  version "3.24.0"
+  resolved "https://registry.yarnpkg.com/web-features/-/web-features-3.24.0.tgz#2583eb1289bb3311aaaa896f7c91b67dbb04d775"
+  integrity sha512-D/e/FlTPpbTbSHwwS+8qgwP6E6TTlYnTJnSk/y80GKqlUVrtq69fpXZrcDy6GhNGgqUYtG8nOoiXj+Fh/a1dBQ==
 
 webdriver-bidi-protocol@0.4.1:
   version "0.4.1"


### PR DESCRIPTION
* Add `web-features` to the upgrade-deps.sh script to keep it fresh with every release
* Update to 3.24.0

BTW, at least for Node users, since `web-features` is pinned with `^`, that means Node users can always pull in the latest version of `web-features` on their end and Lighthouse for Node will use it.