### PR TITLE
misc(build): include license.md in bundle

### DIFF
--- a/build/build-bundle-mcp.js
+++ b/build/build-bundle-mcp.js
@@ -387,6 +387,7 @@ function generateThirdPartyNotices({metafile, sources, inlinedFiles, distDir}) {
       path.join(nodeModulePath, 'LICENSE'),
       path.join(nodeModulePath, 'LICENSE.txt'),
       path.join(nodeModulePath, 'LICENSE.md'),
+      path.join(nodeModulePath, 'license.md'),
       path.join(nodeModulePath, 'LICENSE.MIT'),
       path.join(nodeModulePath, 'LICENSE.APACHE'),
     ];


### PR DESCRIPTION
zeit/ms is using a `license.md` file