### PR TITLE
core(config): import LH types in exported configs

### DIFF
--- a/core/config/agentic-browsing-config.js
+++ b/core/config/agentic-browsing-config.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as LH from '../../types/lh.js';
 import * as i18n from '../lib/i18n/i18n.js';
 
 const UIStrings = {

--- a/core/config/experimental-config.js
+++ b/core/config/experimental-config.js
@@ -9,6 +9,8 @@
  * being enabled by default.
  */
 
+import * as LH from '../../types/lh.js';
+
 /** @type {LH.Config} */
 const config = {
   extends: 'lighthouse:default',

--- a/core/config/full-config.js
+++ b/core/config/full-config.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as LH from '../../types/lh.js';
+
 /** @type {LH.Config} */
 const fullConfig = {
   extends: 'lighthouse:default',

--- a/core/config/lr-desktop-config.js
+++ b/core/config/lr-desktop-config.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as LH from '../../types/lh.js';
 import * as constants from './constants.js';
 
 /** @type {LH.Config} */

--- a/core/config/lr-mobile-config.js
+++ b/core/config/lr-mobile-config.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as LH from '../../types/lh.js';
+
 /** @type {LH.Config} */
 const config = {
   extends: 'lighthouse:default',

--- a/core/config/perf-config.js
+++ b/core/config/perf-config.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as LH from '../../types/lh.js';
+
 /** @type {LH.Config} */
 const perfConfig = {
   extends: 'lighthouse:default',


### PR DESCRIPTION
**Summary**
- fixes the generated declaration files for exported configs that currently emit `LH.Config` without importing `../../types/lh.js`
- reproduces #16503 and the same missing-import problem on the other exported config entry points in `core/config/`
- aligns these config modules with the existing pattern already used by configs like `default-config.js` and `desktop-config.js`

**Related Issues/PRs**
- Fixes #16503

Failing scenario before this change:
- a strict TypeScript project importing `lighthouse/core/config/lr-mobile-config.js` failed with `TS2503: Cannot find namespace 'LH'`
- the generated `.d.ts` for the affected config exports declared `LH.Config` without importing `../../types/lh.js`

After this change:
- the emitted declarations import `../../types/lh.js`, so those config entry points type-check correctly for external consumers

Validation:
- `yarn type-check`
- strict external consumer `tsc` against the built repo tree importing the affected `core/config/*.js` entry points
- `yarn build-pack`
- strict external consumer `tsc` against the packed `dist/lighthouse.tgz` importing `lighthouse/core/config/lr-mobile-config.js`, `lighthouse/core/config/lr-desktop-config.js`, and `lighthouse/core/config/perf-config.js`
