### PR TITLE
core(webmcp): use document.modelContext check in webmcp gatherers

### DIFF
--- a/cli/test/fixtures/webmcp/webmcp_tester.html
+++ b/cli/test/fixtures/webmcp/webmcp_tester.html
@@ -36,6 +36,8 @@
       testingApi.listTools();
     } else if (navigator.modelContext && typeof navigator.modelContext.getRegisteredTools === 'function') {
       navigator.modelContext.getRegisteredTools();
+    } else if (document.modelContext && typeof document.modelContext.getRegisteredTools === 'function') {
+      document.modelContext.getRegisteredTools();
     }
   </script>
 </body>

--- a/core/gather/gatherers/webmcp.js
+++ b/core/gather/gatherers/webmcp.js
@@ -135,8 +135,8 @@ class WebMCP extends BaseGatherer {
    */
   async getArtifact(context) {
     const isSupported = await context.driver.executionContext.evaluate(
-      // @ts-expect-error - modelContext is not in types
-      () => typeof navigator.modelContext !== 'undefined' && document.modelContext !== 'undefined',
+      () => typeof (/** @type {any} */ (navigator)).modelContext !== 'undefined' ||
+        typeof (/** @type {any} */ (document)).modelContext !== 'undefined',
       {args: [], useIsolation: true}
     );
     if (!isSupported || !this._isSupported) {

--- a/core/gather/gatherers/webmcp.js
+++ b/core/gather/gatherers/webmcp.js
@@ -136,7 +136,7 @@ class WebMCP extends BaseGatherer {
   async getArtifact(context) {
     const isSupported = await context.driver.executionContext.evaluate(
       // @ts-expect-error - modelContext is not in types
-      () => typeof navigator.modelContext !== 'undefined',
+      () => typeof navigator.modelContext !== 'undefined' && document.modelContext !== 'undefined',
       {args: [], useIsolation: true}
     );
     if (!isSupported || !this._isSupported) {


### PR DESCRIPTION
navigator.modelContext is deprecated as of M150 and removed in M152. 
document.modelContext is the new API.