### PR TITLE
core(baseline): calculate Baseline High date dynamically from Low date

### DIFF
--- a/core/audits/baseline.js
+++ b/core/audits/baseline.js
@@ -31,6 +31,8 @@ const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
 /** @typedef {LH.TraceEvent & {args: {feature: string, url?: string, lineNumber?: number, columnNumber?: number}}} DXFeatureEvent */
 
 class Baseline extends Audit {
+  static featureData = data;
+
   /**
    * @return {LH.Audit.Meta}
    */
@@ -42,6 +44,51 @@ class Baseline extends Audit {
       description: str_(UIStrings.description, {date: metadata.date}),
       requiredArtifacts: ['Trace'],
     };
+  }
+
+  /**
+   * Determines the baseline status and display string for a given feature ID.
+   * @param {string} featureId
+   * @param {{high: Record<string, string>, low: Record<string, string>, limited: string[]}} featureData
+   * @param {Date} currentDate
+   * @return {{displayStatus: string, baselineTier: 'high' | 'low' | 'limited'} | null}
+   */
+  static getFeatureStatus(featureId, featureData, currentDate) {
+    if (featureId in featureData.high) {
+      const highData = /** @type {Record<string, string>} */ (featureData.high);
+      return {
+        displayStatus: `Widely Available (${highData[featureId]})`,
+        baselineTier: 'high',
+      };
+    }
+
+    if (featureId in featureData.low) {
+      const lowData = /** @type {Record<string, string>} */ (featureData.low);
+      const widelyAvailableDate = new Date(lowData[featureId]);
+      widelyAvailableDate.setUTCMonth(widelyAvailableDate.getUTCMonth() + 30);
+      const widelyAvailableDateStr = widelyAvailableDate.toISOString().slice(0, 10);
+
+      if (widelyAvailableDate <= currentDate) {
+        return {
+          displayStatus: `Widely Available (${widelyAvailableDateStr})`,
+          baselineTier: 'high',
+        };
+      } else {
+        return {
+          displayStatus: `Newly Available (${lowData[featureId]})`,
+          baselineTier: 'low',
+        };
+      }
+    }
+
+    if (featureData.limited.includes(featureId)) {
+      return {
+        displayStatus: 'Limited Availability',
+        baselineTier: 'limited',
+      };
+    }
+
+    return null;
   }
 
   /**
@@ -82,6 +129,7 @@ class Baseline extends Audit {
 
     const baselineFeatures = Array.from(featuresMap.values());
     const baselineStatus = [];
+    const currentDate = new Date;
 
     for (const feature of baselineFeatures) {
       if (!feature.featureId) {
@@ -90,20 +138,9 @@ class Baseline extends Audit {
 
       const featureId = feature.featureId;
 
-      let displayStatus = 'Limited Availability';
-      let baselineTier = 'limited';
-
-      if (featureId in data.high) {
-        const highData = /** @type {Record<string, string>} */ (data.high);
-        displayStatus = `Widely Available (${highData[featureId]})`;
-        baselineTier = 'high';
-      } else if (featureId in data.low) {
-        const lowData = /** @type {Record<string, string>} */ (data.low);
-        displayStatus = `Newly Available (${lowData[featureId]})`;
-        baselineTier = 'low';
-      } else if (!data.limited.includes(featureId)) {
-        continue;
-      }
+      const status = Baseline.getFeatureStatus(featureId, Baseline.featureData, currentDate);
+      if (!status) continue;
+      const {displayStatus, baselineTier} = status;
 
       baselineStatus.push({
         featureId: {

--- a/core/test/audits/baseline-test.js
+++ b/core/test/audits/baseline-test.js
@@ -5,8 +5,34 @@
  */
 
 import Baseline from '../../audits/baseline.js';
+import {timers} from '../test-utils.js';
 
 describe('Baseline Audit', () => {
+  let originalData;
+
+  beforeEach(() => {
+    originalData = Baseline.featureData;
+    timers.useFakeTimers();
+    // Freeze time at June 30, 2026
+    timers.setSystemTime(new Date('2026-06-30T15:00:00Z').getTime());
+
+    Baseline.featureData = {
+      high: {
+        'forced-colors': '2022-09-12',
+        'aborting': '2019-03-25',
+      },
+      low: {
+        'abortsignal-any': '2024-03-19',
+      },
+      limited: ['accelerometer'],
+    };
+  });
+
+  afterEach(() => {
+    timers.dispose();
+    Baseline.featureData = originalData;
+  });
+
   it('should return an empty list when no features are used', async () => {
     const artifacts = {
       Trace: {
@@ -165,6 +191,58 @@ describe('Baseline Audit', () => {
         column: 4,
         original: undefined,
       },
+    });
+  });
+
+  describe('getFeatureStatus', () => {
+    const fakeData = {
+      high: {
+        'high-feature': '2022-09-12',
+      },
+      low: {
+        'low-feature': '2024-03-01',
+      },
+      limited: ['limited-feature'],
+    };
+
+    const dateJune = new Date('2026-06-30T15:00:00Z');
+    const dateOct = new Date('2026-10-01T15:00:00Z');
+
+    it('should return high status for high features', () => {
+      const status = Baseline.getFeatureStatus('high-feature', fakeData, dateJune);
+      expect(status).toEqual({
+        displayStatus: 'Widely Available (2022-09-12)',
+        baselineTier: 'high',
+      });
+    });
+
+    it('should return low status for low features if under 30 months', () => {
+      const status = Baseline.getFeatureStatus('low-feature', fakeData, dateJune);
+      expect(status).toEqual({
+        displayStatus: 'Newly Available (2024-03-01)',
+        baselineTier: 'low',
+      });
+    });
+
+    it('should return high status for low features if over 30 months', () => {
+      const status = Baseline.getFeatureStatus('low-feature', fakeData, dateOct);
+      expect(status).toEqual({
+        displayStatus: 'Widely Available (2026-09-01)',
+        baselineTier: 'high',
+      });
+    });
+
+    it('should return limited status for limited features', () => {
+      const status = Baseline.getFeatureStatus('limited-feature', fakeData, dateJune);
+      expect(status).toEqual({
+        displayStatus: 'Limited Availability',
+        baselineTier: 'limited',
+      });
+    });
+
+    it('should return null for unknown features', () => {
+      const status = Baseline.getFeatureStatus('unknown-feature-id', fakeData, dateJune);
+      expect(status).toBeNull();
     });
   });
 });


### PR DESCRIPTION
core: calculate Baseline High date dynamically from Low date

Adds logic to upgrade Baseline Low features to Baseline High once they have been newly available for 30 months. 

Exposes `Baseline.featureData` and adds mock-based tests to keep integration tests immune to future dataset updates.
