### PR TITLE
i18n(a11y): clarify translator context for accessibility terminology

### DIFF
--- a/core/audits/accessibility/aria-command-name.js
+++ b/core/audits/accessibility/aria-command-name.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if important HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if important HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: '`button`, `link`, and `menuitem` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if important HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if important HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: '`button`, `link`, and `menuitem` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML elements. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML elements. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'When an element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn how to make command elements more accessible](https://dequeuniversity.com/rules/axe/4.12/aria-command-name).',
 };
 

--- a/core/audits/accessibility/aria-dialog-name.js
+++ b/core/audits/accessibility/aria-dialog-name.js
@@ -13,12 +13,12 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if ARIA dialog elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if ARIA dialog elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'Elements with `role="dialog"` or `role="alertdialog"` have accessible names.',
-  /** Title of an accessibility audit that evaluates if ARIA dialog elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if ARIA dialog elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'Elements with `role="dialog"` or `role="alertdialog"` do not have accessible ' +
       'names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for ARIA dialog elements. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for ARIA dialog elements. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'ARIA dialog elements without accessible names may prevent screen readers users ' +
       'from discerning the purpose of these elements. ' +
       '[Learn how to make ARIA dialog elements more accessible](https://dequeuniversity.com/rules/axe/4.12/aria-dialog-name).',

--- a/core/audits/accessibility/aria-input-field-name.js
+++ b/core/audits/accessibility/aria-input-field-name.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that checks that all ARIA input fields have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that checks that all ARIA input fields have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'ARIA input fields have accessible names',
-  /** Title of an accessibility audit that checks that all ARIA input fields have an accessible name. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that checks that all ARIA input fields have an accessible name. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'ARIA input fields do not have accessible names',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'When an input field doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more about input field labels](https://dequeuniversity.com/rules/axe/4.12/aria-input-field-name).',
 };
 

--- a/core/audits/accessibility/aria-meter-name.js
+++ b/core/audits/accessibility/aria-meter-name.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if meter HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if meter HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'ARIA `meter` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if meter HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if meter HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'ARIA `meter` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML 'meter' elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn how...' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML 'meter' elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn how...' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'When a meter element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn how to name `meter` elements](https://dequeuniversity.com/rules/axe/4.12/aria-meter-name).',
 };
 

--- a/core/audits/accessibility/aria-progressbar-name.js
+++ b/core/audits/accessibility/aria-progressbar-name.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if progressbar HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if progressbar HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'ARIA `progressbar` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if progressbar HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if progressbar HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'ARIA `progressbar` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'When a `progressbar` element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn how to label `progressbar` elements](https://dequeuniversity.com/rules/axe/4.12/aria-progressbar-name).',
 };
 

--- a/core/audits/accessibility/aria-toggle-field-name.js
+++ b/core/audits/accessibility/aria-toggle-field-name.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that checks that all ARIA toggle fields have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that checks that all ARIA toggle fields have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'ARIA toggle fields have accessible names',
-  /** Title of an accessibility audit that checks that all ARIA toggle fields have an accessible name. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that checks that all ARIA toggle fields have an accessible name. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'ARIA toggle fields do not have accessible names',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'When a toggle field doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more about toggle fields](https://dequeuniversity.com/rules/axe/4.12/aria-toggle-field-name).',
 };
 

--- a/core/audits/accessibility/aria-tooltip-name.js
+++ b/core/audits/accessibility/aria-tooltip-name.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if tooltip HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if tooltip HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'ARIA `tooltip` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if tooltip HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if tooltip HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'ARIA `tooltip` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML 'tooltip' elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn how...' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML 'tooltip' elements. This is displayed after a user expands the section to see more. No character length limits. 'Learn how...' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'When a tooltip element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn how to name `tooltip` elements](https://dequeuniversity.com/rules/axe/4.12/aria-tooltip-name).',
 };
 

--- a/core/audits/accessibility/aria-treeitem-name.js
+++ b/core/audits/accessibility/aria-treeitem-name.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if treeitem HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if treeitem HTML elements have an accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'ARIA `treeitem` elements have accessible names',
-  /** Title of an accessibility audit that evaluates if treeitem HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if treeitem HTML elements do not have accessible names. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'ARIA `treeitem` elements do not have accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML elements. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should have accessible names for HTML elements. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'When a `treeitem` element doesn\'t have an accessible name, screen readers announce it with a generic name, making it unusable for users who rely on screen readers. [Learn more about labeling `treeitem` elements](https://dequeuniversity.com/rules/axe/4.12/aria-treeitem-name).',
 };
 

--- a/core/audits/accessibility/button-name.js
+++ b/core/audits/accessibility/button-name.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if all button elements have names accessible to screen readers. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if all button elements have names accessible to screen readers. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'Buttons have an accessible name',
-  /** Title of an accessibility audit that evaluates if all button elements have names accessible to screen readers. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if all button elements have names accessible to screen readers. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'Buttons do not have an accessible name',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'When a button doesn\'t have an accessible name, screen readers announce it ' +
       'as "button", making it unusable for users who rely on screen readers. ' +
       '[Learn how to make buttons more accessible](https://dequeuniversity.com/rules/axe/4.12/button-name).',

--- a/core/audits/accessibility/label-content-name-mismatch.js
+++ b/core/audits/accessibility/label-content-name-mismatch.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if elements labeled through their content have their visible text as part of their accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if elements labeled through their content have their visible text as part of their accessible name. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'Elements with visible text labels have matching accessible names.',
-  /** Title of an accessibility audit that evaluates if elements labeled through their content have their visible text as part of their accessible name. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if elements labeled through their content have their visible text as part of their accessible name. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'Elements with visible text labels do not have matching accessible names.',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with 'Learn' becomes link text to additional documentation. "accessible name" is the standard WAI-ARIA term for the name an element exposes to assistive technology. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'Visible text labels that do not match the accessible name can result in a ' +
       'confusing experience for screen reader users. ' +
       '[Learn more about accessible names](https://dequeuniversity.com/rules/axe/4.12/label-content-name-mismatch).',

--- a/core/audits/accessibility/svg-img-alt.js
+++ b/core/audits/accessibility/svg-img-alt.js
@@ -13,11 +13,11 @@ import AxeAudit from './axe-audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title of an accessibility audit that evaluates if SVG elements with an img role have an accessible text alternative. This title is descriptive of the successful state and is shown to users when no user action is required. */
+  /** Title of an accessibility audit that evaluates if SVG elements with an img role have an accessible text alternative. This title is descriptive of the successful state and is shown to users when no user action is required. "accessible text alternative" is text that assistive technology announces in place of the graphic. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   title: 'SVG elements with an `img` role have an accessible text alternative',
-  /** Title of an accessibility audit that evaluates if SVG elements with an img role have an accessible text alternative. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. */
+  /** Title of an accessibility audit that evaluates if SVG elements with an img role have an accessible text alternative. This title is descriptive of the failing state and is shown to users when there is a failure that needs to be addressed. "accessible text alternative" is text that assistive technology announces in place of the graphic. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   failureTitle: 'SVG elements with an `img` role do not have an accessible text alternative',
-  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with \'Learn\' becomes link text to additional documentation. */
+  /** Description of a Lighthouse audit that tells the user *why* they should try to pass. This is displayed after a user expands the section to see more. No character length limits. The last sentence starting with \'Learn\' becomes link text to additional documentation. "accessible text alternative" is text that assistive technology announces in place of the graphic. Here "accessible" does not mean "available". Use your locale's established accessibility terminology. */
   description: 'Ensures SVG elements with an `img`, `graphics-document` or `graphics-symbol` ' +
       'role have an accessible text alternative. ' +
       '[Learn more about SVG alt text](https://dequeuniversity.com/rules/axe/4.12/svg-img-alt).',

