### PR TITLE
report(scorecalc): clamp values on device switch

### DIFF
--- a/scorecalc/calc.js
+++ b/scorecalc/calc.js
@@ -520,6 +520,31 @@ function getMajorVersion(version) {
   return version.split('.')[0];
 }
 
+function clampMetricValuesForDevice(metricValues, versions, device) {
+  const nextMetricValues = {...metricValues};
+  const versionKeys = versions.map(version => `v${version}`);
+
+  for (const id of Object.keys(nextMetricValues)) {
+    const bounds = versionKeys
+      .map(versionKey => {
+        const scoringGuide = scoringGuides[versionKey] && scoringGuides[versionKey][device];
+        return scoringGuide && scoringGuide[id];
+      })
+      .filter(Boolean)
+      .map(determineMinMax);
+
+    if (!bounds.length) continue;
+
+    const min = Math.max(...bounds.map(bound => bound.min));
+    const max = Math.min(...bounds.map(bound => bound.max));
+    if (min <= max) {
+      nextMetricValues[id] = Math.max(Math.min(nextMetricValues[id], max), min);
+    }
+  }
+
+  return nextMetricValues;
+}
+
 class Metric extends m {
   onValueChange(e) {
     const {id} = this.props;
@@ -731,7 +756,10 @@ class App extends m {
   }
 
   onDeviceChange(e) {
-    this.setState({device: e.target.value});
+    const device = e.target.value;
+    const versions = this.normalizeVersions(this.state.versions);
+    const metricValues = clampMetricValuesForDevice(this.state.metricValues, versions, device);
+    this.setState({device, metricValues});
   }
 
   onVersionsChange(e) {


### PR DESCRIPTION
## Problem

When the score calculator switches device type, the rendered range inputs receive the new device bounds, but the shared metric values in app state keep the previous device values. If a mobile value is above the desktop range, the slider visually clamps while the output and metric score are still computed from the stale out-of-range value.

## Root cause

`onDeviceChange()` only updates `device`; it does not normalize `metricValues` against the scoring bounds for the newly selected device.

## Solution

Clamp each shared metric value to the bounds for the newly selected device and currently visible scoring versions before updating state. This keeps the slider, output, score, and permalink hash in sync after the device switch.

## Tests run

- `node --check scorecalc/calc.js`
- `git diff --check`
- Browser verification against local `scorecalc/`: set FCP to mobile max, switched to desktop, confirmed FCP output changed to `4,000 ms`, score input changed to `1`, and hash updated with `FCP=4000&device=desktop`

Fixes #16609