### PR TITLE
report: display used plugins in footer tooltip

### DIFF
--- a/report/renderer/report-renderer.js
+++ b/report/renderer/report-renderer.js
@@ -132,6 +132,15 @@ export class ReportRenderer {
       devicesTooltipTextLines.push(`${Globals.strings.runtimeSettingsAxeVersion}: ${axeVersion}`);
     }
 
+    // Plugin categories are keyed by the plugin name, which is required to
+    // start with 'lighthouse-plugin-'.
+    const pluginNames = Object.keys(report.categories || {})
+      .filter(categoryId => categoryId.startsWith('lighthouse-plugin-'));
+    if (pluginNames.length > 0) {
+      devicesTooltipTextLines.push(
+        `${Globals.strings.runtimeSettingsPlugins}: ${pluginNames.join(', ')}`);
+    }
+
     let stopwatchLabel = Globals.strings.runtimeAnalysisWindow;
     if (report.gatherMode === 'timespan') {
       stopwatchLabel = Globals.strings.runtimeAnalysisWindowTimespan;

--- a/report/renderer/report-utils.js
+++ b/report/renderer/report-utils.js
@@ -441,6 +441,8 @@ const UIStrings = {
   runtimeSettingsBenchmark: 'Unthrottled CPU/Memory Power',
   /** Label for a row in a table that shows the version of the Axe library used. Example row values: 2.1.0, 3.2.3 */
   runtimeSettingsAxeVersion: 'Axe version',
+  /** Label for a list of the Lighthouse plugins that were used during the run. Example row values: lighthouse-plugin-publisher-ads, lighthouse-plugin-soft-navigation */
+  runtimeSettingsPlugins: 'Plugins',
   /** Label for a row in a table that shows the screen resolution and DPR that was emulated for the Lighthouse run. Example values: '800x600, DPR: 3' */
   runtimeSettingsScreenEmulation: 'Screen emulation',
 

--- a/report/test/renderer/report-renderer-test.js
+++ b/report/test/renderer/report-renderer-test.js
@@ -239,6 +239,32 @@ describe('ReportRenderer', () => {
       expect(itemsTxt).toContain('Initial page load');
     });
 
+    it('renders plugins in the footer tooltip', () => {
+      const pluginResults = {
+        ...sampleResults,
+        categories: {
+          ...sampleResults.categories,
+          'lighthouse-plugin-someplugin': {
+            id: 'lighthouse-plugin-someplugin',
+            title: 'Some Plugin',
+            score: 1,
+            auditRefs: [],
+          },
+        },
+      };
+      const footer = renderer._renderReportFooter(pluginResults);
+      const tooltipsTxt = Array.from(footer.querySelectorAll('.lh-tooltip'))
+        .map(el => el.textContent).join('\n');
+      expect(tooltipsTxt).toContain('Plugins: lighthouse-plugin-someplugin');
+    });
+
+    it('does not render a plugins line in the footer tooltip without plugins', () => {
+      const footer = renderer._renderReportFooter(sampleResults);
+      const tooltipsTxt = Array.from(footer.querySelectorAll('.lh-tooltip'))
+        .map(el => el.textContent).join('\n');
+      expect(tooltipsTxt).not.toContain('Plugins:');
+    });
+
     it('renders a timespan footer', () => {
       sampleResults.gatherMode = 'timespan';
       const footer = renderer._renderReportFooter(sampleResults);

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -3662,6 +3662,9 @@
   "report/renderer/report-utils.js | runtimeSettingsNetworkThrottling": {
     "message": "Network throttling"
   },
+  "report/renderer/report-utils.js | runtimeSettingsPlugins": {
+    "message": "Plugins"
+  },
   "report/renderer/report-utils.js | runtimeSettingsScreenEmulation": {
     "message": "Screen emulation"
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -3662,6 +3662,9 @@
   "report/renderer/report-utils.js | runtimeSettingsNetworkThrottling": {
     "message": "N̂ét̂ẃôŕk̂ t́ĥŕôt́t̂ĺîńĝ"
   },
+  "report/renderer/report-utils.js | runtimeSettingsPlugins": {
+    "message": "P̂ĺûǵîńŝ"
+  },
   "report/renderer/report-utils.js | runtimeSettingsScreenEmulation": {
     "message": "Ŝćr̂éêń êḿûĺât́îón̂"
   },


### PR DESCRIPTION
## Summary

Lists the names of any Lighthouse plugins used for the run in the hover tooltip
of the runtime settings item in the report footer, as suggested in
https://github.com/GoogleChrome/lighthouse/issues/9934#issuecomment (the
bottom-left footer item tooltip).

- Plugin names are derived from category ids in the LHR — plugin categories are
  keyed by the plugin package name, which `core/config/validation.js` requires
  to start with `lighthouse-plugin-`. No core/LHR changes needed.
- New `runtimeSettingsPlugins` UI string; locales regenerated via
  `yarn i18n:collect-strings`.
- No visual change for runs without plugins.

## Tests

- `report/test/renderer/report-renderer-test.js`: new cases asserting the
  tooltip lists plugin categories and that no `Plugins:` line renders without
  them. All 18 renderer tests pass locally.

Fixes #9934

🤖 Generated with [Claude Code](https://claude.com/claude-code)