### PR TITLE
core(config): update llms.txt to refine validation logic

### DIFF
--- a/core/audits/agentic/llms-txt.js
+++ b/core/audits/agentic/llms-txt.js
@@ -73,7 +73,7 @@ class LlmsTxt extends Audit {
         score: 0,
         displayValue: str_(UIStrings.displayValueHttpBadCode, {statusCode: status}),
       };
-    } else if (status >= HTTP_CLIENT_ERROR_CODE_LOW || content === '') {
+    } else if (status >= HTTP_CLIENT_ERROR_CODE_LOW) {
       return {
         score: 1,
         notApplicable: true,

--- a/core/test/audits/agentic/llms-txt-test.js
+++ b/core/test/audits/agentic/llms-txt-test.js
@@ -9,19 +9,6 @@ import assert from 'assert/strict';
 import LlmsTxtAudit from '../../../audits/agentic/llms-txt.js';
 
 describe('Agentic: llms.txt audit', () => {
-  it('fails and reports error when no llms.txt was provided', () => {
-    const artifacts = {
-      LlmsTxt: {
-        status: null,
-        content: null,
-      },
-    };
-
-    const auditResult = LlmsTxtAudit.audit(artifacts);
-    assert.equal(auditResult.score, 0);
-    assert.ok(auditResult.explanation);
-  });
-
   it('fails when request for /llms.txt returns a HTTP500+ error', () => {
     const testData = [
       {
@@ -78,6 +65,13 @@ describe('Agentic: llms.txt audit', () => {
         },
         expectedErrors: 3, // Missing H1, Missing links, Too short
       },
+      {
+        LlmsTxt: {
+          status: 200,
+          content: '',
+        },
+        expectedErrors: 3, // Missing H1, Missing links, Too short
+      },
     ];
 
     testData.forEach(({LlmsTxt, expectedErrors}) => {
@@ -92,7 +86,7 @@ describe('Agentic: llms.txt audit', () => {
     });
   });
 
-  it('not applicable when there is no llms.txt or it\'s empty', () => {
+  it('not applicable when there is no llms.txt', () => {
     const testData = [
       {
         status: 404,
@@ -101,10 +95,6 @@ describe('Agentic: llms.txt audit', () => {
       {
         status: 401,
         content: 'invalid content',
-      },
-      {
-        status: 200,
-        content: '',
       },
     ];
 


### PR DESCRIPTION
This PR refines the llms.txt audit logic to distinguish between missing and empty files. While missing files (404s) continue to result in a notApplicable status, an empty llms.txt file will now trigger a failure. Essentially, if the file is present, it must contain valid content
