### PR TITLE
i18n: align Turkish Performance translation

### DIFF
--- a/shared/localization/locales/tr.json
+++ b/shared/localization/locales/tr.json
@@ -3696,7 +3696,7 @@
     "message": "Bu denetim, genel kategori puanını etkilemez."
   },
   "report/renderer/report-utils.js | varianceDisclaimer": {
-    "message": "Değerler tahminidir ve değişiklik gösterebilir. [Performance skorunun hesaplanması ](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/), doğrudan bu metriklerle yapılır."
+    "message": "Değerler tahminidir ve değişiklik gösterebilir. [Performans skorunun hesaplanması ](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/), doğrudan bu metriklerle yapılır."
   },
   "report/renderer/report-utils.js | viewTraceLabel": {
     "message": "İzi Göster"


### PR DESCRIPTION
**Summary**

Improves the Turkish localization of the performance score explanation.

Changes:

* "Performance skorunun hesaplanması" → "Performans skorunun hesaplanması"

This aligns the wording with the existing Turkish localization, where the Performance category is already translated as "Performans".

**Related Issues/PRs**

N/A
