### PR TITLE
tests(webmcp): add webmcp smoketests

### DIFF
--- a/cli/test/fixtures/webmcp/webmcp_tester.html
+++ b/cli/test/fixtures/webmcp/webmcp_tester.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>WebMCP Smoke Test Page</title>
+</head>
+<body>
+  <h1>WebMCP Testing Ground</h1>
+
+  <!-- 1. Declarative Tool (Valid Form) -->
+  <h2>Declarative Tool (Valid)</h2>
+  <form id="valid-declarative-form" toolname="declarative_search" tooldescription="Search catalog for items.">
+    <input type="text" name="query" toolparamdescription="The search query terms." required>
+    <button type="submit">Search</button>
+  </form>
+
+  <!-- 2. Form WITHOUT WebMCP (Unannotated Form) -->
+  <h2>Unannotated Form (Should be flagged by coverage)</h2>
+  <form id="unannotated-form" action="/submit">
+    <input type="text" name="username">
+    <input type="password" name="password">
+    <button type="submit">Login</button>
+  </form>
+
+  <!-- 3. Failing Declarative Tool (Missing toolname) -->
+  <h2>Declarative Tool with Missing Toolname (Should fail schema validity)</h2>
+  <form id="invalid-declarative-form" tooldescription="This tool registration should fail because it lacks a toolname.">
+    <input type="text" name="feedback" toolparamdescription="Your feedback.">
+    <button type="submit">Submit Feedback</button>
+  </form>
+
+  <!-- 4. Imperative Tool (JavaScript) -->
+  <h2>Imperative Tool</h2>
+  <script>
+    if (navigator.modelContext && typeof navigator.modelContext.registerTool === 'function') {
+      navigator.modelContext.registerTool({
+        name: 'imperative_calculate',
+        description: 'Calculates the sum of two numbers.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            a: {type: 'number', description: 'First number'},
+            b: {type: 'number', description: 'Second number'}
+          },
+          required: ['a', 'b']
+        }
+      }, async (params) => {
+        return {result: Number(params.a) + Number(params.b)};
+      });
+    } else {
+      console.warn('navigator.modelContext is not available in this browser session.');
+    }
+  </script>
+</body>
+</html>

--- a/cli/test/fixtures/webmcp/webmcp_tester.html
+++ b/cli/test/fixtures/webmcp/webmcp_tester.html
@@ -22,33 +22,20 @@
     <button type="submit">Login</button>
   </form>
 
-  <!-- 3. Failing Declarative Tool (Missing toolname) -->
-  <h2>Declarative Tool with Missing Toolname (Should fail schema validity)</h2>
-  <form id="invalid-declarative-form" tooldescription="This tool registration should fail because it lacks a toolname.">
-    <input type="text" name="feedback" toolparamdescription="Your feedback.">
+  <!-- 3. Declarative Tool with Missing Parameter Description (Warning) -->
+  <h2>Declarative Tool with Missing Parameter Description (Should trigger warning)</h2>
+  <form id="invalid-declarative-form" toolname="declarative_feedback" tooldescription="Submit feedback to us.">
+    <input type="text" name="feedback">
     <button type="submit">Submit Feedback</button>
   </form>
 
-  <!-- 4. Imperative Tool (JavaScript) -->
-  <h2>Imperative Tool</h2>
+  <!-- 4. Active discovery trigger to force Blink schema validation E2E -->
   <script>
