### PR TITLE
core(has-hsts): account for preloaded public suffixes

### DIFF
--- a/core/audits/has-hsts.js
+++ b/core/audits/has-hsts.js
@@ -36,6 +36,67 @@ const UIStrings = {
 
 const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 
+// Keep in sync with Chromium HSTS preload entries whose `policy` is
+// `public-suffix`, `mode` is `force-https`, and `include_subdomains` is true.
+const HSTS_PRELOADED_PUBLIC_SUFFIXES = new Set([
+  'amazon',
+  'android',
+  'app',
+  'audible',
+  'azure',
+  'bank',
+  'bing',
+  'bmoattachments.org',
+  'boo',
+  'channel',
+  'chrome',
+  'cnpy.gdn',
+  'dad',
+  'day',
+  'dev',
+  'eat',
+  'esq',
+  'fire',
+  'fly',
+  'foo',
+  'fujitsu',
+  'gentapps.com',
+  'gle',
+  'gmail',
+  'google',
+  'hangout',
+  'hotmail',
+  'imdb',
+  'ing',
+  'insurance',
+  'kindle',
+  'meet',
+  'meme',
+  'microsoft',
+  'mov',
+  'new',
+  'nexus',
+  'now.sh',
+  'office',
+  'onavstack.net',
+  'page',
+  'phd',
+  'play',
+  'prime',
+  'prof',
+  'rsvp',
+  'search',
+  'silk',
+  'skype',
+  'windows',
+  'xbox',
+  'xn--cckwcxetd',
+  'xn--jlq480n2rg',
+  'youtube',
+  'zappos',
+  'zip',
+]);
+
 class HasHsts extends Audit {
   /**
    * @return {LH.Audit.Meta}
@@ -90,15 +151,41 @@ class HasHsts extends Audit {
   }
 
   /**
+   * @param {string=} url
+   * @return {boolean}
+   */
+  static isUrlCoveredByHstsPreloadedPublicSuffix(url) {
+    if (!url) return false;
+
+    let hostname;
+    try {
+      hostname = new URL(url).hostname.toLowerCase();
+    } catch {
+      return false;
+    }
+
+    for (const suffix of HSTS_PRELOADED_PUBLIC_SUFFIXES) {
+      if (hostname === suffix || hostname.endsWith(`.${suffix}`)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * @param {string[]} hstsHeaders
+   * @param {string=} finalDisplayedUrl
    * @return {{score: number, results: LH.Audit.Details.TableItem[]}}
    */
-  static constructResults(hstsHeaders) {
+  static constructResults(hstsHeaders, finalDisplayedUrl) {
     const rawHsts = [...hstsHeaders];
     const allowedDirectives = ['max-age', 'includesubdomains', 'preload'];
     const violations = [];
     const warnings = [];
     const syntax = [];
+    const hasPublicSuffixPreload =
+        this.isUrlCoveredByHstsPreloadedPublicSuffix(finalDisplayedUrl);
 
     if (!rawHsts.length) {
       return {
@@ -129,7 +216,7 @@ class HasHsts extends Audit {
       });
     }
 
-    if (!hstsHeaders.toString().includes('preload')) {
+    if (!hstsHeaders.toString().includes('preload') && !hasPublicSuffixPreload) {
       // No preload might be even wanted. But would be preferred.
       warnings.push({
         severity: str_(i18n.UIStrings.itemSeverityMedium),
@@ -184,7 +271,8 @@ class HasHsts extends Audit {
    */
   static async audit(artifacts, context) {
     const hstsHeaders = await this.getRawHsts(artifacts, context);
-    const {score, results} = this.constructResults(hstsHeaders);
+    const {score, results} =
+      this.constructResults(hstsHeaders, artifacts.URL.finalDisplayedUrl);
 
     /** @type {LH.Audit.Details.Table['headings']} */
     const headings = [

--- a/core/test/audits/has-hsts-test.js
+++ b/core/test/audits/has-hsts-test.js
@@ -159,6 +159,31 @@ it('preload missing, but other directives present', async () => {
   ]);
 });
 
+it('preload missing on a preloaded public suffix', async () => {
+  const artifacts = {
+    DevtoolsLog: networkRecordsToDevtoolsLog([
+      {
+        url: 'https://expo.dev',
+        responseHeaders: [
+          {
+            name: 'Strict-Transport-Security',
+            value: `max-age=63072000; includeSubDomains`,
+          },
+        ],
+      },
+    ]),
+    URL: {
+      requestedUrl: 'https://expo.dev',
+      mainDocumentUrl: 'https://expo.dev',
+      finalDisplayedUrl: 'https://expo.dev',
+    },
+  };
+
+  const results = await HasHsts.audit(artifacts, {computedCache: new Map()});
+  expect(results.details.items).toHaveLength(0);
+  expect(results.notApplicable).toBeTruthy();
+});
+
 it('No HSTS header found', async () => {
   const artifacts = {
     DevtoolsLog: networkRecordsToDevtoolsLog([
@@ -363,6 +388,14 @@ describe('constructResults', () => {
         directive: 'foo-directive',
       },
     ]);
+  });
+
+  it('omits the preload warning for preloaded public suffixes', () => {
+    const {score, results} = HasHsts.constructResults(
+        ['max-age=31536000', 'includesubdomains'],
+        'https://example.now.sh');
+    expect(score).toEqual(1);
+    expect(results).toEqual([]);
   });
 
   it('returns single item for no HSTS', () => {


### PR DESCRIPTION
Fixes #16680

## Summary
- Treat URLs under Chromium HSTS preload entries with `policy: "public-suffix"` as already covered for the audit's `preload` recommendation.
- Suppress only the missing-`preload` warning for those suffixes, while preserving the existing `max-age`, `includeSubDomains`, and syntax checks.
- Add regression coverage for `.dev` plus a multi-label preloaded public suffix.

## Root Cause
The audit previously evaluated only the response header directives. Domains under preloaded public suffixes such as `.dev` are already covered by Chrome's HSTS preload policy, so requiring a site-level `preload` directive creates a false warning for pages like `https://expo.dev`.

## Tests
- `corepack yarn install --frozen-lockfile --ignore-scripts --network-timeout 100000`
- Reproduced the original `https://expo.dev` audit warning with a local audit-level fixture before the fix
- `corepack yarn mocha core/test/audits/has-hsts-test.js`
- `corepack yarn eslint core/audits/has-hsts.js core/test/audits/has-hsts-test.js`
- `corepack yarn type-check`
- `corepack yarn i18n:checks`
- `git diff --check`

Also attempted `corepack yarn diff:sample-json`; it timed out locally after 3 minutes without output.