### PR TITLE
core(user-flow): support aborting pending navigations

### DIFF
--- a/core/gather/driver/navigation.js
+++ b/core/gather/driver/navigation.js
@@ -107,10 +107,26 @@ async function gotoURL(driver, requestor, options) {
 
   /** @type {Array<Promise<{timedOut: boolean}>>} */
   const waitConditionPromises = [];
+  /** @type {Array<() => void>} */
+  const cleanups = [];
+
+  /** @type {(event: Event) => void} */
+  let onAbort = () => {};
+  /** @type {Promise<never>} */
+  const abortPromise = new Promise((_, reject) => {
+    if (!options.signal) return;
+    options.signal.throwIfAborted();
+    onAbort = () => reject(new Error('Navigation aborted by signal'));
+    options.signal.addEventListener('abort', onAbort, {once: true});
+  });
+  if (options.signal) cleanups.push(() => options.signal?.removeEventListener('abort', onAbort));
 
   if (waitForNavigated) {
-    const navigatedPromise = waitForFrameNavigated(session).promise;
-    waitConditionPromises.push(navigatedPromise.then(() => ({timedOut: false})));
+    const {promise, cancel} = waitForFrameNavigated(session);
+    cleanups.push(() => cancel());
+    waitConditionPromises.push(promise
+      .then(() => ({timedOut: false}))
+      .catch(() => ({timedOut: false})));
   }
 
   if (waitForLoad) {
@@ -122,10 +138,18 @@ async function gotoURL(driver, requestor, options) {
     throw new Error('Cannot wait for FCP without waiting for page load');
   }
 
-  const waitConditions = await Promise.race([
+  const waitConditionsRace = [
     session.onCrashPromise(),
     Promise.all(waitConditionPromises),
-  ]);
+  ];
+  if (options.signal) waitConditionsRace.push(abortPromise);
+
+  let waitConditions;
+  try {
+    waitConditions = await Promise.race(waitConditionsRace);
+  } finally {
+    for (const cleanup of cleanups) cleanup();
+  }
   const timedOut = waitConditions.some(condition => condition.timedOut);
   const navigationUrls = await networkMonitor.getNavigationUrls();
 
@@ -144,7 +168,9 @@ async function gotoURL(driver, requestor, options) {
   const mainDocumentUrl = navigationUrls.mainDocumentUrl || requestedUrl;
 
   // Bring `Page.navigate` errors back into the promise chain. See https://github.com/GoogleChrome/lighthouse/pull/6739.
-  await waitForNavigationTriggered;
+  await Promise.race(options.signal ?
+    [waitForNavigationTriggered, abortPromise] :
+    [waitForNavigationTriggered]);
 
   if (options.debugNavigation) {
     await waitForUserToContinue(driver);

--- a/core/gather/driver/navigation.js
+++ b/core/gather/driver/navigation.js
@@ -39,7 +39,7 @@ const DEFAULT_NETWORK_QUIET_THRESHOLD = 5000;
 // Controls how long to wait between longtasks before determining the CPU is idle, off by default
 const DEFAULT_CPU_QUIET_THRESHOLD = 0;
 
-/** @typedef {{waitUntil: Array<'fcp'|'load'|'navigated'>} & Partial<LH.Config.Settings>} NavigationOptions */
+/** @typedef {{waitUntil: Array<'fcp'|'load'|'navigated'>, signal?: AbortSignal} & Partial<LH.Config.Settings>} NavigationOptions */
 
 /** @param {NavigationOptions} options */
 function resolveWaitForFullyLoadedOptions(options) {
@@ -115,7 +115,9 @@ async function gotoURL(driver, requestor, options) {
 
   if (waitForLoad) {
     const waitOptions = resolveWaitForFullyLoadedOptions(options);
-    waitConditionPromises.push(waitForFullyLoaded(session, networkMonitor, waitOptions));
+    waitConditionPromises.push(
+      waitForFullyLoaded(session, networkMonitor, waitOptions, options.signal)
+    );
   } else if (waitForFcp) {
     throw new Error('Cannot wait for FCP without waiting for page load');
   }

--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -533,6 +533,7 @@ async function waitForFullyLoaded(session, networkMonitor, options, signal) {
   let onAbort = () => {};
   /** @type {Promise<() => Promise<{timedOut: boolean}>>} */
   const abortPromise = new Promise((resolve) => {
+    signal?.throwIfAborted();
     onAbort = () => resolve(async () => ({timedOut: false}));
     signal?.addEventListener('abort', onAbort, {once: true});
   });

--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -422,9 +422,10 @@ const DEFAULT_WAIT_FUNCTIONS = {waitForFcp, waitForLoadEvent, waitForCPUIdle, wa
  * @param {LH.Gatherer.ProtocolSession} session
  * @param {NetworkMonitor} networkMonitor
  * @param {WaitOptions} options
+ * @param {AbortSignal} [signal]
  * @return {Promise<{timedOut: boolean}>}
  */
-async function waitForFullyLoaded(session, networkMonitor, options) {
+async function waitForFullyLoaded(session, networkMonitor, options, signal) {
   const {pauseAfterFcpMs, pauseAfterLoadMs, networkQuietThresholdMs,
     cpuQuietThresholdMs, maxWaitForLoadedMs, maxWaitForFcpMs} = options;
   const {waitForFcp, waitForLoadEvent, waitForNetworkIdle, waitForCPUIdle} =
@@ -528,12 +529,22 @@ async function waitForFullyLoaded(session, networkMonitor, options) {
     };
   });
 
+  /** @type {(event: Event) => void} */
+  let onAbort = () => {};
+  /** @type {Promise<() => Promise<{timedOut: boolean}>>} */
+  const abortPromise = new Promise((resolve) => {
+    onAbort = () => resolve(async () => ({timedOut: false}));
+    signal?.addEventListener('abort', onAbort, {once: true});
+  });
+
   // Wait for load or timeout and run the cleanup function the winner returns.
   const cleanupFn = await Promise.race([
     loadPromise,
     maxTimeoutPromise,
+    abortPromise,
   ]);
 
+  signal?.removeEventListener('abort', onAbort);
   maxTimeoutHandle && clearTimeout(maxTimeoutHandle);
   resolveOnFcp.cancel();
   resolveOnLoadEvent.cancel();

--- a/core/gather/navigation-runner.js
+++ b/core/gather/navigation-runner.js
@@ -32,6 +32,7 @@ import {NetworkRecords} from '../computed/network-records.js';
  * @property {LH.NavigationRequestor} requestor
  * @property {LH.BaseArtifacts} baseArtifacts
  * @property {Map<string, LH.ArbitraryEqualityMap>} computedCache
+ * @property {AbortSignal} [signal]
  */
 
 /** @typedef {Omit<Parameters<typeof collectPhaseArtifacts>[0], 'phase'>} PhaseState */
@@ -79,12 +80,13 @@ async function _cleanupNavigation({driver}) {
  * @return {Promise<{requestedUrl: string, mainDocumentUrl: string, navigationError: LH.LighthouseError | undefined}>}
  */
 async function _navigate(navigationContext) {
-  const {driver, resolvedConfig, requestor} = navigationContext;
+  const {driver, resolvedConfig, requestor, signal} = navigationContext;
 
   try {
     const {requestedUrl, mainDocumentUrl, warnings} = await gotoURL(driver, requestor, {
       ...resolvedConfig.settings,
       waitUntil: resolvedConfig.settings.pauseAfterFcpMs ? ['fcp', 'load'] : ['load'],
+      signal,
     });
 
     navigationContext.baseArtifacts.LighthouseRunWarnings.push(...warnings);
@@ -251,11 +253,11 @@ async function _cleanup({requestedUrl, driver, resolvedConfig, lhBrowser, lhPage
 /**
  * @param {LH.Puppeteer.Page|undefined} page
  * @param {LH.NavigationRequestor|undefined} requestor
- * @param {{config?: LH.Config, flags?: LH.Flags}} [options]
+ * @param {{config?: LH.Config, flags?: LH.Flags, signal?: AbortSignal }} [options]
  * @return {Promise<LH.Gatherer.GatherResult>}
  */
 async function navigationGather(page, requestor, options = {}) {
-  const {flags = {}, config} = options;
+  const {flags = {}, config, signal} = options;
   log.setLevel(flags.logLevel || 'error');
 
   const {resolvedConfig} = await initializeConfig('navigation', config, flags);
@@ -291,6 +293,7 @@ async function navigationGather(page, requestor, options = {}) {
       resolvedConfig,
       requestor: normalizedRequestor,
       computedCache,
+      signal,
     };
     const {baseArtifacts} = await _setup(context);
 

--- a/core/test/gather/driver/navigation-test.js
+++ b/core/test/gather/driver/navigation-test.js
@@ -243,6 +243,66 @@ describe('.gotoURL', () => {
       message: 'Cannot wait for FCP without waiting for page load',
     });
   });
+
+  it('aborts when signal is already aborted before gotoURL is called', async () => {
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
+    await driver.networkMonitor.enable();
+
+    const url = 'https://www.example.com';
+    const controller = new AbortController();
+    controller.abort();
+
+    const loadPromise = makePromiseInspectable(
+      gotoURL(driver, url, {waitUntil: ['navigated'], signal: controller.signal})
+    );
+
+    await expect(loadPromise).rejects.toThrow('This operation was aborted');
+  });
+
+  it('aborts when signal is aborted before wait conditions resolve', async () => {
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
+    await driver.networkMonitor.enable();
+
+    const url = 'https://www.example.com';
+    const controller = new AbortController();
+
+    const loadPromise = makePromiseInspectable(
+      gotoURL(driver, url, {waitUntil: ['navigated'], signal: controller.signal})
+    );
+    await flushAllTimersAndMicrotasks();
+    expect(loadPromise).not.toBeDone('Did not wait for frameNavigated');
+
+    controller.abort();
+    await flushAllTimersAndMicrotasks();
+
+    await expect(loadPromise).rejects.toThrow('Navigation aborted by signal');
+  });
+
+  it('aborts when signal is aborted while waiting for navigated', async () => {
+    mockDriver.defaultSession.on = mockDriver.defaultSession.once;
+    await driver.networkMonitor.enable();
+
+    const url = 'https://www.example.com';
+    const controller = new AbortController();
+
+    const loadPromise = makePromiseInspectable(
+      gotoURL(driver, url, {waitUntil: ['navigated', 'load'], signal: controller.signal})
+    );
+    await flushAllTimersAndMicrotasks();
+    expect(loadPromise).not.toBeDone('Did not wait for frameNavigated/load');
+
+    // Simulate navigation resolving
+    const [_, navigatedListener] = mockDriver.defaultSession.on.getListeners('Page.frameNavigated');
+    navigatedListener({frame: {url: 'https://www.example.com'}});
+    await flushAllTimersAndMicrotasks();
+    expect(loadPromise).not.toBeDone('Did not wait for load');
+
+    // Abort before load happens
+    controller.abort();
+    await flushAllTimersAndMicrotasks();
+
+    await expect(loadPromise).rejects.toThrow('Navigation aborted by signal');
+  });
 });
 
 describe('.getNavigationWarnings()', () => {

--- a/core/test/gather/driver/wait-for-condition-test.js
+++ b/core/test/gather/driver/wait-for-condition-test.js
@@ -244,6 +244,52 @@ describe('waitForFullyLoaded()', () => {
     // Make sure we still cleaned up our listeners
     expect(options._waitForTestOverrides.waitForLoadEvent.getMockCancelFn()).toHaveBeenCalled();
   });
+
+  it('should stop waiting and cancel listeners when aborted', async () => {
+    const controller = new AbortController();
+
+    const loadPromise = makePromiseInspectable(wait.waitForFullyLoaded(
+      session,
+      networkMonitor,
+      {...options, maxWaitForFcpMs: 60000},
+      controller.signal
+    ));
+
+    await flushAllTimersAndMicrotasks();
+    expect(loadPromise).not.toBeDone();
+
+    controller.abort();
+    await flushAllTimersAndMicrotasks();
+
+    expect(loadPromise).toBeDone();
+    expect(await loadPromise).toEqual({timedOut: false});
+    expect(options._waitForTestOverrides.waitForFcp.getMockCancelFn()).toHaveBeenCalled();
+    expect(options._waitForTestOverrides.waitForLoadEvent.getMockCancelFn()).toHaveBeenCalled();
+  });
+
+  it('should remove the abort listener when loading completes', async () => {
+    const signal = /** @type {AbortSignal} */ ({
+      addEventListener: fnAny(),
+      removeEventListener: fnAny(),
+    });
+
+    const loadPromise = wait.waitForFullyLoaded(
+      session,
+      networkMonitor,
+      options,
+      signal
+    );
+
+    options._waitForTestOverrides.waitForLoadEvent.mockResolve();
+    options._waitForTestOverrides.waitForNetworkIdle.mockResolve();
+    await flushAllTimersAndMicrotasks();
+
+    options._waitForTestOverrides.waitForCPUIdle.mockResolve();
+    await loadPromise;
+
+    const onAbort = signal.addEventListener.mock.calls[0][1];
+    expect(signal.removeEventListener).toHaveBeenCalledWith('abort', onAbort);
+  });
 });
 
 describe('waitForFcp()', () => {

--- a/core/test/gather/driver/wait-for-condition-test.js
+++ b/core/test/gather/driver/wait-for-condition-test.js
@@ -271,6 +271,7 @@ describe('waitForFullyLoaded()', () => {
     const signal = /** @type {AbortSignal} */ ({
       addEventListener: fnAny(),
       removeEventListener: fnAny(),
+      throwIfAborted: fnAny(),
     });
 
     const loadPromise = wait.waitForFullyLoaded(

--- a/core/test/gather/mock-driver.js
+++ b/core/test/gather/mock-driver.js
@@ -8,6 +8,7 @@
  * @fileoverview Mock driver for testing.
  */
 
+import {EventEmitter} from 'node:events';
 import jestMock from 'jest-mock';
 import * as td from 'testdouble';
 
@@ -110,6 +111,7 @@ function createMockPage() {
   return {
     url: fnAny().mockReturnValue('https://example.com'),
     goto: fnAny(),
+    on: fnAny(),
     target: () => ({createCDPSession: () => createMockSession()}),
 
     /** @return {LH.Puppeteer.Page} */

--- a/core/test/gather/mock-driver.js
+++ b/core/test/gather/mock-driver.js
@@ -8,7 +8,6 @@
  * @fileoverview Mock driver for testing.
  */
 
-import {EventEmitter} from 'node:events';
 import jestMock from 'jest-mock';
 import * as td from 'testdouble';
 

--- a/core/test/scenarios/start-end-navigation-test-pptr.js
+++ b/core/test/scenarios/start-end-navigation-test-pptr.js
@@ -53,4 +53,26 @@ describe('Start/End navigation', function() {
       throw new Error(`Unexpected audit error: ${JSON.stringify(erroredAudits[0], null, 2)}`);
     }
   });
+
+  it('should cleanly abort an active navigation when dispose is called', async () => {
+    const pageUrl = `${state.serverBaseUrl}/links-to-index.html`;
+    await state.page.goto(pageUrl, {waitUntil: ['networkidle0']});
+
+    const flow = await api.startFlow(state.page);
+
+    await flow.startNavigation();
+    // Leave the internal gatherer hanging, waiting indefinitely for a page load.
+    // Disposing the flow should immediately abort those internal wait conditions.
+    flow.dispose();
+
+    // Attempting to end the navigation after disposal should resolve cleanly without hanging
+    // because the internal aborted promise was caught and swallowed by the gatherer.
+    // If dispose() fails to abort the gatherer, this will hang until Lighthouse's 45s timeout.
+    // We wrap it in a 10s timeout to ensure the test fails fast if aborting is broken.
+    const endNavPromise = flow.endNavigation();
+    const timeoutPromise =
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Test timed out')), 10000));
+
+    await expect(Promise.race([endNavPromise, timeoutPromise])).resolves.toBeUndefined();
+  });
 });

--- a/core/user-flow.js
+++ b/core/user-flow.js
@@ -68,6 +68,12 @@ class UserFlow {
     this._gatherStepRunnerOptions = new WeakMap();
   }
 
+  _controller = new AbortController();
+
+  dispose() {
+    this._controller.abort();
+  }
+
   /**
    * @param {LH.UserFlow.StepFlags|undefined} flags
    * @return {LH.UserFlow.StepFlags|undefined}
@@ -131,6 +137,7 @@ class UserFlow {
     const gatherResult = await navigationGather(this._page, requestor, {
       config: this._options?.config,
       flags: nextFlags,
+      signal: this._controller.signal,
     });
 
     this._addGatherStep(gatherResult, nextFlags);

--- a/core/user-flow.js
+++ b/core/user-flow.js
@@ -173,6 +173,7 @@ class UserFlow {
       () => new Promise(continueNavigation => completeSetup(continueNavigation)),
       stepOptions
     ).catch(err => {
+      if (this._controller.signal.aborted) return;
       if (this.currentNavigation) {
         // If the navigation already started, re-throw the error so it is emitted when `navigationResultPromise` is awaited.
         throw err;

--- a/core/user-flow.js
+++ b/core/user-flow.js
@@ -66,9 +66,13 @@ class UserFlow {
     this._gatherSteps = [];
     /** @type {GatherStepRunnerOptions} */
     this._gatherStepRunnerOptions = new WeakMap();
-  }
+    /** @type {AbortController} */
+    this._controller = new AbortController();
 
-  _controller = new AbortController();
+    page.on('close', () => {
+      this.dispose();
+    });
+  }
 
   dispose() {
     this._controller.abort();

--- a/docs/user-flows.md
+++ b/docs/user-flows.md
@@ -254,6 +254,7 @@ await flow.navigate('https://example.com');
 - Always audit page navigations with navigation mode, avoid auditing hard page navigations with timespan mode.
 - Use snapshot recordings when a substantial portion of the page content has changed.
 - Always wait for transitions and interactions to finish before ending a timespan. The puppeteer APIs `page.waitForSelector`/`page.waitForFunction`/`page.waitForResponse`/`page.waitForTimeout` are your friends here.
+- Use dispose to cancel navigations and gracefully cleanup navigations wait conditions.
 
 ## Related Reading
 

--- a/docs/user-flows.md
+++ b/docs/user-flows.md
@@ -254,7 +254,18 @@ await flow.navigate('https://example.com');
 - Always audit page navigations with navigation mode, avoid auditing hard page navigations with timespan mode.
 - Use snapshot recordings when a substantial portion of the page content has changed.
 - Always wait for transitions and interactions to finish before ending a timespan. The puppeteer APIs `page.waitForSelector`/`page.waitForFunction`/`page.waitForResponse`/`page.waitForTimeout` are your friends here.
-- Use dispose to cancel navigations and gracefully cleanup navigations wait conditions.
+- Use `flow.dispose()` to cancel navigations and gracefully cleanup wait conditions. This allows you to handle failed navigations programmatically.
+
+  ```javascript
+  try {
+    await flow.startNavigation();
+    await page.goto('https://invalid-url.dev/');
+    await flow.endNavigation();
+  } catch (error) {
+    flow.dispose();
+    console.error("Navigation failed:", error);
+  }
+  ```
 
 ## Related Reading
 


### PR DESCRIPTION
**Summary**

Introduces a way to gracefully dispose of ongoing wait for conditions in Userflow navigation audits.

This allows programatic usage to handle failed navigations without having to await for wait for conditions to throw timeout errors.

It also automatically handles disposal of the conditions when the puppeteer page is closed.

Example usage:

```javascript
import { writeFileSync } from 'fs';
import puppeteer from 'puppeteer';
import { startFlow } from 'lighthouse';

const browser = await puppeteer.launch();
const page = await browser.newPage();
const flow = await startFlow(page);

try {
  await flow.startNavigation();
  await page.goto('https://invalid-url.dev/');
  await flow.endNavigation();

  writeFileSync('report.html', await flow.generateReport());
} catch (error) {
  flow.dispose();
  console.error(error);
}

await browser.close();
```

**Related Issues/PRs**

CLOSES: #17065 