### PR TITLE
tests(types): enable type-checking for arbitrary-equality-map-test.js

### DIFF
--- a/core/test/lib/arbitrary-equality-map-test.js
+++ b/core/test/lib/arbitrary-equality-map-test.js
@@ -37,27 +37,29 @@ describe('ArbitraryEqualityMap', () => {
     assert.equal(map.get('foo'), 4);
   });
 
-  it('is not hella slow', () => {
-    const map = new ArbitraryEqualityMap();
-    map.setEqualityFn(ArbitraryEqualityMap.deepEquals);
-    for (let i = 0; i < 100; i++) {
-      map.set({i}, i);
-    }
+ it('is not hella slow', function() {
+  this.timeout(1000);
+  const map = new ArbitraryEqualityMap();
+  map.setEqualityFn(ArbitraryEqualityMap.deepEquals);
+  for (let i = 0; i < 100; i++) {
+    map.set({i}, i);
+  }
 
-    for (let j = 0; j < 1000; j++) {
-      const i = j % 100;
-      assert.equal(map.get({i}), i);
-    }
-  }, 1000);
+  for (let j = 0; j < 1000; j++) {
+    const i = j % 100;
+    assert.equal(map.get({i}), i);
+  }
+});
 
-  it('is fast for expected usage', () => {
-    const map = new ArbitraryEqualityMap();
-    map.setEqualityFn(ArbitraryEqualityMap.deepEquals);
-    map.set([trace, {x: 0}], 'foo');
-    map.set([trace, {x: 1}], 'bar');
+ it('is fast for expected usage', function() {
+  this.timeout(1000);
+  const map = new ArbitraryEqualityMap();
+  map.setEqualityFn(ArbitraryEqualityMap.deepEquals);
+  map.set([trace, {x: 0}], 'foo');
+  map.set([trace, {x: 1}], 'bar');
 
-    for (let i = 0; i < 10000; i++) {
-      assert.equal(map.get([trace, {x: i % 2}]), i % 2 ? 'bar' : 'foo');
-    }
-  }, 1000);
+  for (let i = 0; i < 10000; i++) {
+    assert.equal(map.get([trace, {x: i % 2}]), i % 2 ? 'bar' : 'foo');
+  }
+});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,7 +63,6 @@
     "core/test/gather/gatherers/trace-elements-test.js",
     "core/test/gather/gatherers/viewport-dimensions-test.js",
     "core/test/index-test.js",
-    "core/test/lib/arbitrary-equality-map-test.js",
     "core/test/lib/asset-saver-test.js",
     "core/test/lib/emulation-test.js",
     "core/test/lib/i18n/i18n-test.js",


### PR DESCRIPTION
Removes core/test/lib/arbitrary-equality-map-test.js from tsconfig.json's type-check exclude list (one of the files noted as needing further work before they can be type-checked).

Fixed 2 resulting TS2554 errors — both were calls to Mocha's it(title, fn, timeoutMs), whose types only declare 1–2 params. Converted to the this.timeout(ms) pattern already used elsewhere in the test suite (e.g. core/test/scenarios/api-test-pptr.js).

Verified: yarn type-check passes clean, and all 4 tests in the file still pass.