### PR TITLE
docs(a11y): clarify identical links audit text

### DIFF
--- a/core/audits/accessibility/identical-links-same-purpose.js
+++ b/core/audits/accessibility/identical-links-same-purpose.js
@@ -13,13 +13,14 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that checks if identical links have the same purpose. This title is descriptive of the successful state and is shown to users when no user action is required. */
-  title: 'Identical links have the same purpose.',
-  /** Title of an accessibility audit that checks if identical links have the same purpose. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
-  failureTitle: 'Identical links do not have the same purpose.',
+  /** Title of an accessibility audit that checks if links with the same accessible name have a similar purpose. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  title: 'Links with the same name have a similar purpose.',
+  /** Title of an accessibility audit that checks if links with the same accessible name have a similar purpose. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  failureTitle: 'Links with the same name do not have a similar purpose.',
   /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
-  description: 'Links with the same destination should have the same description, to help users ' +
-      'understand the link\'s purpose and decide whether to follow it. ' +
+  description: 'Links that have the same accessible name should lead to destinations with ' +
+      'a similar purpose, so users can understand what each link does before deciding whether ' +
+      'to follow it. ' +
       '[Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).',
 };
 

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -2270,8 +2270,8 @@
           },
           "identical-links-same-purpose": {
             "id": "identical-links-same-purpose",
-            "title": "Identical links have the same purpose.",
-            "description": "Links with the same destination should have the same description, to help users understand the link's purpose and decide whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).",
+            "title": "Links with the same name have a similar purpose.",
+            "description": "Links that have the same accessible name should lead to destinations with a similar purpose, so users can understand what each link does before deciding whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).",
             "score": null,
             "scoreDisplayMode": "notApplicable"
           },
@@ -13402,8 +13402,8 @@
           },
           "identical-links-same-purpose": {
             "id": "identical-links-same-purpose",
-            "title": "Identical links have the same purpose.",
-            "description": "Links with the same destination should have the same description, to help users understand the link's purpose and decide whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).",
+            "title": "Links with the same name have a similar purpose.",
+            "description": "Links that have the same accessible name should lead to destinations with a similar purpose, so users can understand what each link does before deciding whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).",
             "score": null,
             "scoreDisplayMode": "notApplicable"
           },
@@ -19910,8 +19910,8 @@
           },
           "identical-links-same-purpose": {
             "id": "identical-links-same-purpose",
-            "title": "Identical links have the same purpose.",
-            "description": "Links with the same destination should have the same description, to help users understand the link's purpose and decide whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).",
+            "title": "Links with the same name have a similar purpose.",
+            "description": "Links that have the same accessible name should lead to destinations with a similar purpose, so users can understand what each link does before deciding whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).",
             "score": null,
             "scoreDisplayMode": "notApplicable"
           },

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -3138,8 +3138,8 @@
     },
     "identical-links-same-purpose": {
       "id": "identical-links-same-purpose",
-      "title": "Identical links have the same purpose.",
-      "description": "Links with the same destination should have the same description, to help users understand the link's purpose and decide whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).",
+      "title": "Links with the same name have a similar purpose.",
+      "description": "Links that have the same accessible name should lead to destinations with a similar purpose, so users can understand what each link does before deciding whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose).",
       "score": null,
       "scoreDisplayMode": "notApplicable"
     },

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -345,13 +345,13 @@
     "message": "`<html>` element has an `[xml:lang]` attribute with the same base language as the `[lang]` attribute."
   },
   "core/audits/accessibility/identical-links-same-purpose.js | description": {
-    "message": "Links with the same destination should have the same description, to help users understand the link's purpose and decide whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose)."
+    "message": "Links that have the same accessible name should lead to destinations with a similar purpose, so users can understand what each link does before deciding whether to follow it. [Learn more about identical links](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose)."
   },
   "core/audits/accessibility/identical-links-same-purpose.js | failureTitle": {
-    "message": "Identical links do not have the same purpose."
+    "message": "Links with the same name do not have a similar purpose."
   },
   "core/audits/accessibility/identical-links-same-purpose.js | title": {
-    "message": "Identical links have the same purpose."
+    "message": "Links with the same name have a similar purpose."
   },
   "core/audits/accessibility/image-alt.js | description": {
     "message": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more about the `alt` attribute](https://dequeuniversity.com/rules/axe/4.12/image-alt)."

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -345,13 +345,13 @@
     "message": "`<html>` êĺêḿêńt̂ h́âś âń `[xml:lang]` ât́t̂ŕîb́ût́ê ẃît́ĥ t́ĥé ŝám̂é b̂áŝé l̂án̂ǵûáĝé âś t̂h́ê `[lang]` át̂t́r̂íb̂út̂é."
   },
   "core/audits/accessibility/identical-links-same-purpose.js | description": {
-    "message": "L̂ín̂ḱŝ ẃît́ĥ t́ĥé ŝám̂é d̂éŝt́îńât́îón̂ śĥóûĺd̂ h́âv́ê t́ĥé ŝám̂é d̂éŝćr̂íp̂t́îón̂, t́ô h́êĺp̂ úŝér̂ś ûńd̂ér̂śt̂án̂d́ t̂h́ê ĺîńk̂'ś p̂úr̂ṕôśê án̂d́ d̂éĉíd̂é ŵh́êt́ĥér̂ t́ô f́ôĺl̂óŵ ít̂. [Ĺêár̂ń m̂ór̂é âb́ôút̂ íd̂én̂t́îćâĺ l̂ín̂ḱŝ](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose)."
+    "message": "L̂ín̂ḱŝ t́ĥát̂ h́âv́ê t́ĥé ŝám̂é âćĉéŝśîb́l̂é n̂ám̂é ŝh́ôúl̂d́ l̂éâd́ t̂ó d̂éŝt́îńât́îón̂ś ŵít̂h́ â śîḿîĺâŕ p̂úr̂ṕôśê, śô úŝér̂ś ĉán̂ ún̂d́êŕŝt́âńd̂ ẃĥát̂ éâćĥ ĺîńk̂ d́ôéŝ b́êf́ôŕê d́êćîd́îńĝ ẃĥét̂h́êŕ t̂ó f̂ól̂ĺôẃ ît́. [L̂éâŕn̂ ḿôŕê áb̂óût́ îd́êńt̂íĉál̂ ĺîńk̂ś](https://dequeuniversity.com/rules/axe/4.12/identical-links-same-purpose)."
   },
   "core/audits/accessibility/identical-links-same-purpose.js | failureTitle": {
-    "message": "Îd́êńt̂íĉál̂ ĺîńk̂ś d̂ó n̂ót̂ h́âv́ê t́ĥé ŝám̂é p̂úr̂ṕôśê."
+    "message": "L̂ín̂ḱŝ ẃît́ĥ t́ĥé ŝám̂é n̂ám̂é d̂ó n̂ót̂ h́âv́ê á ŝím̂íl̂ár̂ ṕûŕp̂óŝé."
   },
   "core/audits/accessibility/identical-links-same-purpose.js | title": {
-    "message": "Îd́êńt̂íĉál̂ ĺîńk̂ś ĥáv̂é t̂h́ê śâḿê ṕûŕp̂óŝé."
+    "message": "L̂ín̂ḱŝ ẃît́ĥ t́ĥé ŝám̂é n̂ám̂é ĥáv̂é â śîḿîĺâŕ p̂úr̂ṕôśê."
   },
   "core/audits/accessibility/image-alt.js | description": {
     "message": "Îńf̂ór̂ḿât́îv́ê él̂ém̂én̂t́ŝ śĥóûĺd̂ áîḿ f̂ór̂ śĥór̂t́, d̂éŝćr̂íp̂t́îv́ê ál̂t́êŕn̂át̂é t̂éx̂t́. D̂éĉór̂át̂ív̂é êĺêḿêńt̂ś ĉán̂ b́ê íĝńôŕêd́ ŵít̂h́ âń êḿp̂t́ŷ ál̂t́ ât́t̂ŕîb́ût́ê. [Ĺêár̂ń m̂ór̂é âb́ôút̂ t́ĥé `alt` ât́t̂ŕîb́ût́ê](https://dequeuniversity.com/rules/axe/4.12/image-alt)."


### PR DESCRIPTION
**Summary**
- Clarify the `identical-links-same-purpose` audit copy so it matches the axe rule semantics.
- Update the generated English locale files, sample LHR, and sample flow fixture.

The axe rule checks whether links with the same accessible name serve a similar purpose. The previous Lighthouse description described the inverse relationship, which made reports confusing when links had the same label but different destinations.

**Related Issues/PRs**
- Related to #16793

**Tests**
- `corepack yarn install --frozen-lockfile --ignore-scripts`
- `corepack yarn build-report --standalone --flow`
- `corepack yarn update:sample-json`
- `corepack yarn eslint core/audits/accessibility/identical-links-same-purpose.js`
- `corepack yarn i18n:checks`
- `C:\Program Files\Git\bin\bash.exe core/scripts/assert-golden-lhr-unchanged.sh`
- `git diff --check`