### PR TITLE
core: render Render Blocking insight as a warning

### DIFF
--- a/core/audits/insights/render-blocking-insight.js
+++ b/core/audits/insights/render-blocking-insight.js
@@ -36,7 +36,8 @@ class RenderBlockingInsight extends Audit {
    */
   static async audit(artifacts, context) {
     // TODO: show UIStrings.noRenderBlocking if nothing was blocking?
-    return adaptInsightToAuditProduct(artifacts, context, 'RenderBlocking', (insight) => {
+    // eslint-disable-next-line max-len
+    const product = await adaptInsightToAuditProduct(artifacts, context, 'RenderBlocking', (insight) => {
       /** @type {LH.Audit.Details.Table['headings']} */
       const headings = [
         {key: 'url', valueType: 'url', label: str_(i18n.UIStrings.columnURL)},
@@ -51,6 +52,12 @@ class RenderBlockingInsight extends Audit {
       }));
       return Audit.makeTableDetails(headings, items);
     });
+
+    if (product.score === 0) {
+      return {...product, scoreDisplayMode: Audit.SCORING_MODES.NUMERIC, score: 0.5};
+    }
+
+    return product;
   }
 }
 

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -5938,7 +5938,7 @@
       "title": "Render-blocking requests",
       "description": "Requests are blocking the page's initial render, which may delay LCP. [Deferring or inlining](https://developer.chrome.com/docs/performance/insights/render-blocking) can move these network requests out of the critical path.",
       "score": 0.5,
-      "scoreDisplayMode": "metricSavings",
+      "scoreDisplayMode": "numeric",
       "metricSavings": {
         "FCP": 0,
         "LCP": 0


### PR DESCRIPTION
## Summary

Changes the Render Blocking insight to be displayed as a warning (amber) instead of an error (red).

## What changed

- Override the failed Render Blocking insight to use `scoreDisplayMode: numeric`
- Set the score to `0.5` for failed insights so it renders as an amber warning
- Regenerated `core/test/results/sample_v2.json`

## Testing

- Ran renderer tests
- Regenerated `sample_v2.json`
- Ran `yarn type-check`
- Ran `yarn lint`