### PR TITLE
core: handle missing storage usage breakdown

### DIFF
--- a/core/gather/driver/storage.js
+++ b/core/gather/driver/storage.js
@@ -100,7 +100,8 @@ async function getImportantStorageWarning(session, url) {
     indexeddb: 'IndexedDB',
     websql: 'Web SQL',
   };
-  const locations = usageData.usageBreakdown
+  const usageBreakdown = usageData.usageBreakdown || [];
+  const locations = usageBreakdown
     .filter(usage => usage.usage)
     .map(usage => storageTypeNames[usage.storageType] || '')
     .filter(Boolean);

--- a/core/test/gather/driver/storage-test.js
+++ b/core/test/gather/driver/storage-test.js
@@ -139,4 +139,13 @@ describe('.getImportantDataWarning', () => {
     );
     expect(warning).toBeUndefined();
   });
+
+  it('does not warn when storage usage breakdown is omitted', async () => {
+    sessionMock.sendCommand.mockResponse('Storage.getUsageAndQuota', {});
+    const warning = await storage.getImportantStorageWarning(
+      sessionMock.asSession(),
+      'https://example.com'
+    );
+    expect(warning).toBeUndefined();
+  });
 });


### PR DESCRIPTION
**Summary**
- Treat a missing `Storage.getUsageAndQuota().usageBreakdown` response field as an empty usage list.
- Add a regression test for quota responses that omit `usageBreakdown`.

**Root cause**
`getImportantStorageWarning()` assumed `usageBreakdown` was always present and called `.filter()` on it directly. When Chrome returns a quota response without that field, Lighthouse throws before the audit can continue.

**Related Issues/PRs**
Fixes #17015.

**Tests**
- `corepack yarn mocha storage-test`
- `node node_modules/eslint/bin/eslint.js core/gather/driver/storage.js core/test/gather/driver/storage-test.js`
- `git diff --check`