### PR TITLE
report: decouple link creation from link details rendering

### DIFF
--- a/report/renderer/details-renderer.js
+++ b/report/renderer/details-renderer.js
@@ -115,7 +115,7 @@ export class DetailsRenderer {
     }
 
     const element = this._dom.createElement('div', 'lh-text__url');
-    element.append(this._renderLink({text: displayedPath, url}));
+    element.append(this._createLink({text: displayedPath, url}));
 
     if (displayedHost) {
       const hostElem = this._renderText(displayedHost);
@@ -132,10 +132,18 @@ export class DetailsRenderer {
   }
 
   /**
-   * @param {{text: string, url: string}} details
+   * @param {LH.Audit.Details.LinkValue} details
    * @return {HTMLElement}
    */
   _renderLink(details) {
+    return this._createLink(details);
+  }
+
+  /**
+   * @param {{text: string, url: string}} details
+   * @return {HTMLElement}
+   */
+  _createLink(details) {
     const a = this._dom.createElement('a');
     this._dom.safelySetHref(a, details.url);
 
@@ -689,7 +697,7 @@ export class DetailsRenderer {
     // We render slightly differently based on presence of source map and provenance of URL.
     let element;
     if (item.urlProvider === 'network' && sourceMappedOriginalLocation) {
-      element = this._renderLink({
+      element = this._createLink({
         url: item.url,
         text: sourceMappedOriginalLocation,
       });


### PR DESCRIPTION
fixes #9631

this is a simple PR to address an old PR comment from Brendan. It's a trivial change, but just future-proofs the code in case we want to change how the link detail type is rendered without accidentally changing the other use cases of this function.