### PR TITLE
scorecalc: clamp metric values when switching device type

### DIFF
--- a/scorecalc/calc.js
+++ b/scorecalc/calc.js
@@ -731,7 +731,31 @@ class App extends m {
   }
 
   onDeviceChange(e) {
-    this.setState({device: e.target.value});
+    const device = e.target.value;
+    this.setState(({versions, metricValues}) => ({
+      device,
+      // Clamp existing values into the new device's min/max. Without this,
+      // a value that was valid for e.g. mobile (values are shared across
+      // device types) can be out of range for desktop; the range input
+      // then silently clamps its own displayed value, but the underlying
+      // metricValues never updates, so the computed score is wrong
+      // (and reverts to the stale value if the device is switched back).
+      metricValues: this.clampMetricValuesToDevice(metricValues, versions, device),
+    }));
+  }
+
+  clampMetricValuesToDevice(metricValues, versions, device) {
+    const clamped = {...metricValues};
+    for (const version of this.normalizeVersions(versions)) {
+      const scoring = scoringGuides[`v${version}`][device];
+      for (const id of Object.keys(clamped)) {
+        const metricScoring = scoring[id];
+        if (!metricScoring) continue;
+        const {min, max} = determineMinMax(metricScoring);
+        clamped[id] = Math.max(Math.min(clamped[id], max), min);
+      }
+    }
+    return clamped;
   }
 
   onVersionsChange(e) {


### PR DESCRIPTION
## Summary

Fixes #16609. The score calculator (scorecalc/) shares one set of metric
values across device types, but each device type defines its own min/max
range per metric. Switching device type never re-clamped existing values
into the new range: the `<input type=range>` silently clamps its own
*displayed* value once `min`/`max` shrink, but the underlying `metricValues`
state is never updated — so the score computed from it (`QUANTILE_AT_VALUE`)
runs against the stale, out-of-range value. Switching back to the original
device reveals the stale value was retained the whole time (this is exactly
what #16609 reports: scores read ~0, and the slider's effective minimum
silently shifts).

## Change

`onDeviceChange` now reclamps every value in `metricValues` into the new
device's per-metric min/max, mirroring the clamp already applied in
`Metric.onScoreChange`.

## A note on where this lives

I couldn't find a build step that produces `scorecalc/calc.js` from source
anywhere in the repo — `calc.js.map` references `script/main.js` etc., which
don't exist on `main` or any branch I could find. If `gh-pages` is generated/
overwritten by a release process I'm not aware of, let me know and I'm happy
to resubmit against whatever the actual source location is.

## Testing

No test harness exists for this static tool, so I verified with a Playwright
script driving the real page locally:
- Reproduced the bug pre-fix: maxed a metric on mobile, switched to desktop
  (score → ~0 as reported), switched back to mobile — confirmed the "reset"
  value was never actually applied internally (the original stale value
  reappeared).
- Re-ran the identical script post-fix: values now stay correctly clamped
  and consistent across repeated device switches.
- Stress-tested repeated toggling plus the "show all versions" mode (multiple
  scoring guides rendered at once) — no out-of-range values, no console
  errors, across 22 checked rows.