### PR TITLE
core(storage): handle missing usage breakdown

### DIFF
--- a/core/gather/driver/storage.js
+++ b/core/gather/driver/storage.js
@@ -87,7 +87,7 @@ async function getImportantStorageWarning(session, url) {
     indexeddb: 'IndexedDB',
     websql: 'Web SQL',
   };
-  const locations = usageData.usageBreakdown
+  const locations = (usageData.usageBreakdown ?? [])
     .filter(usage => usage.usage)
     .map(usage => storageTypeNames[usage.storageType] || '')
     .filter(Boolean);

--- a/core/test/gather/driver/storage-test.js
+++ b/core/test/gather/driver/storage-test.js
@@ -139,4 +139,13 @@ describe('.getImportantDataWarning', () => {
     );
     expect(warning).toBeUndefined();
   });
+
+  it('does not throw when usage breakdown is missing', async () => {
+    sessionMock.sendCommand.mockResponse('Storage.getUsageAndQuota', {});
+    const warning = await storage.getImportantStorageWarning(
+      sessionMock.asSession(),
+      'https://example.com'
+    );
+    expect(warning).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #17015.

`getImportantStorageWarning()` assumes the DevTools `Storage.getUsageAndQuota` response always includes `usageBreakdown`. When Chrome returns a response without that field, Lighthouse crashes during storage reset with `Cannot read properties of undefined (reading 'filter')` before the audit can run.

This treats a missing `usageBreakdown` as an empty breakdown, so Lighthouse simply skips the optional storage-data warning instead of failing the run.

## Tests

- Reproduced before fix with a mocked `Storage.getUsageAndQuota` response missing `usageBreakdown`: `TypeError: Cannot read properties of undefined (reading 'filter')`.
- Verified after fix with the same mocked response: returns no warning and does not throw.
- `corepack yarn mocha --testMatch core/test/gather/driver/storage-test.js` (9 passing)
- `corepack yarn eslint core/gather/driver/storage.js core/test/gather/driver/storage-test.js`
- `corepack yarn type-check`
- `git diff --check`

Note: the first focused Mocha run passed all 9 assertions but exited during Windows teardown because the harness expected optional test plugin symlinks that were not created in this checkout. I reran the same command cleanly after creating temporary placeholder plugin entries for the harness to remove.