### PR TITLE
core(baseline): store newest feature year in debugData, remove displayValue

### DIFF
--- a/core/audits/baseline.js
+++ b/core/audits/baseline.js
@@ -217,14 +217,20 @@ class Baseline extends Audit {
 
     const hasLimited = baselineStatus.some(item => item.displayStatus.status === 'limited');
 
-    let displayValue;
+    /** @type {LH.Audit.Details.DebugData | undefined} */
+    let debugData;
     if (!hasLimited && sortedStatuses.length > 0) {
       const newestFeature = sortedStatuses[0];
       const featureName = newestFeature.featureId.text;
       const lowDate = newestFeature.lowDate;
       if (lowDate) {
         const year = lowDate.substring(0, 4);
-        displayValue = `Baseline ${year} based on ${featureName} (${lowDate})`;
+        debugData = {
+          type: 'debugdata',
+          newestFeatureId: featureName,
+          newestFeatureYear: year,
+          newestFeatureLowDate: lowDate,
+        };
       }
     }
 
@@ -235,10 +241,12 @@ class Baseline extends Audit {
     });
 
     const details = Audit.makeTableDetails(webFeatureHeadings, tableItems);
+    if (debugData) {
+      details.debugData = debugData;
+    }
 
     return {
       score: 1,
-      displayValue,
       details,
     };
   }

--- a/core/test/audits/baseline-test.js
+++ b/core/test/audits/baseline-test.js
@@ -194,7 +194,7 @@ describe('Baseline Audit', () => {
     });
   });
 
-  it('should not set displayValue when a limited availability feature ' +
+  it('should not set debugData when a limited availability feature ' +
     'is present (newest is newly available)', async () => {
     const traceEvents = [
       {args: {feature: 'accelerometer'}, cat: 'blink.webdx_feature_usage'},
@@ -206,9 +206,10 @@ describe('Baseline Audit', () => {
     ];
     const result = await Baseline.audit({Trace: {traceEvents}});
     expect(result.displayValue).toBeUndefined();
+    expect(result.details.debugData).toBeUndefined();
   });
 
-  it('should not set displayValue when a limited availability feature ' +
+  it('should not set debugData when a limited availability feature ' +
     'is present (newest is widely available)', async () => {
     const traceEvents = [
       {args: {feature: 'accelerometer'}, cat: 'blink.webdx_feature_usage'},
@@ -216,34 +217,48 @@ describe('Baseline Audit', () => {
     ];
     const result = await Baseline.audit({Trace: {traceEvents}});
     expect(result.displayValue).toBeUndefined();
+    expect(result.details.debugData).toBeUndefined();
   });
 
-  it('should not set displayValue when a limited availability feature ' +
+  it('should not set debugData when a limited availability feature ' +
     'is present (only limited)', async () => {
     const traceEvents = [
       {args: {feature: 'accelerometer'}, cat: 'blink.webdx_feature_usage'},
     ];
     const result = await Baseline.audit({Trace: {traceEvents}});
     expect(result.displayValue).toBeUndefined();
+    expect(result.details.debugData).toBeUndefined();
   });
 
-  it('should set correct displayValue when no limited availability features ' +
+  it('should set correct debugData when no limited availability features ' +
     'are present (newest is newly available)', async () => {
     const traceEvents = [
       {args: {feature: 'abortsignal-any'}, cat: 'blink.webdx_feature_usage'}, // low (2024-03-19)
       {args: {feature: 'forced-colors'}, cat: 'blink.webdx_feature_usage'}, // high (2022-09-12)
     ];
     const result = await Baseline.audit({Trace: {traceEvents}});
-    expect(result.displayValue).toEqual('Baseline 2024 based on abortsignal-any (2024-03-19)');
+    expect(result.displayValue).toBeUndefined();
+    expect(result.details.debugData).toEqual({
+      type: 'debugdata',
+      newestFeatureId: 'abortsignal-any',
+      newestFeatureYear: '2024',
+      newestFeatureLowDate: '2024-03-19',
+    });
   });
 
-  it('should set correct displayValue when no limited availability features ' +
+  it('should set correct debugData when no limited availability features ' +
     'are present (newest is widely available)', async () => {
     const traceEvents = [
       {args: {feature: 'forced-colors'}, cat: 'blink.webdx_feature_usage'}, // high (2022-09-12)
     ];
     const result = await Baseline.audit({Trace: {traceEvents}});
-    expect(result.displayValue).toEqual('Baseline 2020 based on forced-colors (2020-03-12)');
+    expect(result.displayValue).toBeUndefined();
+    expect(result.details.debugData).toEqual({
+      type: 'debugdata',
+      newestFeatureId: 'forced-colors',
+      newestFeatureYear: '2020',
+      newestFeatureLowDate: '2020-03-12',
+    });
   });
 
   describe('getFeatureStatus', () => {

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -4335,7 +4335,6 @@
       "description": "Lists web features used on the page and their Baseline status as of 2026-06-19. [Learn more about Baseline](https://webstatus.dev/).",
       "score": 1,
       "scoreDisplayMode": "informative",
-      "displayValue": "Baseline 2024 based on fetch-priority (2024-10-29)",
       "details": {
         "type": "table",
         "headings": [
@@ -4454,7 +4453,13 @@
               "column": 2
             }
           }
-        ]
+        ],
+        "debugData": {
+          "type": "debugdata",
+          "newestFeatureId": "fetch-priority",
+          "newestFeatureYear": "2024",
+          "newestFeatureLowDate": "2024-10-29"
+        }
       }
     },
     "meta-description": {


### PR DESCRIPTION
Gates the calculation and display of the newest baseline feature year in the displayValue behind a new `SHOW_BASELINE_FEATURE_YEAR` flag (defaulting to `false`).