-    if (navigator.modelContext && typeof navigator.modelContext.registerTool === 'function') {
-      navigator.modelContext.registerTool({
-        name: 'imperative_calculate',
-        description: 'Calculates the sum of two numbers.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            a: {type: 'number', description: 'First number'},
-            b: {type: 'number', description: 'Second number'}
-          },
-          required: ['a', 'b']
-        }
-      }, async (params) => {
-        return {result: Number(params.a) + Number(params.b)};
-      });
-    } else {
-      console.warn('navigator.modelContext is not available in this browser session.');
+    const testingApi = window.navigator.modelContextTesting || window.navigator.modelContext;
+    if (testingApi && typeof testingApi.listTools === 'function') {
+      testingApi.listTools();
+    } else if (navigator.modelContext && typeof navigator.modelContext.getRegisteredTools === 'function') {
+      navigator.modelContext.getRegisteredTools();
     }
   </script>
 </body>

--- a/cli/test/smokehouse/core-tests.js
+++ b/cli/test/smokehouse/core-tests.js
@@ -66,6 +66,7 @@ import sourceMaps from './test-definitions/source-maps.js';
 import timing from './test-definitions/timing.js';
 import trustedTypesDirectivePresent from './test-definitions/trusted-types-directive-present.js';
 import trustedTypesDirectiveMissingDirective from './test-definitions/trusted-types-missing-directives.js';
+import webmcp from './test-definitions/webmcp.js';
 
 /** @type {ReadonlyArray<Smokehouse.TestDfn>} */
 const smokeTests = [
@@ -131,6 +132,7 @@ const smokeTests = [
   timing,
   trustedTypesDirectivePresent,
   trustedTypesDirectiveMissingDirective,
+  webmcp,
 ];
 
 export default smokeTests;

--- a/cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -87,7 +87,6 @@ async function runBundledLighthouse(url, config, testRunnerOptions) {
   }
 
   // Launch and connect to Chrome.
-  console.log('CHROME FLAGS:', chromeFlags);
   const launchedChrome = await ChromeLauncher.launch({
     chromeFlags,
   });

--- a/cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -80,11 +80,16 @@ async function runBundledLighthouse(url, config, testRunnerOptions) {
   const thirdPartyWeb = global.thirdPartyWeb;
   thirdPartyWeb.provideThirdPartyWeb(thirdPartyWebLib);
 
+  const chromeFlags = [];
+  if (testRunnerOptions?.headless) chromeFlags.push('--headless=new');
+  if (testRunnerOptions?.chromeFlags) {
+    chromeFlags.push(...testRunnerOptions.chromeFlags.split(' '));
+  }
+
   // Launch and connect to Chrome.
+  console.log('CHROME FLAGS:', chromeFlags);
   const launchedChrome = await ChromeLauncher.launch({
-    chromeFlags: [
-      testRunnerOptions?.headless ? '--headless=new' : '',
-    ],
+    chromeFlags,
   });
   const port = launchedChrome.port;
 

--- a/cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/cli/test/smokehouse/lighthouse-runners/cli.js
@@ -68,7 +68,7 @@ async function internalRun(url, tmpPath, config, logger, options) {
 
   let chromeFlags = '';
   if (headless) chromeFlags += '--headless=new ';
-if (options && options.chromeFlags) chromeFlags += options.chromeFlags;
+  if (options && options.chromeFlags) chromeFlags += options.chromeFlags;
 
   if (chromeFlags) args.push(`--chrome-flags="${chromeFlags.trim()}"`);
 

--- a/cli/test/smokehouse/lighthouse-runners/cli.js
+++ b/cli/test/smokehouse/lighthouse-runners/cli.js
@@ -66,7 +66,11 @@ async function internalRun(url, tmpPath, config, logger, options) {
     '--quiet',
   ];
 
-  if (headless) args.push('--chrome-flags="--headless=new"');
+  let chromeFlags = '';
+  if (headless) chromeFlags += '--headless=new ';
+if (options && options.chromeFlags) chromeFlags += options.chromeFlags;
+
+  if (chromeFlags) args.push(`--chrome-flags="${chromeFlags.trim()}"`);
 
   // Config can be optionally provided.
   if (config) {

--- a/cli/test/smokehouse/lighthouse-runners/devtools-mcp.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools-mcp.js
@@ -56,11 +56,15 @@ async function runBundledLighthouse(url, config, testRunnerOptions) {
   // Load bundle.
   const {navigation} = await import(LH_ROOT + '/dist/lighthouse-devtools-mcp-bundle.js');
 
+  const chromeFlags = [];
+  if (testRunnerOptions?.headless) chromeFlags.push('--headless=new');
+  if (testRunnerOptions?.chromeFlags) {
+    chromeFlags.push(...testRunnerOptions.chromeFlags.split(' '));
+  }
+
   // Launch and connect to Chrome.
   const launchedChrome = await ChromeLauncher.launch({
-    chromeFlags: [
-      testRunnerOptions?.headless ? '--headless=new' : '',
-    ],
+    chromeFlags,
   });
   const port = launchedChrome.port;
 

--- a/cli/test/smokehouse/lighthouse-runners/devtools.js
+++ b/cli/test/smokehouse/lighthouse-runners/devtools.js
@@ -46,9 +46,12 @@ async function setup() {
  */
 async function runLighthouse(url, config, logger, testRunnerOptions) {
   const chromeFlags = [
-    testRunnerOptions?.headless ? '--headless=new' : '',
     `--custom-devtools-frontend=file://${devtoolsDir}/out/LighthouseIntegration/gen/front_end`,
   ];
+  if (testRunnerOptions?.headless) chromeFlags.push('--headless=new');
+  if (testRunnerOptions?.chromeFlags) {
+    chromeFlags.push(...testRunnerOptions.chromeFlags.split(' '));
+  }
   // TODO: `testUrlFromDevtools` should accept a logger, so we get some output even for time outs.
   const {lhr, artifacts, logs} = await testUrlFromDevtools(url, {
     config,

--- a/cli/test/smokehouse/smokehouse.js
+++ b/cli/test/smokehouse/smokehouse.js
@@ -136,7 +136,7 @@ function purpleify(str) {
  * @return {Promise<SmokehouseResult>}
  */
 async function runSmokeTest(smokeTestDefn, testOptions) {
-  const {id, expectations, config, testRunnerOptions: defnTestRunnerOptions} = smokeTestDefn;
+  const {id, expectations, config, testRunnerOptions: customTestRunnerOptions} = smokeTestDefn;
   const {
     lighthouseRunner,
     retries,
@@ -147,7 +147,7 @@ async function runSmokeTest(smokeTestDefn, testOptions) {
 
   const mergedTestRunnerOptions = {
     ...testRunnerOptions,
-    ...defnTestRunnerOptions,
+    ...customTestRunnerOptions,
   };
 
   console.log(`${purpleify(id)} smoketest starting…`);

--- a/cli/test/smokehouse/smokehouse.js
+++ b/cli/test/smokehouse/smokehouse.js
@@ -136,7 +136,7 @@ function purpleify(str) {
  * @return {Promise<SmokehouseResult>}
  */
 async function runSmokeTest(smokeTestDefn, testOptions) {
-  const {id, expectations, config} = smokeTestDefn;
+  const {id, expectations, config, testRunnerOptions: defnTestRunnerOptions} = smokeTestDefn;
   const {
     lighthouseRunner,
     retries,
@@ -144,6 +144,11 @@ async function runSmokeTest(smokeTestDefn, testOptions) {
     takeNetworkRequestUrls,
   } = testOptions;
   const requestedUrl = expectations.lhr.requestedUrl;
+
+  const mergedTestRunnerOptions = {
+    ...testRunnerOptions,
+    ...defnTestRunnerOptions,
+  };
 
   console.log(`${purpleify(id)} smoketest starting…`);
 
@@ -170,7 +175,7 @@ async function runSmokeTest(smokeTestDefn, testOptions) {
           reject(new Error('Timed out waiting for provided lighthouseRunner')), 1000 * 120);
       });
       const timedResult = await Promise.race([
-        lighthouseRunner(requestedUrl, config, logger, testRunnerOptions),
+        lighthouseRunner(requestedUrl, config, logger, mergedTestRunnerOptions),
         timeoutPromise,
       ]);
       result = {

--- a/cli/test/smokehouse/test-definitions/webmcp.js
+++ b/cli/test/smokehouse/test-definitions/webmcp.js
@@ -27,11 +27,6 @@ const expectations = {
   lhr: {
     requestedUrl: 'http://localhost:10200/webmcp/webmcp_tester.html',
     finalDisplayedUrl: 'http://localhost:10200/webmcp/webmcp_tester.html',
-    categories: {
-      'agentic-browsing': {
-        title: 'Agentic Browsing',
-      },
-    },
     audits: {
       // 1. Registered Tools Audit
       // Verifies that both declarative forms are successfully registered.

--- a/cli/test/smokehouse/test-definitions/webmcp.js
+++ b/cli/test/smokehouse/test-definitions/webmcp.js
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import agenticBrowsingConfig from '../../../../core/config/agentic-browsing-config.js';
+
+/**
+ * Config to run only the agentic browsing category.
+ * We use the full agenticBrowsingConfig as the base since it defines the category.
+ * @type {LH.Config}
+ */
+const config = {
+  ...agenticBrowsingConfig,
+  settings: {
+    onlyCategories: [
+      'agentic-browsing',
+    ],
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const expectations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/webmcp/webmcp_tester.html',
+    finalDisplayedUrl: 'http://localhost:10200/webmcp/webmcp_tester.html',
+    categories: {
+      'agentic-browsing': {
+        title: 'Agentic Browsing',
+      },
+    },
+    audits: {
+      // 1. Registered Tools Audit
+      // Verifies that the declarative tool is successfully registered and listed.
+      'webmcp-registered-tools': {
+        score: 1,
+        details: {
+          items: [
+            {
+              value: {
+                items: [
+                  {
+                    tool: 'declarative_search',
+                    description: 'Search catalog for items.',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      // 2. Form Coverage Audit
+      // Should flag 'unannotated-form' (form without WebMCP).
+      'webmcp-form-coverage': {
+        score: 1, // Informative, so always 1
+        details: {
+          items: [
+            {
+              node: {
+                selector: 'body > form#unannotated-form',
+              },
+            },
+          ],
+        },
+      },
+      // 3. Schema Validity Audit
+      // Currently passes (score 1) because the experimental browser does not yet
+      // reliably emit Audits.issueAdded events for all schema violations in this headless context.
+      'webmcp-schema-validity': {
+        score: 1,
+      },
+    },
+  },
+};
+
+export default {
+  id: 'webmcp',
+  config,
+  expectations,
+  testRunnerOptions: {
+    chromeFlags: '--enable-features=WebMCPTesting',
+  },
+};

--- a/cli/test/smokehouse/test-definitions/webmcp.js
+++ b/cli/test/smokehouse/test-definitions/webmcp.js
@@ -34,17 +34,22 @@ const expectations = {
     },
     audits: {
       // 1. Registered Tools Audit
-      // Verifies that the declarative tool is successfully registered and listed.
+      // Verifies that both declarative forms are successfully registered.
       'webmcp-registered-tools': {
         score: 1,
         details: {
           items: [
             {
+              title: 'Declarative Tools',
               value: {
                 items: [
                   {
                     tool: 'declarative_search',
                     description: 'Search catalog for items.',
+                  },
+                  {
+                    tool: 'declarative_feedback',
+                    description: 'Submit feedback to us.',
                   },
                 ],
               },
@@ -67,10 +72,20 @@ const expectations = {
         },
       },
       // 3. Schema Validity Audit
-      // Currently passes (score 1) because the experimental browser does not yet
-      // reliably emit Audits.issueAdded events for all schema violations in this headless context.
+      // Should flag 'declarative_feedback' because its input is missing 'toolparamdescription'.
+      // A warning-severity issue results in a score of 0.5 (partial pass).
       'webmcp-schema-validity': {
-        score: 1,
+        score: 0.5,
+        details: {
+          items: [
+            {
+              element: {
+                selector: 'body > form#invalid-declarative-form > input',
+              },
+              issue: 'Add a description to make this form more accessible for AI agents.',
+            },
+          ],
+        },
       },
     },
   },

--- a/cli/test/smokehouse/test-definitions/webmcp.js
+++ b/cli/test/smokehouse/test-definitions/webmcp.js
@@ -86,6 +86,6 @@ export default {
   config,
   expectations,
   testRunnerOptions: {
-    chromeFlags: '--enable-features=WebMCPTesting',
+    chromeFlags: '--enable-features=WebMCPTesting,DevToolsWebMCPSupport',
   },
 };

--- a/cli/test/smokehouse/test-definitions/webmcp.js
+++ b/cli/test/smokehouse/test-definitions/webmcp.js
@@ -4,22 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import agenticBrowsingConfig from '../../../../core/config/agentic-browsing-config.js';
-
-/**
- * Config to run only the agentic browsing category.
- * We use the full agenticBrowsingConfig as the base since it defines the category.
- * @type {LH.Config}
- */
+/** @type {LH.Config} */
 const config = {
-  ...agenticBrowsingConfig,
+  extends: 'lighthouse:default',
   settings: {
-    onlyCategories: [
-      'agentic-browsing',
+    onlyAudits: [
+      'webmcp-registered-tools',
+      'webmcp-form-coverage',
+      'webmcp-schema-validity',
     ],
   },
 };
-
 /**
  * @type {Smokehouse.ExpectedRunnerResult}
  */

--- a/types/internal/smokehouse.d.ts
+++ b/types/internal/smokehouse.d.ts
@@ -13,7 +13,6 @@ declare global {
   module Smokehouse {
     interface ExpectedLHR {
       audits: Record<string, any>;
-      categories?: Record<string, any>;
       requestedUrl: string;
       finalDisplayedUrl: string | RegExp;
       userAgent?: string | RegExp;

--- a/types/internal/smokehouse.d.ts
+++ b/types/internal/smokehouse.d.ts
@@ -13,6 +13,7 @@ declare global {
   module Smokehouse {
     interface ExpectedLHR {
       audits: Record<string, any>;
+      categories?: Record<string, any>;
       requestedUrl: string;
       finalDisplayedUrl: string | RegExp;
       userAgent?: string | RegExp;
@@ -42,6 +43,10 @@ declare global {
       config?: Config;
       /** If test is performance sensitive, set to true so that it won't be run parallel to other tests. */
       runSerially?: boolean;
+      /** Custom options for the test runner (e.g., custom Chrome flags). */
+      testRunnerOptions?: {
+        chromeFlags?: string;
+      };
     }
 
     /**
@@ -54,7 +59,7 @@ declare global {
       {expectations: Smokehouse.ExpectedRunnerResult | Array<Smokehouse.ExpectedRunnerResult>}
 
     export type LighthouseRunner =
-      {runnerName?: string} & ((url: string, config?: Config, logger?: LocalConsole, runnerOptions?: {isDebug?: boolean}) => Promise<{lhr: LHResult, artifacts: Artifacts}>);
+      {runnerName?: string} & ((url: string, config?: Config, logger?: LocalConsole, runnerOptions?: SmokehouseOptions['testRunnerOptions']) => Promise<{lhr: LHResult, artifacts: Artifacts}>);
 
     export interface SmokehouseOptions {
       /** Options to pass to the specific Lighthouse runner. */
@@ -63,6 +68,8 @@ declare global {
         isDebug?: boolean;
         /** Launch Chrome in the new headless mode (`--headless=new`), rather than the typical desktop headful mode. */
         headless?: boolean;
+        /** Custom Chrome flags to pass to the launched browser. */
+        chromeFlags?: string;
       };
       /** Manually set the number of jobs to run at once. `1` runs all tests serially. */
       jobs: number;


### PR DESCRIPTION
Add webmcp smoketests

This PR also add Chrome flags as a test runner options. This is to allow WebMCP tests to pass the WebMCPTesting feature flag, without which these audits are N/A. We don't want to turn on WebMCPTesting by default yet because we don't want to turn on WebMCP audits just yet for every agentic browsing run. 