### PR TITLE
core(llms-txt): allow leading BOM

### DIFF
--- a/core/audits/agentic/llms-txt.js
+++ b/core/audits/agentic/llms-txt.js
@@ -84,9 +84,11 @@ class LlmsTxt extends Audit {
       throw new Error(`Status ${status} was valid, but content was null`);
     }
 
-    const hasH1 = /^#\s+.+/m.test(content);
-    const hasLink = /\[.+\]\(.+\)/.test(content);
-    const isTooShort = content.length < 50;
+    const contentWithoutBom = content.replace(/^\uFEFF/, '');
+
+    const hasH1 = /^#\s+.+/m.test(contentWithoutBom);
+    const hasLink = /\[.+\]\(.+\)/.test(contentWithoutBom);
+    const isTooShort = contentWithoutBom.length < 50;
 
     const errors = [];
     if (!hasH1) errors.push(str_(UIStrings.missingH1));

--- a/core/test/audits/agentic/llms-txt-test.js
+++ b/core/test/audits/agentic/llms-txt-test.js
@@ -170,6 +170,10 @@ describe('Agentic: llms.txt audit', () => {
 This content is long enough to pass the length check and has a link [Here](https://example.com).
 `,
       },
+      {
+        status: 200,
+        content: `\uFEFF# Title\nLong enough file with a link [Link](https://example.com) after a BOM.`,
+      },
     ];
 
     testData.forEach(LlmsTxt => {


### PR DESCRIPTION
## Problem

Some valid `llms.txt` files start with a UTF-8 byte-order mark before the first Markdown heading. The audit checks the raw fetched content with an H1 regex anchored at the start of a line, so a leading BOM prevents `# Title` from being detected.

## Root cause

The validation runs against the fetched text without normalizing a leading U+FEFF byte-order mark.

## Solution

Strip only a leading BOM before running the existing H1, link, and length checks. This keeps the audit behavior unchanged for the rest of the file content while allowing BOM-prefixed Markdown to validate normally.

## Tests run

- `corepack yarn mocha core/test/audits/agentic/llms-txt-test.js`
- `corepack yarn eslint core/audits/agentic/llms-txt.js core/test/audits/agentic/llms-txt-test.js`
- `git diff --check`

`corepack yarn type-check` was attempted, but this local checkout still fails in unrelated files because `puppeteer-core/lib/puppeteer/cdp/*` deep imports cannot be resolved.

Fixes #17051