### PR TITLE
docs: add documentation links for newest audits

### DIFF
--- a/core/audits/agentic/agent-accessibility-tree.js
+++ b/core/audits/agentic/agent-accessibility-tree.js
@@ -13,7 +13,7 @@ const UIStrings = {
   /** Title shown when one or more agent accessibility checks fail. */
   failureTitle: 'Accessibility tree is not well-formed',
   /** Description of a Lighthouse audit that tells the user *why* they need a well-formed accessibility tree. */
-  description: 'A well-formed [accessibility tree](http://goo.gle/lighthouse-agentic-a11y) helps AI agents to ' +
+  description: 'A well-formed [accessibility tree](https://developer.chrome.com/docs/lighthouse/agentic-browsing/accessibility-for-agents) helps AI agents to ' +
     'navigate and interact with the page.',
   /** Label of a table column that identifies the accessibility rule that failed. */
   columnRule: 'Failing Rule',

--- a/core/audits/webmcp-form-coverage.js
+++ b/core/audits/webmcp-form-coverage.js
@@ -11,7 +11,7 @@ const UIStrings = {
   /** Title of a Lighthouse audit that lists forms found in the page for WebMCP coverage. "WebMCP" stands for "Web Model Context Protocol" and should not be translated. */
   title: 'WebMCP form coverage',
   /** Description of a Lighthouse audit that lists forms found in the page and indicates whether they have WebMCP declarative tool annotations. This is displayed after a user expands the section to see more. No character length limits. "WebMCP" stands for "Web Model Context Protocol" and should not be translated. */
-  description: 'Consider adding [WebMCP](http://goo.gle/webmcp-docs) annotations to the forms listed below. This helps AI ' +
+  description: 'Consider adding [WebMCP](https://developer.chrome.com/docs/ai/webmcp) annotations to the forms listed below. This helps AI ' +
   'agents identify and interact with these forms more reliably.',
   /** [ICU Syntax] Label for the audit identifying the number of forms missing annotations. "WebMCP" stands for "Web Model Context Protocol" and should not be translated. */
   displayValue: `{itemCount, plural,

--- a/core/audits/webmcp-registered-tools.js
+++ b/core/audits/webmcp-registered-tools.js
@@ -15,7 +15,7 @@ const UIStrings = {
   /** Title of a Lighthouse audit that lists registered WebMCP tools. "WebMCP" stands for "Web Model Context Protocol" and should not be translated. */
   title: 'WebMCP tools registered',
   /** Description of a Lighthouse audit that lists registered WebMCP tools. This is displayed after a user expands the section to see more. No character length limits. "WebMCP" stands for "Web Model Context Protocol", neither should be translated. */
-  description: 'Lists the [WebMCP tools](http://goo.gle/webmcp-docs) registered at the time of analysis.',
+  description: 'Lists the [WebMCP tools](https://developer.chrome.com/docs/ai/webmcp) registered at the time of analysis.',
   /** Label for a column in a data table; entries will be the name of a WebMCP tool. */
   columnTool: 'Tool name',
   /** Label for a column in a data table; entries will be the description of a WebMCP tool. */

--- a/core/audits/webmcp-schema-validity.js
+++ b/core/audits/webmcp-schema-validity.js
@@ -13,7 +13,7 @@ const UIStrings = {
   /** Title of a Lighthouse audit that provides detail on WebMCP schema validity. This descriptive title is shown to users when there are schema validity issues. "WebMCP" stands for "Web Model Context Protocol" and should not be translated. */
   failureTitle: 'WebMCP schemas are invalid',
   /** Description of a Lighthouse audit that tells the user why they should ensure WebMCP schemas are valid. This is displayed after a user expands the section to see more. No character length limits. "WebMCP" stands for "Web Model Context Protocol" and should not be translated. */
-  description: 'Valid [WebMCP schemas](http://goo.gle/webmcp-docs) are required for AI agents to ' +
+  description: 'Valid [WebMCP schemas](https://developer.chrome.com/docs/ai/webmcp) are required for AI agents to ' +
   ' understand and interact with tools correctly. ' +
       'Please fix any errors or warnings reported by the browser.',
   /** Header of the table column which displays the element. */

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -603,7 +603,7 @@
     "message": "Failing Rule"
   },
   "core/audits/agentic/agent-accessibility-tree.js | description": {
-    "message": "A well-formed [accessibility tree](http://goo.gle/lighthouse-agentic-a11y) helps AI agents to navigate and interact with the page."
+    "message": "A well-formed [accessibility tree](https://developer.chrome.com/docs/lighthouse/agentic-browsing/accessibility-for-agents) helps AI agents to navigate and interact with the page."
   },
   "core/audits/agentic/agent-accessibility-tree.js | displayValuePassed": {
     "message": "All audits passed"
@@ -1356,7 +1356,7 @@
     "message": "Form"
   },
   "core/audits/webmcp-form-coverage.js | description": {
-    "message": "Consider adding [WebMCP](http://goo.gle/webmcp-docs) annotations to the forms listed below. This helps AI agents identify and interact with these forms more reliably."
+    "message": "Consider adding [WebMCP](https://developer.chrome.com/docs/ai/webmcp) annotations to the forms listed below. This helps AI agents identify and interact with these forms more reliably."
   },
   "core/audits/webmcp-form-coverage.js | displayValue": {
     "message": "{itemCount, plural,\n    =1 {1 form missing annotations}\n    other {# forms missing annotations}\n    }"
@@ -1380,7 +1380,7 @@
     "message": "Tool name"
   },
   "core/audits/webmcp-registered-tools.js | description": {
-    "message": "Lists the [WebMCP tools](http://goo.gle/webmcp-docs) registered at the time of analysis."
+    "message": "Lists the [WebMCP tools](https://developer.chrome.com/docs/ai/webmcp) registered at the time of analysis."
   },
   "core/audits/webmcp-registered-tools.js | title": {
     "message": "WebMCP tools registered"
@@ -1398,7 +1398,7 @@
     "message": "Issue"
   },
   "core/audits/webmcp-schema-validity.js | description": {
-    "message": "Valid [WebMCP schemas](http://goo.gle/webmcp-docs) are required for AI agents to  understand and interact with tools correctly. Please fix any errors or warnings reported by the browser."
+    "message": "Valid [WebMCP schemas](https://developer.chrome.com/docs/ai/webmcp) are required for AI agents to  understand and interact with tools correctly. Please fix any errors or warnings reported by the browser."
   },
   "core/audits/webmcp-schema-validity.js | failureTitle": {
     "message": "WebMCP schemas are invalid"

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -603,7 +603,7 @@
     "message": "F̂áîĺîńĝ Ŕûĺê"
   },
   "core/audits/agentic/agent-accessibility-tree.js | description": {
-    "message": "Â ẃêĺl̂-f́ôŕm̂éd̂ [áĉćêśŝíb̂íl̂ít̂ý t̂ŕêé](http://goo.gle/lighthouse-agentic-a11y) ĥél̂ṕŝ ÁÎ áĝén̂t́ŝ t́ô ńâv́îǵât́ê án̂d́ îńt̂ér̂áĉt́ ŵít̂h́ t̂h́ê ṕâǵê."
+    "message": "Â ẃêĺl̂-f́ôŕm̂éd̂ [áĉćêśŝíb̂íl̂ít̂ý t̂ŕêé](https://developer.chrome.com/docs/lighthouse/agentic-browsing/accessibility-for-agents) ĥél̂ṕŝ ÁÎ áĝén̂t́ŝ t́ô ńâv́îǵât́ê án̂d́ îńt̂ér̂áĉt́ ŵít̂h́ t̂h́ê ṕâǵê."
   },
   "core/audits/agentic/agent-accessibility-tree.js | displayValuePassed": {
     "message": "Âĺl̂ áûd́ît́ŝ ṕâśŝéd̂"
@@ -1356,7 +1356,7 @@
     "message": "F̂ór̂ḿ"
   },
   "core/audits/webmcp-form-coverage.js | description": {
-    "message": "Ĉón̂śîd́êŕ âd́d̂ín̂ǵ [Ŵéb̂ḾĈṔ](http://goo.gle/webmcp-docs) âńn̂ót̂át̂íôńŝ t́ô t́ĥé f̂ór̂ḿŝ ĺîśt̂éd̂ b́êĺôẃ. T̂h́îś ĥél̂ṕŝ ÁÎ áĝén̂t́ŝ íd̂én̂t́îf́ŷ án̂d́ îńt̂ér̂áĉt́ ŵít̂h́ t̂h́êśê f́ôŕm̂ś m̂ór̂é r̂él̂íâb́l̂ý."
+    "message": "Ĉón̂śîd́êŕ âd́d̂ín̂ǵ [Ŵéb̂ḾĈṔ](https://developer.chrome.com/docs/ai/webmcp) âńn̂ót̂át̂íôńŝ t́ô t́ĥé f̂ór̂ḿŝ ĺîśt̂éd̂ b́êĺôẃ. T̂h́îś ĥél̂ṕŝ ÁÎ áĝén̂t́ŝ íd̂én̂t́îf́ŷ án̂d́ îńt̂ér̂áĉt́ ŵít̂h́ t̂h́êśê f́ôŕm̂ś m̂ór̂é r̂él̂íâb́l̂ý."
   },
   "core/audits/webmcp-form-coverage.js | displayValue": {
     "message": "{itemCount, plural,\n    =1 {1 f̂ór̂ḿ m̂íŝśîńĝ án̂ńôt́ât́îón̂ś}\n    other {# f̂ór̂ḿŝ ḿîśŝín̂ǵ âńn̂ót̂át̂íôńŝ}\n    }"
@@ -1380,7 +1380,7 @@
     "message": "T̂óôĺ n̂ám̂é"
   },
   "core/audits/webmcp-registered-tools.js | description": {
-    "message": "L̂íŝt́ŝ t́ĥé [Ŵéb̂ḾĈṔ t̂óôĺŝ](http://goo.gle/webmcp-docs) ŕêǵîśt̂ér̂éd̂ át̂ t́ĥé t̂ím̂é ôf́ âńâĺŷśîś."
+    "message": "L̂íŝt́ŝ t́ĥé [Ŵéb̂ḾĈṔ t̂óôĺŝ](https://developer.chrome.com/docs/ai/webmcp) ŕêǵîśt̂ér̂éd̂ át̂ t́ĥé t̂ím̂é ôf́ âńâĺŷśîś."
   },
   "core/audits/webmcp-registered-tools.js | title": {
     "message": "Ŵéb̂ḾĈṔ t̂óôĺŝ ŕêǵîśt̂ér̂éd̂"
@@ -1398,7 +1398,7 @@
     "message": "Îśŝúê"
   },
   "core/audits/webmcp-schema-validity.js | description": {
-    "message": "V̂ál̂íd̂ [Ẃêb́M̂ĆP̂ śĉh́êḿâś](http://goo.gle/webmcp-docs) âŕê ŕêq́ûír̂éd̂ f́ôŕ ÂÍ âǵêńt̂ś t̂ó  ûńd̂ér̂śt̂án̂d́ âńd̂ ín̂t́êŕâćt̂ ẃît́ĥ t́ôól̂ś ĉór̂ŕêćt̂ĺŷ. Ṕl̂éâśê f́îx́ âńŷ ér̂ŕôŕŝ ór̂ ẃâŕn̂ín̂ǵŝ ŕêṕôŕt̂éd̂ b́ŷ t́ĥé b̂ŕôẃŝér̂."
+    "message": "V̂ál̂íd̂ [Ẃêb́M̂ĆP̂ śĉh́êḿâś](https://developer.chrome.com/docs/ai/webmcp) âŕê ŕêq́ûír̂éd̂ f́ôŕ ÂÍ âǵêńt̂ś t̂ó  ûńd̂ér̂śt̂án̂d́ âńd̂ ín̂t́êŕâćt̂ ẃît́ĥ t́ôól̂ś ĉór̂ŕêćt̂ĺŷ. Ṕl̂éâśê f́îx́ âńŷ ér̂ŕôŕŝ ór̂ ẃâŕn̂ín̂ǵŝ ŕêṕôŕt̂éd̂ b́ŷ t́ĥé b̂ŕôẃŝér̂."
   },
   "core/audits/webmcp-schema-validity.js | failureTitle": {
     "message": "Ŵéb̂ḾĈṔ ŝćĥém̂áŝ ár̂é îńv̂ál̂íd̂"


### PR DESCRIPTION
## Summary

This PR updates the documentation links for the newest Lighthouse audits by replacing short documentation URLs with direct documentation URLs where they are available.

### Changes

* Updated documentation links in:

  * `core/audits/agentic/agent-accessibility-tree.js`
  * `core/audits/webmcp-form-coverage.js`
  * `core/audits/webmcp-registered-tools.js`
  * `core/audits/webmcp-schema-validity.js`
* Updated generated localization files after collecting strings.

`baseline.js` and `llms-txt.js` were intentionally left unchanged because the corresponding documentation URLs could not be determined from the repository or issue discussion, and I did not want to introduce incorrect links.

## Testing

* ✅ Unit tests passed
* ✅ `yarn type-check`
* ✅ `yarn lint --fix`
* ✅ `yarn i18n:collect-strings`

Related: #17089
