### PR TITLE
core(driver): add ExecutionContext.evaluateOnObject

### DIFF
--- a/build/test/page-functions-test-case-computeBenchmarkIndex.js
+++ b/build/test/page-functions-test-case-computeBenchmarkIndex.js
@@ -18,6 +18,7 @@ function stringify(mainFn, args, deps) {
   const argsSerialized = ExecutionContext.serializeArguments(args);
   const depsSerialized = ExecutionContext.serializeDeps(deps);
   const expression = `(() => {
+    ${pageFunctions.esbuildFunctionWrapperString}
     ${depsSerialized}
     return (${mainFn})(${argsSerialized});
   })()`;

--- a/build/test/page-functions-test-case-getElementsInDocument.js
+++ b/build/test/page-functions-test-case-getElementsInDocument.js
@@ -19,6 +19,7 @@ function stringify(mainFn, args, deps) {
   const argsSerialized = ExecutionContext.serializeArguments(args);
   const depsSerialized = ExecutionContext.serializeDeps(deps);
   const expression = `(() => {
+    ${pageFunctions.esbuildFunctionWrapperString}
     ${depsSerialized}
     return (${mainFn})(${argsSerialized});
   })()`;

--- a/build/test/page-functions-test-case-getNodeDetails.js
+++ b/build/test/page-functions-test-case-getNodeDetails.js
@@ -19,6 +19,7 @@ function stringify(mainFn, args, deps) {
   const argsSerialized = ExecutionContext.serializeArguments(args);
   const depsSerialized = ExecutionContext.serializeDeps(deps);
   const expression = `(() => {
+    ${pageFunctions.esbuildFunctionWrapperString}
     ${depsSerialized}
     return (${mainFn})(${argsSerialized});
   })()`;

--- a/core/gather/driver/execution-context.js
+++ b/core/gather/driver/execution-context.js
@@ -223,12 +223,94 @@ class ExecutionContext {
 
     const expression = `(() => {
       ${ExecutionContext._cachedNativesPreamble};
+      ${pageFunctions.esbuildFunctionWrapperString}
       ${depsSerialized};
       (${mainFn})(${argsSerialized});
     })()
     //# sourceURL=_lighthouse-eval.js`;
 
     await this._session.sendCommand('Page.addScriptToEvaluateOnNewDocument', {source: expression});
+  }
+
+  /**
+   * Call a function on the given object.
+   * Returns a promise that resolves on a value of `mainFn`'s return type.
+   * @template {unknown[]} T, R
+   * @param {((thisArg: any, ...args: T) => R)} mainFn The main function to call.
+   * @param {{args: T, objectId: string, deps?: Array<Function|string>}} options `args` should
+   *   match the args of `mainFn`, and can be any serializable value. `deps` are functions that must be
+   *   defined for `mainFn` to work.
+   * @return {Promise<Awaited<R>>}
+   */
+  evaluateOnObject(mainFn, options) {
+    const argsSerialized = ExecutionContext.serializeArguments(options.args);
+    const depsSerialized = ExecutionContext.serializeDeps(options.deps);
+
+    const argsString = argsSerialized ? `this, ${argsSerialized}` : 'this';
+    const functionDeclaration = `function() {
+      ${depsSerialized}
+      return (${mainFn})(${argsString});
+    }`;
+    return this._callFunctionOn(functionDeclaration, options);
+  }
+
+  /**
+   * @param {string} functionDeclaration
+   * @param {{objectId: string}} options
+   * @return {Promise<*>}
+   */
+  async _callFunctionOn(functionDeclaration, options) {
+    const timeout = this._session.hasNextProtocolTimeout() ?
+      this._session.getNextProtocolTimeout() :
+      60000;
+
+    const evaluationParams = {
+      functionDeclaration: `function wrapInNativePromise() {
+        ${ExecutionContext._cachedNativesPreamble};
+        ${pageFunctions.esbuildFunctionWrapperString}
+        const self = this;
+        const args = arguments;
+        return new Promise(function (resolve) {
+          return Promise.resolve()
+            .then(_ => (${functionDeclaration}).apply(self, args))
+            .catch(${pageFunctions.wrapRuntimeEvalErrorInBrowser})
+            .then(resolve);
+        });
+      }
+      //# sourceURL=_lighthouse-eval.js
+      `,
+      objectId: options.objectId,
+      returnByValue: true,
+      awaitPromise: true,
+      timeout,
+    };
+
+    this._session.setNextProtocolTimeout(timeout);
+    const response = await this._session.sendCommand('Runtime.callFunctionOn', evaluationParams);
+
+    const ex = response.exceptionDetails;
+    if (ex) {
+      const elidedExpression = functionDeclaration.replace(/\s+/g, ' ').substring(0, 100);
+      const messageLines = [
+        'Runtime.callFunctionOn exception',
+        `Expression: ${elidedExpression}\n---- (elided)`,
+        !ex.stackTrace ? `Parse error at: ${ex.lineNumber + 1}:${ex.columnNumber + 1}` : null,
+        ex.exception?.description || ex.text,
+      ].filter(Boolean);
+      const evaluationError = new Error(messageLines.join('\n'));
+      return Promise.reject(evaluationError);
+    }
+
+    if (response.result === undefined) {
+      return Promise.reject(
+        new Error('Runtime.callFunctionOn response did not contain a "result" object'));
+    }
+    const value = response.result.value;
+    if (value?.__failedInBrowser) {
+      return Promise.reject(Object.assign(new Error(), value));
+    } else {
+      return value;
+    }
   }
 
   /**
@@ -279,7 +361,10 @@ class ExecutionContext {
    * @return {string}
    */
   static serializeDeps(deps) {
-    deps = [pageFunctions.esbuildFunctionWrapperString, ...deps || []];
+    if (!deps) {
+      return '';
+    }
+
     return deps.map(dep => {
       if (typeof dep === 'function') {
         // esbuild will change the actual function name (ie. function actualName() {})

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -20,7 +20,6 @@ import Trace from './trace.js';
 import {ProcessedTrace} from '../../computed/processed-trace.js';
 import {Responsiveness} from '../../computed/metrics/responsiveness.js';
 import {CumulativeLayoutShift} from '../../computed/metrics/cumulative-layout-shift.js';
-import {ExecutionContext} from '../driver/execution-context.js';
 import {TraceEngineResult} from '../../computed/trace-engine-result.js';
 import SourceMaps from './source-maps.js';
 
@@ -29,14 +28,14 @@ import SourceMaps from './source-maps.js';
 const MAX_LAYOUT_SHIFTS = 15;
 
 /**
- * @this {HTMLElement}
+ * @param {Element | ShadowRoot | Text} node
  */
 /* c8 ignore start */
-function getNodeDetailsData() {
-  /** @type {Element|null} */
-  let elem = this.nodeType === document.ELEMENT_NODE ? this : this.parentElement;
-  if (!elem && this instanceof ShadowRoot) {
-    elem = this.host;
+function getNodeDetailsData(node) {
+  /** @type {Element | ShadowRoot | Text | null} */
+  let elem = node.nodeType === document.ELEMENT_NODE ? node : node.parentElement;
+  if (!elem && node instanceof ShadowRoot) {
+    elem = node.host;
   }
 
   let traceElement;
@@ -292,26 +291,22 @@ class TraceElements extends BaseGatherer {
 
   /**
    * @param {LH.Gatherer.ProtocolSession} session
+   * @param {LH.Gatherer.Driver['executionContext']} executionContext
    * @param {number} backendNodeId
    */
-  async getNodeDetails(session, backendNodeId) {
+  async getNodeDetails(session, executionContext, backendNodeId) {
     try {
       const objectId = await resolveNodeIdToObjectId(session, backendNodeId);
       if (!objectId) return null;
 
-      const deps = ExecutionContext.serializeDeps([
-        pageFunctions.getNodeDetails,
+      return await executionContext.evaluateOnObject(
         getNodeDetailsData,
-      ]);
-      return await session.sendCommand('Runtime.callFunctionOn', {
-        objectId,
-        functionDeclaration: `function () {
-          ${deps}
-          return getNodeDetailsData.call(this);
-        }`,
-        returnByValue: true,
-        awaitPromise: true,
-      });
+        {
+          objectId,
+          args: [],
+          deps: [pageFunctions.getNodeDetails],
+        }
+      );
     } catch (err) {
       Sentry.captureException(err, {
         tags: {gatherer: 'TraceElements'},
@@ -346,29 +341,30 @@ class TraceElements extends BaseGatherer {
       trace, traceEngineResult, context);
     const animatedElementData = await this.getAnimatedElements(mainThreadEvents);
 
-    /** @type {Map<string, TraceElementData[]>} */
+    /** @type {Map<LH.Artifacts.TraceElement['traceEventType'], TraceElementData[]>} */
     const backendNodeDataMap = new Map([
       ['trace-engine', traceEngineData],
       ['layout-shift', shiftsData],
       ['animation', animatedElementData],
     ]);
 
-    /** @type {Map<number, LH.Crdp.Runtime.CallFunctionOnResponse | null>} */
-    const callFunctionOnCache = new Map();
+    /** @type {Map<number, {node: LH.Artifacts.NodeDetails} | null>} */
+    const evaluateOnObjectCache = new Map();
     /** @type {LH.Artifacts.TraceElement[]} */
     const traceElements = [];
     for (const [traceEventType, backendNodeData] of backendNodeDataMap) {
       for (let i = 0; i < backendNodeData.length; i++) {
         const backendNodeId = backendNodeData[i].nodeId;
-        let response = callFunctionOnCache.get(backendNodeId);
+        let response = evaluateOnObjectCache.get(backendNodeId);
         if (response === undefined) {
-          response = await this.getNodeDetails(session, backendNodeId);
-          callFunctionOnCache.set(backendNodeId, response);
+          response = await this.getNodeDetails(
+            session, context.driver.executionContext, backendNodeId) || null;
+          evaluateOnObjectCache.set(backendNodeId, response);
         }
 
-        if (response?.result?.value) {
+        if (response?.node) {
           traceElements.push({
-            ...response.result.value,
+            ...response,
             traceEventType,
             animations: backendNodeData[i].animations,
             nodeId: backendNodeId,

--- a/core/gather/gatherers/webmcp-schema.js
+++ b/core/gather/gatherers/webmcp-schema.js
@@ -7,7 +7,6 @@
 import BaseGatherer from '../base-gatherer.js';
 import {resolveNodeIdToObjectId} from '../driver/dom.js';
 import {pageFunctions} from '../../lib/page-functions.js';
-import {ExecutionContext} from '../driver/execution-context.js';
 
 class WebMcpSchemaIssues extends BaseGatherer {
   /** @type {LH.Gatherer.GathererMeta} */
@@ -68,27 +67,21 @@ class WebMcpSchemaIssues extends BaseGatherer {
   async getArtifact(context) {
     const session = context.driver.defaultSession;
 
-    const deps = ExecutionContext.serializeDeps([
-      pageFunctions.getNodeDetails,
-    ]);
-
     const promises = this._issues.map(async (issue) => {
       const processedIssue = {...issue};
       if (issue.violatingNodeId) {
         try {
           const objectId = await resolveNodeIdToObjectId(session, issue.violatingNodeId);
           if (objectId) {
-            const response = await session.sendCommand('Runtime.callFunctionOn', {
-              objectId,
-              functionDeclaration: `function () {
-                ${deps}
-                return getNodeDetails(this);
-              }`,
-              returnByValue: true,
-              awaitPromise: true,
-            });
-            if (response && response.result && response.result.value) {
-              processedIssue.nodeDetails = response.result.value;
+            const nodeDetails = await context.driver.executionContext.evaluateOnObject(
+              pageFunctions.getNodeDetails,
+              {
+                objectId,
+                args: [],
+              }
+            );
+            if (nodeDetails) {
+              processedIssue.nodeDetails = nodeDetails;
             }
           }
         } catch (err) {

--- a/core/gather/gatherers/webmcp.js
+++ b/core/gather/gatherers/webmcp.js
@@ -119,7 +119,6 @@ class WebMCP extends BaseGatherer {
         pageFunctions.getNodeDetails, {
           objectId,
           args: [],
-          deps: [pageFunctions.getNodeDetails],
         }
       );
       if (nodeDetails) {

--- a/core/gather/gatherers/webmcp.js
+++ b/core/gather/gatherers/webmcp.js
@@ -11,7 +11,6 @@
 import BaseGatherer from '../base-gatherer.js';
 import {resolveNodeIdToObjectId} from '../driver/dom.js';
 import {pageFunctions} from '../../lib/page-functions.js';
-import {ExecutionContext} from '../driver/execution-context.js';
 
 /**
  * @typedef {Object} WebMCPTool
@@ -101,6 +100,38 @@ class WebMCP extends BaseGatherer {
 
   /**
    * @param {LH.Gatherer.Context} context
+   * @param {WebMCPTool} tool
+   */
+  async _tryResolveToolNodeDetails(context, tool) {
+    if (!tool.backendNodeId) {
+      return;
+    }
+
+    const session = context.driver.defaultSession;
+
+    try {
+      const objectId = await resolveNodeIdToObjectId(session, tool.backendNodeId);
+      if (!objectId) {
+        return;
+      }
+
+      const nodeDetails = await context.driver.executionContext.evaluateOnObject(
+        pageFunctions.getNodeDetails, {
+          objectId,
+          args: [],
+          deps: [pageFunctions.getNodeDetails],
+        }
+      );
+      if (nodeDetails) {
+        tool.nodeDetails = nodeDetails;
+      }
+    } catch (err) {
+      // Ignore error
+    }
+  }
+
+  /**
+   * @param {LH.Gatherer.Context} context
    * @return {Promise<LH.Artifacts['WebMCP']>}
    */
   async getArtifact(context) {
@@ -113,9 +144,8 @@ class WebMCP extends BaseGatherer {
       return {isSupported: false, tools: []};
     }
 
-    const session = context.driver.defaultSession;
-
     // Remove duplicates based on name, keeping the latest occurrence.
+    /** @type {Map<string, WebMCPTool>} */
     const toolMap = new Map();
     for (const tool of this._tools) {
       toolMap.set(tool.name, tool);
@@ -123,32 +153,10 @@ class WebMCP extends BaseGatherer {
 
     const resolvedTools = [];
     for (const tool of toolMap.values()) {
-      if (tool.backendNodeId) {
-        try {
-          const objectId = await resolveNodeIdToObjectId(session, tool.backendNodeId);
-          if (objectId) {
-            const deps = ExecutionContext.serializeDeps([
-              pageFunctions.getNodeDetails,
-            ]);
-            const response = await session.sendCommand('Runtime.callFunctionOn', {
-              objectId,
-              functionDeclaration: `function () {
-                ${deps}
-                return getNodeDetails(this);
-              }`,
-              returnByValue: true,
-              awaitPromise: true,
-            });
-            if (response && response.result && response.result.value) {
-              tool.nodeDetails = response.result.value;
-            }
-          }
-        } catch (err) {
-          // Ignore error
-        }
-      }
+      await this._tryResolveToolNodeDetails(context, tool);
       resolvedTools.push(tool);
     }
+
     return {
       isSupported: true,
       tools: resolvedTools,

--- a/core/test/gather/driver/execution-context-test.js
+++ b/core/test/gather/driver/execution-context-test.js
@@ -361,8 +361,7 @@ const fetch = globalThis.__nativeFetch || globalThis.fetch;
 
     const code = mockFn.mock.calls[0][0];
     expect(trimTrailingWhitespace(code)).toEqual(`(() => {
-
-function abs(val) {
+      function abs(val) {
       return Math.abs(val);
     }
 function square(val) {

--- a/core/test/gather/gatherers/trace-elements-test.js
+++ b/core/test/gather/gatherers/trace-elements-test.js
@@ -209,16 +209,18 @@ describe('Trace Elements gatherer - Animated Elements', () => {
     driver._session.sendCommand
       // Trace engine 1 / Shifts 1
       .mockResponse('DOM.resolveNode', {object: {objectId: 4}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: layoutShiftNodeData}})
       // Trace engine 2
       .mockResponse('DOM.resolveNode', {object: {objectId: 7}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: null}})
       // Trace engine 3 / Animations 1
       .mockResponse('DOM.resolveNode', {object: {objectId: 5}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: animationNodeData}})
       // LCP 1
-      .mockResponse('DOM.resolveNode', {object: {objectId: 5}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: LCPNodeData}});
+      .mockResponse('DOM.resolveNode', {object: {objectId: 5}});
+
+    driver._executionContext.evaluateOnObject
+      .mockResolvedValueOnce({node: layoutShiftNodeData})
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({node: animationNodeData})
+      .mockResolvedValueOnce({node: LCPNodeData});
 
     const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
     trace.traceEvents.push(
@@ -256,22 +258,22 @@ describe('Trace Elements gatherer - Animated Elements', () => {
 
     expect(sorted).toEqual([
       {
-        ...layoutShiftNodeData,
+        node: layoutShiftNodeData,
         traceEventType: 'trace-engine',
         nodeId: 4,
       },
       {
-        ...animationNodeData,
+        node: animationNodeData,
         traceEventType: 'trace-engine',
         nodeId: 5,
       },
       {
-        ...layoutShiftNodeData,
+        node: layoutShiftNodeData,
         traceEventType: 'layout-shift',
         nodeId: 4,
       },
       {
-        ...animationNodeData,
+        node: animationNodeData,
         traceEventType: 'animation',
         animations: [
           {name: 'example', failureReasonsMask: 8192, unsupportedProperties: ['height']},
@@ -314,10 +316,12 @@ describe('Trace Elements gatherer - Animated Elements', () => {
     driver._session.sendCommand
       // LCP node / animated node
       .mockResponse('DOM.resolveNode', {object: {objectId: 5}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: animationNodeData}})
       // Composited node
-      .mockResponse('DOM.resolveNode', {object: {objectId: 7}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: compositedNodeData}});
+      .mockResponse('DOM.resolveNode', {object: {objectId: 7}});
+
+    driver._executionContext.evaluateOnObject
+      .mockResolvedValueOnce({node: animationNodeData})
+      .mockResolvedValueOnce({node: compositedNodeData});
 
     const gatherer = new TraceElementsGatherer();
     gatherer.animationIdToName.set('3', 'alpha');
@@ -383,12 +387,14 @@ describe('Trace Elements gatherer - Animated Elements', () => {
       })
       // Trace engine 2 / Animation 2
       .mockResponse('DOM.resolveNode', {object: {objectId: 6}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: animationNodeData}})
       // LCP 1
       .mockResponse('DOM.resolveNode', {object: {objectId: 7}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: LCPNodeData}})
       // Animation 2
       .mockResponse('DOM.resolveNode', {object: {objectId: 6}});
+
+    driver._executionContext.evaluateOnObject
+      .mockResolvedValueOnce({node: animationNodeData})
+      .mockResolvedValueOnce({node: LCPNodeData});
 
     const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
     trace.traceEvents.push(makeAnimationTraceEvent('0x363db876c8', 'b', {id: '1', nodeId: 5}));
@@ -417,12 +423,12 @@ describe('Trace Elements gatherer - Animated Elements', () => {
 
     expect(result).toEqual([
       {
-        ...animationNodeData,
+        node: animationNodeData,
         traceEventType: 'trace-engine',
         nodeId: 6,
       },
       {
-        ...animationNodeData,
+        node: animationNodeData,
         traceEventType: 'animation',
         animations: [
           {name: 'example', failureReasonsMask: 8192, unsupportedProperties: ['color']},
@@ -451,10 +457,12 @@ describe('Trace Elements gatherer - Animated Elements', () => {
     driver._session.sendCommand
       // Trace engine 1 (happens to be same node as Animation 1)
       .mockResponse('DOM.resolveNode', {object: {objectId: 5}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: animationNodeData}})
       // Animation 1
-      .mockResponse('DOM.resolveNode', {object: {objectId: 5}})
-      .mockResponse('Runtime.callFunctionOn', {result: {value: animationNodeData}});
+      .mockResponse('DOM.resolveNode', {object: {objectId: 5}});
+
+    driver._executionContext.evaluateOnObject
+      .mockResolvedValueOnce({node: animationNodeData})
+      .mockResolvedValueOnce({node: animationNodeData});
 
     const trace = createTestTrace({timeOrigin: 0, traceEnd: 2000});
     trace.traceEvents = trace.traceEvents.filter(event => event.name !== 'firstContentfulPaint');
@@ -478,13 +486,13 @@ describe('Trace Elements gatherer - Animated Elements', () => {
 
     expect(result).toEqual([
       {
-        ...animationNodeData,
+        node: animationNodeData,
         traceEventType: 'trace-engine',
         animations: undefined,
         nodeId: 5,
       },
       {
-        ...animationNodeData,
+        node: animationNodeData,
         traceEventType: 'animation',
         animations: [
           {name: 'example', failureReasonsMask: 8192, unsupportedProperties: ['height']},

--- a/core/test/gather/gatherers/webmcp-schema-test.js
+++ b/core/test/gather/gatherers/webmcp-schema-test.js
@@ -24,17 +24,14 @@ describe('WebMcpSchemaIssues Gatherer', () => {
       sendCommand: async (/** @type {string} */ command, /** @type {any} */ _) => {
         if (command === 'Audits.enable') return {};
         if (command === 'DOM.resolveNode') return {object: {objectId: 'obj1'}};
-        if (command === 'Runtime.callFunctionOn') {
-          return {
-            result: {
-              value: {
-                nodeName: 'INPUT',
-                selector: '#my-input',
-              },
-            },
-          };
-        }
       },
+    });
+
+    const mockExecutionContext = /** @type {any} */ ({
+      evaluateOnObject: async () => ({
+        nodeName: 'INPUT',
+        selector: '#my-input',
+      }),
     });
 
     // Helper to resolve node ID to object ID (mocked as returning true for simplify)
@@ -59,7 +56,10 @@ describe('WebMcpSchemaIssues Gatherer', () => {
     });
 
     const artifact = await gatherer.getArtifact(
-      /** @type {any} */ ({driver: {defaultSession: mockSession}}));
+      /** @type {any} */ ({driver: {
+        defaultSession: mockSession,
+        executionContext: mockExecutionContext,
+      }}));
 
     assert.equal(artifact.length, 1);
     assert.equal(artifact[0].errorType, 'FormModelContextParameterMissingTitleAndDescription');

--- a/core/test/gather/gatherers/webmcp-test.js
+++ b/core/test/gather/gatherers/webmcp-test.js
@@ -202,9 +202,10 @@ describe('WebMCP Gatherer', () => {
     mockContext.driver.defaultSession.sendCommand
       .mockResponse('WebMCP.enable')
       .mockResponse('DOM.resolveNode', {object: {objectId: 'remote-obj-1'}})
-      .mockResponse('Runtime.callFunctionOn',
-        {result: {value: {snippet: '<form></form>', selector: 'form'}}})
       .mockResponse('WebMCP.disable');
+
+    mockContext.driver._executionContext.evaluateOnObject
+      .mockResolvedValue({snippet: '<form></form>', selector: 'form'});
 
     await gatherer.startInstrumentation(mockContext.asContext());
     await new Promise(resolve => setTimeout(resolve, 0));

--- a/core/test/gather/mock-driver.js
+++ b/core/test/gather/mock-driver.js
@@ -126,6 +126,8 @@ function createMockExecutionContext() {
     evaluateAsync: fnAny(),
     evaluateOnNewDocument: fnAny(),
     cacheNativesOnNewDocument: fnAny(),
+    evaluateOnObject: fnAny(),
+    evaluateOnObjectAsync: fnAny(),
 
     /** @return {ExecutionContext} */
     asExecutionContext() {


### PR DESCRIPTION
This adds `ExecutionContext.evaluateOnObject` to wrap the CDP `Runtime.callFunctionOn` command, providing the same ergonomics, dependency serialization, and robust error handling as `.evaluate()`.

Key benefits over raw `session.sendCommand` calls:

- Protects native objects from page polyfills via `_cachedNativesPreamble`.
- Properly throws on browser-side execution errors via `exceptionDetails`.
- Safely manages `this` context binding and parameter serialization.

The `WebMCP`, `WebMcpSchemaIssues`, and `TraceElements` gatherers have been migrated to use this safer execution path. Unit tests and mock drivers are updated to reflect the new architecture.

If a page mocked the URL constructor, it was possible these old usages of Runtime.callFunctionOn would error. Now they won't.

ref #14003