--- a/core/audits/agentic/agent-accessibility-tree.js
+++ b/core/audits/agentic/agent-accessibility-tree.js
@@ -8,11 +8,11 @@ import {Audit} from '../audit.js';
 import * as i18n from '../../lib/i18n/i18n.js';
 
 const UIStrings = {
-  /** Title shown when all agent accessibility checks pass. */
+  /** Title shown when all agent accessibility checks pass. "accessibility tree" is the standard term for the structure a browser exposes to assistive technology and to AI agents. Here "accessibility" does not mean "availability". Use your locale's established accessibility terminology. */
   title: 'Accessibility tree is well-formed',
-  /** Title shown when one or more agent accessibility checks fail. */
+  /** Title shown when one or more agent accessibility checks fail. "accessibility tree" is the standard term for the structure a browser exposes to assistive technology and to AI agents. Here "accessibility" does not mean "availability". Use your locale's established accessibility terminology. */
   failureTitle: 'Accessibility tree is not well-formed',
-  /** Description of a Lighthouse audit that tells the user *why* they need a well-formed accessibility tree. */
+  /** Description of a Lighthouse audit that tells the user *why* they need a well-formed accessibility tree. "accessibility tree" is the standard term for the structure a browser exposes to assistive technology and to AI agents. Here "accessibility" does not mean "availability". Use your locale's established accessibility terminology. */
   description: 'A well-formed ' +
   '[accessibility tree](https://developer.chrome.com/docs/lighthouse/agentic-browsing/accessibility-for-agents) ' +
   'helps AI agents to navigate and interact with the page.',

--- a/core/config/agentic-browsing-config.js
+++ b/core/config/agentic-browsing-config.js
@@ -18,9 +18,9 @@ const UIStrings = {
   webmcpGroupTitle: 'WebMCP',
   /** Description of the WebMCP group. */
   webmcpGroupDescription: 'Audits validating WebMCP integration.',
-  /** Title of the Agent Accessibility group of audits. */
+  /** Title of the Agent Accessibility group of audits. These audits check how well an AI agent can perceive and operate the site, using the same semantics that assistive technology relies on. Here "Accessibility" refers to that usability, not to the site being available. Use your locale's established accessibility terminology. */
   agentAccessibilityGroupTitle: 'Agent Accessibility',
-  /** Description of the Agent Accessibility group of audits. */
+  /** Description of the Agent Accessibility group of audits. Here "Accessibility" refers to how well an AI agent can perceive and operate the site, not to the site being available. Use your locale's established accessibility terminology. */
   agentAccessibilityGroupDescription: 'These audits highlight best practices for improving the ' +
   'accessibility of the website for AI agents.',
 };

--- a/core/config/default-config.js
+++ b/core/config/default-config.js
@@ -31,7 +31,7 @@ const UIStrings = {
   diagnosticsGroupTitle: 'Diagnostics',
   /** Description of the diagnostics section of the Performance category. Within this section are audits with non-imperative titles that provide more detail on a web page's load performance characteristics. Within this section, the user may read the details and deduce additional actions they could take to improve performance. */
   diagnosticsGroupDescription: 'More information about the performance of your application. These numbers don\'t [directly affect](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/) the Performance score.',
-  /** Title of the Accessibility category of audits. This section contains audits focused on making web content accessible to all users. Also used as a label of a score gauge; try to limit to 20 characters. */
+  /** Title of the Accessibility category of audits. This section contains audits focused on making web content accessible to all users. Also used as a label of a score gauge; try to limit to 20 characters. Here "Accessibility" refers to usability for people with disabilities and assistive technology, not to the page being available. Use your locale's established accessibility terminology. */
   a11yCategoryTitle: 'Accessibility',
   /** Description of the Accessibility category. This is displayed at the top of a list of audits focused on making web content accessible to all users. No character length limits. 'improve the accessibility of your web app' and 'manual testing' become link texts to additional documentation. */
   a11yCategoryDescription: 'These checks highlight opportunities to [improve the accessibility of your web app](https://developer.chrome.com/docs/lighthouse/accessibility/). Automatic detection can only detect a subset of issues and does not guarantee the accessibility of your web app, so [manual testing](https://web.dev/articles/how-to-review) is also encouraged.',
@@ -110,9 +110,9 @@ const UIStrings = {
   webmcpGroupTitle: 'WebMCP',
   /** Description of the WebMCP group. */
   webmcpGroupDescription: 'Audits validating WebMCP integration.',
-  /** Title of the Agent Accessibility group of audits. */
+  /** Title of the Agent Accessibility group of audits. These audits check how well an AI agent can perceive and operate the site, using the same semantics that assistive technology relies on. Here "Accessibility" refers to that usability, not to the site being available. Use your locale's established accessibility terminology. */
   agentAccessibilityGroupTitle: 'Agent Accessibility',
-  /** Description of the Agent Accessibility group of audits. */
+  /** Description of the Agent Accessibility group of audits. Here "Accessibility" refers to how well an AI agent can perceive and operate the site, not to the site being available. Use your locale's established accessibility terminology. */
   agentAccessibilityGroupDescription: 'These audits highlight best practices for improving the ' +
   'accessibility of the website for AI agents.',
 };

--- a/flow-report/src/i18n/ui-strings.js
+++ b/flow-report/src/i18n/ui-strings.js
@@ -37,7 +37,7 @@ export const UIStrings = {
   categories: 'Categories',
   /** Title of the Performance category of audits. Equivalent to 'Web performance', this term is inclusive of all web page speed and loading optimization topics. Also used as a label of a score gauge; try to limit to 20 characters. */
   categoryPerformance: 'Performance',
-  /** Title of the Accessibility category of audits. This section contains audits focused on making web content accessible to all users. Also used as a label of a score gauge; try to limit to 20 characters. */
+  /** Title of the Accessibility category of audits. This section contains audits focused on making web content accessible to all users. Also used as a label of a score gauge; try to limit to 20 characters. Here "Accessibility" refers to usability for people with disabilities and assistive technology, not to the page being available. Use your locale's established accessibility terminology. */
   categoryAccessibility: 'Accessibility',
   /** Title of the Best Practices category of audits. This is displayed at the top of a list of audits focused on topics related to following web development best practices and accepted guidelines. Also used as a label of a score gauge; try to limit to 20 characters. */
   categoryBestPractices: 'Best Practices',


### PR DESCRIPTION
## Summary

Issue #17113 reports that the Slovak locale systematically mistranslates accessibility terminology — `Dostupnosť` ("availability") where `Prístupnosť` ("accessibility") is meant, and `dostupný názov` where `prístupný názov` ("accessible name") is meant.

**This PR does not edit `sk.json`, and it is not a fix for #17113.** It addresses the upstream cause: several of the affected `UIStrings` give translators no context to tell the two senses of "accessibility" apart. Some give none at all —

```js
/** Title of the Agent Accessibility group of audits. */
agentAccessibilityGroupTitle: 'Agent Accessibility',
```

A translator seeing that has no way to know whether "Accessibility" means *usable by people with disabilities* or *reachable/up*. In Slovak those are different words.

This appends a translator note to the 42 descriptions behind the terminology anchors: the bare `Accessibility` label, and the terms of art `accessible name`, `accessibility tree`, and `accessible text alternative`.

## Why not just fix `sk.json`?

`shared/localization/locales/*.json` are marked `linguist-generated=true` (`.gitattributes:2`) and are replaced wholesale by the periodic `i18n: import` commits that carry translations out of Google's Translation Console (`core/lib/i18n/README.md`, "Translation done in the Google TC pipeline"). A hand-edit would pass CI and then be silently reverted on the next import. The `@description` comment is the only in-repo lever that reaches a translator.

## What this actually achieves — and what it doesn't

Per `core/lib/i18n/README.md`, TC's message ID is a hash of `message` and `meaning`, and `resolveMessageCollisions()` copies `description` into `meaning` **only for colliding messages**. Diffing the generated `en-US.ctc.json` before/after:

| | count | effect |
|---|---|---|
| messages changed | 0 | no user-visible text changes |
| placeholders changed | 0 | |
| descriptions changed | 42 | translators see the new context |
| `meaning` added / removed | 0 / 0 | no collision created or resolved |
| `meaning` **values** changed | 8 | new TC message ID → re-translated |

So, plainly:

- **8 strings** — `aria-meter-name`, `aria-progressbar-name`, `aria-tooltip-name`, `aria-treeitem-name` × (`title`, `failureTitle`) — share a placeholdered message, so their `meaning` *is* their description. Editing it changes their TC ID. **These will be re-sent for translation in all 46 locales.** Per the README, fixed collisions "cost real money" — flagging that explicitly so you can weigh it. It is unavoidable if these strings are to gain context.
- **The other 34** keep their message and have no `meaning`, so their TC IDs are unchanged and their existing translations are retained. They gain context for whenever a translator next looks at them.

**Consequently the strings at the heart of #17113 — the `Accessibility` category label and the `Agent Accessibility` group title — are in the second group.** Their current Slovak translations will not change as a result of this PR. Correcting those requires someone with Translation Console access to fix the Slovak term. I could not find any in-repo mechanism (glossary, term list, override map) that a community contributor could use instead; if one exists I'd be glad to use it.

This PR is a prerequisite for getting the translation right, not the correction itself.

## Scope

Glossed the ambiguous single-word labels and the coined ARIA terms. Deliberately left alone the ~11 remaining strings from the issue where "accessibility" appears in ordinary prose that already disambiguates it (`aria-roles.js`, `aria-required-children.js`, `aria-required-parent.js`, `aria-allowed-role.js`, `empty-heading.js`, `seo/link-text.js`, `webmcp-schema-validity.js`, the three a11y category descriptions in `default-config.js`, and `helpUseCaseSnapshot1`). Happy to extend if you'd rather they were consistent.

Each note closes with the same canonical sentence, reused verbatim, following the convention in `core/audits/agentic/llms-txt.js`.

Two pairs of strings must keep byte-identical descriptions or they flip from an *allowed* collision to a *disallowed* one and trip `checkKnownFixedCollisions`: `a11yCategoryTitle`/`categoryAccessibility` (message `Accessibility`), and `agentAccessibilityGroupTitle`/`Description` across both config files. Kept identical — and verified by fault injection: desyncing either pair makes `yarn i18n:collect-strings` exit 1 with the expected collision-allowlist error (before any file is written), while a lone edit to one of the four legitimately-colliding ARIA descriptions still passes. Runtime lookup of edited keys via `format.getFormatted()` was also spot-checked in `en-US` and `sk`.

## Verification

```
yarn i18n:checks          exit 0   ✅ PASS. All strings have been collected.
yarn diff:sample-json     exit 0   ✅ PASS. No change in LHR.
yarn type-check           exit 0
yarn lint  (full repo)    exit 0
yarn mocha (full suite)   2526 passing, 9 pending, 2 failing*
yarn unit-flow            50 passing
```

\* The 2 failures (`build-bundle-test.js`, `build-lightrider-bundles-test.js`) fail identically on unmodified `main` in a bare local checkout — esbuild cannot resolve the host `lighthouse` package from `node_modules/lighthouse-plugin-soft-navigation` (same four errors, byte-identical, both sides). `yarn diff:flow-sample-json` likewise fails identically on unmodified `main` (a Node-version `errorStack` frame absent from the committed baseline); its failing diff is byte-for-byte the same with and without this change.

Every changed line in the diff is a single-line JSDoc comment (machine-checked: zero non-comment changed lines). Runtime lookup of edited keys via `format.getFormatted()` verified in `en-US` and `sk`.

Refs #17113. Thanks to @rraddatch for the very thorough report.
