### PR TITLE
clients(lr): split locales out of bundle

### DIFF
--- a/build/build-bundle.js
+++ b/build/build-bundle.js
@@ -129,8 +129,8 @@ async function buildBundle(entryPath, distPath, opts = {minify: true}) {
       'export const reportAssets = {}';
   }
 
-  // Don't include locales in DevTools.
-  if (isDevtools(entryPath)) {
+  // Don't include locales in DevTools or Lightrider.
+  if (isDevtools(entryPath) || isLightrider(entryPath)) {
     shimsObj[`${LH_ROOT}/shared/localization/locales.js`] = 'export const locales = {};';
   }
 

--- a/clients/lightrider/lightrider-entry.js
+++ b/clients/lightrider/lightrider-entry.js
@@ -17,6 +17,7 @@ import * as assetSaver from '../../core/lib/asset-saver.js';
 import mobileConfig from '../../core/config/lr-mobile-config.js';
 import desktopConfig from '../../core/config/lr-desktop-config.js';
 import {pageFunctions} from '../../core/lib/page-functions.js';
+import {registerLocaleData} from '../../shared/localization/format.js';
 
 /** @type {Record<'mobile'|'desktop', LH.Config>} */
 const LR_PRESETS = {
@@ -71,14 +72,27 @@ async function getPageFromConnection(connection) {
  * Run lighthouse for connection and provide similar results as in CLI.
  *
  * If configOverride is provided, lrDevice and categoryIDs are ignored.
+ *
  * @param {any} connection
  * @param {string} url
  * @param {LH.Flags} flags Lighthouse flags
- * @param {{lrDevice?: 'desktop'|'mobile', categoryIDs?: Array<string>, logAssets: boolean, configOverride?: LH.Config, ignoreStatusCode?: boolean}} lrOpts Options coming from Lightrider
+ * @param {{lrDevice?: 'desktop'|'mobile', categoryIDs?: Array<string>, logAssets: boolean, configOverride?: LH.Config, ignoreStatusCode?: boolean, locale?: string, localeData?: any}} lrOpts Options coming from Lightrider
  * @return {Promise<string>}
  */
 async function runLighthouseInLR(connection, url, flags, lrOpts) {
-  const {lrDevice, categoryIDs, logAssets, configOverride, ignoreStatusCode} = lrOpts;
+  const {lrDevice,
+    categoryIDs,
+    logAssets,
+    configOverride,
+    ignoreStatusCode,
+    locale,
+    localeData,
+  } = lrOpts;
+
+  if (locale && localeData) {
+    registerLocaleData(/** @type {LH.Locale} */(locale), localeData);
+    flags.locale = /** @type {LH.Locale} */(locale);
+  }
 
   // Certain fixes need to kick in under LR, see https://github.com/GoogleChrome/lighthouse/issues/5839
   global.isLightrider = true;


### PR DESCRIPTION
Reduces the Lightrider bundle a lot: 16.3 MB -> 2.7 MB.

This should help with our OOM issues.

Confirmed working with my in-development LR patch.