### PR TITLE
core(driver): increase network resource body buffer

### DIFF
--- a/core/gather/driver/network.js
+++ b/core/gather/driver/network.js
@@ -6,6 +6,12 @@
 
 import {NetworkRequest} from '../../lib/network-request.js';
 
+// Give each response body more room in the inspector cache before gatherers call
+// `Network.getResponseBody`.
+const NETWORK_ENABLE_OPTIONS = {
+  maxResourceBufferSize: 20 * 1024 * 1024,
+};
+
 /**
  * Return the body of the response with the given ID. Rejects if getting the
  * body times out.
@@ -24,4 +30,4 @@ async function fetchResponseBodyFromCache(session, requestId, timeout = 1000) {
   return result.body;
 }
 
-export {fetchResponseBodyFromCache};
+export {fetchResponseBodyFromCache, NETWORK_ENABLE_OPTIONS};

--- a/core/gather/driver/prepare.js
+++ b/core/gather/driver/prepare.js
@@ -9,6 +9,7 @@ import log from 'lighthouse-logger';
 import * as storage from './storage.js';
 import * as emulation from '../../lib/emulation.js';
 import {pageFunctions} from '../../lib/page-functions.js';
+import {NETWORK_ENABLE_OPTIONS} from './network.js';
 
 /**
  * Enables `Debugger` domain to receive async stacktrace information on network request initiators.
@@ -143,7 +144,7 @@ async function prepareThrottlingAndNetwork(session, settings) {
  */
 async function prepareDeviceEmulation(driver, settings) {
   // Enable network domain here so future calls to `emulate()` don't clear cache (https://github.com/GoogleChrome/lighthouse/issues/12631)
-  await driver.defaultSession.sendCommand('Network.enable');
+  await driver.defaultSession.sendCommand('Network.enable', NETWORK_ENABLE_OPTIONS);
 
   // Emulate our target device screen and user agent.
   await emulation.emulate(driver.defaultSession, settings);

--- a/core/gather/driver/target-manager.js
+++ b/core/gather/driver/target-manager.js
@@ -14,6 +14,7 @@ import EventEmitter from 'events';
 import log from 'lighthouse-logger';
 
 import {ProtocolSession} from '../session.js';
+import {NETWORK_ENABLE_OPTIONS} from './network.js';
 
 /**
  * @typedef {{
@@ -159,7 +160,7 @@ class TargetManager extends ProtocolEventEmitter {
       this._targetIdToTargets.set(targetId, targetWithSession);
 
       // We want to receive information about network requests from iframes, so enable the Network domain.
-      await newSession.sendCommand('Network.enable');
+      await newSession.sendCommand('Network.enable', NETWORK_ENABLE_OPTIONS);
       // We also want to receive information about subtargets of subtargets, so make sure we autoattach recursively.
       await newSession.sendCommand('Target.setAutoAttach', {
         autoAttach: true,

--- a/core/test/gather/driver/prepare-test.js
+++ b/core/test/gather/driver/prepare-test.js
@@ -20,6 +20,7 @@ await td.replaceEsm('../../../gather/driver/storage.js', storageMock);
 // https://github.com/GoogleChrome/lighthouse/blob/main/docs/hacking-tips.md#mocking-modules-with-testdouble
 const prepare = await import('../../../gather/driver/prepare.js');
 const constants = await import('../../../config/constants.js');
+const network = await import('../../../gather/driver/network.js');
 
 const url = 'https://example.com';
 let sessionMock = createMockSession();
@@ -189,6 +190,16 @@ describe('.prepareTargetForNavigationMode()', () => {
       width: 200,
       height: 300,
     });
+  });
+
+  it('enables Network with a larger resource cache buffer', async () => {
+    await prepare.prepareTargetForNavigationMode(driverMock.asDriver(), {
+      ...constants.defaultSettings,
+    }, requestor);
+
+    expect(sessionMock.sendCommand.findInvocation('Network.enable')).toEqual(
+      network.NETWORK_ENABLE_OPTIONS
+    );
   });
 
   it('cache natives on new document', async () => {
@@ -372,6 +383,10 @@ describe('.prepareTargetForTimespanMode()', () => {
       blockedUrlPatterns: ['.jpg'],
       extraHeaders: {Cookie: 'name=wolverine'},
     });
+
+    expect(sessionMock.sendCommand.findInvocation('Network.enable')).toEqual(
+      network.NETWORK_ENABLE_OPTIONS
+    );
 
     const blockedInvocation = sessionMock.sendCommand.findInvocation('Network.setBlockedURLs');
     expect(blockedInvocation).toEqual({urls: ['.jpg']});

--- a/core/test/gather/driver/target-manager-test.js
+++ b/core/test/gather/driver/target-manager-test.js
@@ -12,6 +12,7 @@ import {TargetManager} from '../../../gather/driver/target-manager.js';
 import {createMockCdpSession} from '../mock-driver.js';
 import {createMockSendCommandFn} from '../../gather/mock-commands.js';
 import {fnAny} from '../../test-utils.js';
+import {NETWORK_ENABLE_OPTIONS} from '../../../gather/driver/network.js';
 
 /**
  * @param {{type?: string, targetId?: string}} [overrides]
@@ -57,6 +58,7 @@ describe('TargetManager', () => {
         .mockResponse('Target.setAutoAttach');
       await targetManager.enable();
 
+      expect(sendMock.findAllInvocations('Network.enable')[0]).toEqual(NETWORK_ENABLE_OPTIONS);
       expect(sendMock.findAllInvocations('Target.setAutoAttach')).toHaveLength(1);
       expect(sendMock.findAllInvocations('Runtime.runIfWaitingForDebugger')).toHaveLength(1);
       expect(targetManager._mainFrameId).toEqual('mainFrameId');
@@ -103,6 +105,11 @@ describe('TargetManager', () => {
       await sessionListener(sessionMock);
       expect(sendMock.findAllInvocations('Target.getTargetInfo')).toHaveLength(4);
       expect(sendMock.findAllInvocations('Target.setAutoAttach')).toHaveLength(3);
+      expect(sendMock.findAllInvocations('Network.enable')).toEqual([
+        NETWORK_ENABLE_OPTIONS,
+        NETWORK_ENABLE_OPTIONS,
+        NETWORK_ENABLE_OPTIONS,
+      ]);
 
       // Four resumes because in finally clause, so runs regardless of uniqueness.
       expect(sendMock.findAllInvocations('Runtime.runIfWaitingForDebugger')).toHaveLength(4);


### PR DESCRIPTION
### Summary
- pass a larger `maxResourceBufferSize` when enabling the Network domain
- reuse the same Network enable options for root preparation and target-manager attached sessions
- add driver tests covering navigation/timespan preparation and attached target sessions

### Rationale
`Network.getResponseBody` can fail with `Request content was evicted from inspector cache` when a large response is evicted before Lighthouse reads it. Increasing the per-resource buffer gives Lighthouse more room for those response bodies while keeping the change scoped to Network domain setup.

### Tests
- `corepack yarn mocha core/test/gather/driver/target-manager-test.js core/test/gather/driver/prepare-test.js`
- `corepack yarn eslint core/gather/driver/network.js core/gather/driver/target-manager.js core/gather/driver/prepare.js core/test/gather/driver/target-manager-test.js core/test/gather/driver/prepare-test.js`
- `corepack yarn type-check`
- `git diff --check`

Fixes #15704