### PR TITLE
misc(core): restore trace minifier

### DIFF
--- a/core/lib/minify-trace.js
+++ b/core/lib/minify-trace.js
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Minifies a trace by removing events that are not needed for
+ * Lantern metric calculations and by throttling screenshot events.
+ */
+
+import {TraceProcessor} from './tracehouse/trace-processor.js';
+
+const topLevelTaskNames = new Set([
+  'RunTask', // m71+
+  'ThreadControllerImpl::RunTask', // m69-70
+  'ThreadControllerImpl::DoWork', // m66-68
+  'TaskQueueManager::ProcessTaskFromWorkQueue', // m65 and below
+]);
+
+const traceCategoriesToAlwaysKeep = new Set([
+  // Labels the threads correctly in DevTools Performance panel.
+  '__metadata',
+]);
+
+const traceCategoriesToDrop = new Set([
+  'disabled-by-default-devtools.timeline.frame',
+  'disabled-by-default-v8.cpu_profiler',
+  'disabled-by-default-v8.cpu_profiler.hires',
+  'latencyInfo',
+]);
+
+const traceEventsToAlwaysKeep = new Set([
+  'Screenshot',
+  'TracingStartedInBrowser',
+  'TracingStartedInPage',
+  'navigationStart',
+  'ParseAuthorStyleSheet',
+  'ParseHTML',
+  'PlatformResourceSendRequest',
+  'ResourceSendRequest',
+  'ResourceReceiveResponse',
+  'ResourceFinish',
+  'ResourceReceivedData',
+  'EventDispatch',
+  'LayoutShift',
+  'FrameCommittedInBrowser',
+  // Not currently used by Lighthouse but might be used in the future for cross-frame LCP.
+  'NavStartToLargestContentfulPaint::Invalidate::AllFrames::UKM',
+  'NavStartToLargestContentfulPaint::Candidate::AllFrames::UKM',
+]);
+
+const traceEventsToKeepInTopLevelTask = new Set([
+  // Needed for CPU node timing simulations.
+  'Layout',
+  'RunMicrotasks',
+  // All of these are needed to create graph relationships.
+  'TimerInstall',
+  'TimerFire',
+  'InvalidateLayout',
+  'ScheduleStyleRecalculation',
+  'EvaluateScript',
+  'XHRReadyStateChange',
+  'FunctionCall',
+  'v8.compile',
+  'ParseAuthorStyleSheet',
+  'ResourceSendRequest',
+]);
+
+const traceEventsToKeepInProcess = new Set([
+  ...topLevelTaskNames,
+  ...traceEventsToKeepInTopLevelTask,
+
+  // See the DevTools marker events.
+  // https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/panels/timeline/TimelineUIUtils.ts
+  'firstPaint',
+  'firstContentfulPaint',
+  'firstMeaningfulPaint',
+  'firstMeaningfulPaintCandidate',
+  'loadEventEnd',
+  'MarkLoad',
+  'domContentLoadedEventEnd',
+  'MarkDOMContent',
+  'largestContentfulPaint::Invalidate',
+  'largestContentfulPaint::Candidate',
+  'Animation',
+]);
+
+/**
+ * @param {LH.TraceEvent} event
+ * @return {boolean}
+ */
+function hasDroppedCategory(event) {
+  const categories = event.cat?.split(',') || [];
+  return categories.some(category => traceCategoriesToDrop.has(category));
+}
+
+/**
+ * @param {LH.TraceEvent[]} events
+ * @return {LH.TraceEvent[]}
+ */
+function filterOutUnnecessaryTasksByNameAndDuration(events) {
+  const {startingPid} = TraceProcessor.findMainFrameIds(events);
+
+  return events.filter(event => {
+    if (hasDroppedCategory(event)) return false;
+    if (topLevelTaskNames.has(event.name) && event.dur && event.dur < 1000) return false;
+    if (event.pid === startingPid && traceEventsToKeepInProcess.has(event.name)) return true;
+    if (event.cat && traceCategoriesToAlwaysKeep.has(event.cat)) return true;
+    return traceEventsToAlwaysKeep.has(event.name);
+  });
+}
+
+/**
+ * Filters out tasks that are not within a top-level task.
+ * @param {LH.TraceEvent[]} events
+ * @return {LH.TraceEvent[]}
+ */
+function filterOutOrphanedTasks(events) {
+  const topLevelRanges = events
+    .filter(event => topLevelTaskNames.has(event.name) && event.dur)
+    .map(event => [event.ts, event.ts + event.dur]);
+
+  /** @param {LH.TraceEvent} event */
+  const isInTopLevelTask =
+    event => topLevelRanges.some(([start, end]) => event.ts >= start && event.ts <= end);
+
+  return events.filter((event, index) => {
+    if (!traceEventsToKeepInTopLevelTask.has(event.name)) return true;
+    if (!isInTopLevelTask(event)) return false;
+
+    if (event.ph === 'B') {
+      const endEvent = events.slice(index).find(e => e.name === event.name && e.ph === 'E');
+      return endEvent && isInTopLevelTask(endEvent);
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Throttles screenshot events in the trace to 2fps.
+ * @param {LH.TraceEvent[]} events
+ * @return {LH.TraceEvent[]}
+ */
+function filterOutExcessiveScreenshots(events) {
+  const screenshotTimestamps = events.filter(event => event.name === 'Screenshot')
+    .map(event => event.ts);
+
+  let lastScreenshotTs = -Infinity;
+  return events.filter(event => {
+    if (event.name !== 'Screenshot') return true;
+    const timeSinceLastScreenshot = event.ts - lastScreenshotTs;
+    const nextScreenshotTs = screenshotTimestamps.find(ts => ts > event.ts);
+    const timeUntilNextScreenshot = nextScreenshotTs ? nextScreenshotTs - event.ts : Infinity;
+    const threshold = 500 * 1000; // Throttle to ~2fps.
+    const shouldKeep = timeUntilNextScreenshot > threshold || timeSinceLastScreenshot > threshold;
+    if (shouldKeep) lastScreenshotTs = event.ts;
+    return shouldKeep;
+  });
+}
+
+/**
+ * @param {LH.TraceEvent[]} events
+ * @return {LH.TraceEvent[]}
+ */
+function filterTraceEvents(events) {
+  let filtered = filterOutUnnecessaryTasksByNameAndDuration(events);
+  filtered = filterOutOrphanedTasks(filtered);
+  return filterOutExcessiveScreenshots(filtered);
+}
+
+/**
+ * @param {LH.Trace} inputTrace
+ * @return {LH.Trace}
+ */
+function minifyTrace(inputTrace) {
+  return {
+    ...inputTrace,
+    traceEvents: filterTraceEvents(inputTrace.traceEvents),
+  };
+}
+
+export {minifyTrace};

--- a/core/scripts/lantern/minify-trace.js
+++ b/core/scripts/lantern/minify-trace.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Minifies a trace by removing events that are not needed for Lantern.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import {minifyTrace} from '../../lib/minify-trace.js';
+
+if (process.argv.length !== 4) {
+  console.error('Usage $0: <input file> <output file>');
+  process.exit(1);
+}
+
+const inputTracePath = path.resolve(process.cwd(), process.argv[2]);
+const outputTracePath = path.resolve(process.cwd(), process.argv[3]);
+const inputTraceRaw = fs.readFileSync(inputTracePath, 'utf8');
+/** @type {LH.Trace} */
+const inputTrace = JSON.parse(inputTraceRaw);
+
+const outputTrace = minifyTrace(inputTrace);
+const output = `{
+  "traceEvents": [
+${outputTrace.traceEvents.map(event => '    ' + JSON.stringify(event)).join(',\n')}
+  ]
+}`;
+
+/** @param {string} s */
+const size = s => Math.round(s.length / 1024) + 'kb';
+const eventDelta = inputTrace.traceEvents.length - outputTrace.traceEvents.length;
+console.log(`Reduced trace from ${size(inputTraceRaw)} to ${size(output)}`);
+console.log(`Filtered out ${eventDelta} trace events`);
+fs.writeFileSync(outputTracePath, output);

--- a/core/test/lib/minify-trace-test.js
+++ b/core/test/lib/minify-trace-test.js
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {minifyTrace} from '../../lib/minify-trace.js';
+import MetricsAudit from '../../audits/metrics.js';
+import {getURLArtifactFromDevtoolsLog, readJson} from '../test-utils.js';
+import {defaultSettings} from '../../config/constants.js';
+
+const trace = readJson('../fixtures/traces/progressive-app-m60.json', import.meta);
+const devtoolsLog = readJson('../fixtures/traces/progressive-app-m60.devtools.log.json', import.meta);
+const settings = JSON.parse(JSON.stringify(defaultSettings));
+
+/**
+ * @return {LH.Audit.Context}
+ */
+function createAuditContext() {
+  return /** @type {LH.Audit.Context} */ (/** @type {unknown} */ ({
+    settings: {...settings, throttlingMethod: 'simulate'},
+    options: {},
+    computedCache: new Map(),
+  }));
+}
+
+describe('minify-trace', () => {
+  it('removes DevTools-only trace categories', () => {
+    const minifiedTrace = minifyTrace({
+      traceEvents: [
+        {name: 'TracingStartedInBrowser', cat: 'disabled-by-default-devtools.timeline', ph: 'I',
+          pid: 1, tid: 1, ts: 0, dur: 0,
+          args: {data: {frames: [{frame: 'frame', processId: 1, url: 'https://example.com/'}]}}},
+        {name: 'navigationStart', cat: 'blink.user_timing', ph: 'R', pid: 1, tid: 1, ts: 1, dur: 0,
+          args: {data: {documentLoaderURL: 'https://example.com/'}}},
+        {name: 'RunTask', cat: 'disabled-by-default-lighthouse', ph: 'X', pid: 1, tid: 1, ts: 2,
+          dur: 2000, args: {}},
+        {name: 'DroppedFrame', cat: 'disabled-by-default-devtools.timeline.frame', ph: 'I',
+          pid: 1, tid: 1, ts: 3, dur: 0, args: {}},
+        {name: 'EventLatency', cat: 'latencyInfo', ph: 'X', pid: 1, tid: 1, ts: 4, dur: 1,
+          args: {}},
+        {name: 'ProfileChunk', cat: 'disabled-by-default-v8.cpu_profiler', ph: 'I',
+          pid: 1, tid: 1, ts: 5, dur: 0, args: {}},
+      ],
+    });
+
+    expect(minifiedTrace.traceEvents.map(event => event.name)).toEqual([
+      'TracingStartedInBrowser',
+      'navigationStart',
+      'RunTask',
+    ]);
+  });
+
+  it('has identical metrics to unminified', async () => {
+    /** @type {LH.Artifacts} */
+    const artifacts = /** @type {LH.Artifacts} */ (/** @type {unknown} */ ({
+      GatherContext: {gatherMode: 'navigation'},
+      Trace: trace,
+      DevtoolsLog: devtoolsLog,
+      URL: getURLArtifactFromDevtoolsLog(devtoolsLog),
+      SourceMaps: [],
+      HostDPR: 1,
+    }));
+    const beforeResult = await MetricsAudit.audit(artifacts, createAuditContext());
+    const beforeDetails = /** @type {LH.Audit.Details.DebugData} */ (beforeResult.details);
+    const before = beforeDetails.items[0];
+    const beforeSize = JSON.stringify(trace).length;
+
+    const minifiedTrace = minifyTrace(trace);
+    artifacts.Trace = minifiedTrace;
+    const afterResult = await MetricsAudit.audit(artifacts, createAuditContext());
+    const afterDetails = /** @type {LH.Audit.Details.DebugData} */ (afterResult.details);
+    const after = afterDetails.items[0];
+    const afterSize = JSON.stringify(minifiedTrace).length;
+
+    for (const key of Object.keys(after)) {
+      // Speed Index is expected to differ because of screenshot throttling.
+      // Trace End can also differ if the last event was unimportant.
+      if (/speedIndex|traceEnd/i.test(key)) {
+        delete before[key];
+        delete after[key];
+      }
+    }
+
+    // It should greatly reduce the size of the trace.
+    expect(afterSize).toBeLessThan(beforeSize * 0.2);
+    // And not affect the metrics.
+    expect(after).toEqual(before);
+  });
+});


### PR DESCRIPTION
### Summary
- Restore a trace minifier in the current ESM layout.
- Drop DevTools-only trace categories (`disabled-by-default-devtools.timeline.frame`, CPU profiler categories, and `latencyInfo`) before applying the Lantern keep-list.
- Add a focused unit test that verifies the category pruning and confirms the minified fixture keeps the same metrics.

### Rationale
#12748 notes that additional DevTools trace categories increased saved trace size. Lighthouse no longer has the old `minify-trace` helper, so this reintroduces it with the modern `TraceProcessor` API and keeps the script next to the existing Lantern devtools log minifier.

### Tests
- `corepack yarn mocha core/test/lib/minify-trace-test.js`
- `corepack yarn eslint core/lib/minify-trace.js core/scripts/lantern/minify-trace.js core/test/lib/minify-trace-test.js`
- `node core/scripts/lantern/minify-trace.js core/test/fixtures/traces/progressive-app-m60.json <temp-file>` (reduced the fixture from 5711kb to 564kb; output parsed successfully)
- `git diff --check`

Attempted: `corepack yarn type-check`; the linked local dependency setup fails on existing Puppeteer deep import resolution errors in `target-manager-test.js`, `session-test.js`, and `clients/lightrider/lightrider-entry.js`. No errors remained from the touched files after the test typing fixes.

Fixes #12748.
