### PR TITLE
clients(viewer): enable Agentic Browsing category via psi api

### DIFF
--- a/viewer/app/src/psi-api.js
+++ b/viewer/app/src/psi-api.js
@@ -13,8 +13,7 @@ const PSI_DEFAULT_CATEGORIES = [
   'accessibility',
   'seo',
   'best-practices',
-  // TODO: this is not supported in PSI yet.
-  // 'agentic-browsing',
+  'agentic-browsing',
 ];
 
 /**

--- a/viewer/test/viewer-test-pptr.js
+++ b/viewer/test/viewer-test-pptr.js
@@ -415,7 +415,7 @@ describe('Lighthouse Viewer', () => {
           'accessibility',
           'seo',
           'best-practices',
-          // 'agentic-browsing',
+          'agentic-browsing',
         ],
         strategy: 'mobile',
         // These values aren't set by default.
@@ -424,8 +424,7 @@ describe('Lighthouse Viewer', () => {
       });
 
       // Confirm that all default categories are used.
-      const defaultCategories = Object.keys(defaultConfig.categories).sort()
-        .filter(c => c !== 'agentic-browsing');
+      const defaultCategories = Object.keys(defaultConfig.categories).sort();
       expect(interceptedUrl.searchParams.getAll('category').sort()).toEqual(defaultCategories);
 
       // No errors.


### PR DESCRIPTION
was disabled in #17041 but can be turned on now