### PR TITLE
core(gather): handle missing DOM resolve objects

### DIFF
--- a/core/gather/driver/dom.js
+++ b/core/gather/driver/dom.js
@@ -29,7 +29,7 @@ function handlePotentialMissingNodeError(err) {
 async function resolveNodeIdToObjectId(session, backendNodeId) {
   try {
     const resolveNodeResponse = await session.sendCommand('DOM.resolveNode', {backendNodeId});
-    return resolveNodeResponse.object.objectId;
+    return resolveNodeResponse.object?.objectId;
   } catch (err) {
     return handlePotentialMissingNodeError(err);
   }
@@ -47,8 +47,8 @@ async function resolveNodeIdToObjectId(session, backendNodeId) {
 async function resolveDevtoolsNodePathToObjectId(session, path) {
   try {
     const {nodeId} = await session.sendCommand('DOM.pushNodeByPathToFrontend', {path});
-    const {object: {objectId}} = await session.sendCommand('DOM.resolveNode', {nodeId});
-    return objectId;
+    const resolveNodeResponse = await session.sendCommand('DOM.resolveNode', {nodeId});
+    return resolveNodeResponse.object?.objectId;
   } catch (err) {
     return handlePotentialMissingNodeError(err);
   }

--- a/core/test/gather/driver/dom-test.js
+++ b/core/test/gather/driver/dom-test.js
@@ -32,6 +32,12 @@ describe('.resolveNodeIdToObjectId', () => {
     expect(objectId).toEqual(undefined);
   });
 
+  it('handles a resolve response without an object', async () => {
+    sessionMock.sendCommand.mockResponse('DOM.resolveNode', {});
+    const objectId = await dom.resolveNodeIdToObjectId(sessionMock.asSession(), 1);
+    expect(objectId).toEqual(undefined);
+  });
+
   it('raise other exceptions', async () => {
     const error = new Error('PROTOCOL_TIMEOUT');
     sessionMock.sendCommand.mockRejectedValue(error);
@@ -56,6 +62,14 @@ describe('.resolveDevtoolsNodePathToObjectId', () => {
 
   it('handle nodes in other documents', async () => {
     sessionMock.sendCommand.mockRejectedValue(new Error('Node 1 does not belong to the document'));
+    const objectId = await dom.resolveDevtoolsNodePathToObjectId(sessionMock.asSession(), 'div');
+    expect(objectId).toEqual(undefined);
+  });
+
+  it('handles a resolve response without an object', async () => {
+    sessionMock.sendCommand
+      .mockResponse('DOM.pushNodeByPathToFrontend', {nodeId: 1})
+      .mockResponse('DOM.resolveNode', {});
     const objectId = await dom.resolveDevtoolsNodePathToObjectId(sessionMock.asSession(), 'div');
     expect(objectId).toEqual(undefined);
   });


### PR DESCRIPTION
﻿Problem
- The AnchorElements gatherer can crash with "Cannot read properties of undefined (reading 'objectId')" when Chrome returns a DOM.resolveNode response without a Runtime remote object for an anchor node.

Root cause
- The shared DOM resolver destructured resolveNodeResponse.object.objectId unconditionally. Existing missing-node handling only covered protocol errors, not a successful-but-empty resolve response.

Solution
- Treat a missing Runtime object the same as other missing node cases by returning undefined from both DOM resolver helpers.
- Add regression coverage for backend-node and DevTools-node-path resolution responses without objects.

Tests run
- corepack yarn mocha --testMatch core/test/gather/driver/dom-test.js
- .\\node_modules\\.bin\\eslint.cmd --quiet core\\gather\\driver\\dom.js core\\test\\gather\\driver\\dom-test.js
- git diff --check

Fixes #16860
