### PR TITLE
misc(build): minify Lightrider bundle

### DIFF
--- a/build/build-lightrider-bundles.js
+++ b/build/build-lightrider-bundles.js
@@ -24,7 +24,7 @@ fs.mkdirSync(distDir, {recursive: true});
 function buildEntryPoint() {
   const inFile = `${sourceDir}/${entrySourceName}`;
   const outFile = `${distDir}/${entryDistName}`;
-  return buildBundle(inFile, outFile, {minify: false});
+  return buildBundle(inFile, outFile, {minify: true});
 }
 
 async function buildReportGenerator() {


### PR DESCRIPTION
shrunk by ~4.2 MB (~20.8%) from ~20.5 MB to ~16.2 MB.
