### PR TITLE
core(lantern): account for slow document response in LCP

### DIFF
--- a/core/computed/metrics/largest-contentful-paint.js
+++ b/core/computed/metrics/largest-contentful-paint.js
@@ -13,8 +13,11 @@
  */
 
 import {makeComputedArtifact} from '../computed-artifact.js';
+import {MainResource} from '../main-resource.js';
+import {NetworkAnalysis} from '../network-analysis.js';
 import {NavigationMetric} from './navigation-metric.js';
 import {LighthouseError} from '../../lib/lh-error.js';
+import * as Lantern from '../../lib/lantern/lantern.js';
 import {LanternLargestContentfulPaint} from './lantern-largest-contentful-paint.js';
 
 class LargestContentfulPaint extends NavigationMetric {
@@ -23,9 +26,42 @@ class LargestContentfulPaint extends NavigationMetric {
    * @param {LH.Artifacts.ComputedContext} context
    * @return {Promise<LH.Artifacts.LanternMetric>}
    */
-  static computeSimulatedMetric(data, context) {
+  static async computeSimulatedMetric(data, context) {
     const metricData = NavigationMetric.getMetricComputationInput(data);
-    return LanternLargestContentfulPaint.request(metricData, context);
+    const [result, mainResource, networkAnalysis] = await Promise.all([
+      LanternLargestContentfulPaint.request(metricData, context),
+      MainResource.request(data, context),
+      NetworkAnalysis.request(data.devtoolsLog, context),
+    ]);
+
+    const origin = mainResource.parsedURL.securityOrigin;
+    const simulatedResponseTime = data.settings.precomputedLanternData ?
+      data.settings.precomputedLanternData.serverResponseTimeByOrigin[origin] :
+      networkAnalysis.serverResponseTimeByOrigin.get(origin);
+    if (simulatedResponseTime === undefined) return result;
+
+    const rtt = networkAnalysis.rtt +
+      (networkAnalysis.additionalRttByOrigin.get(origin) ?? 0);
+    const responseTimeSummary =
+      Lantern.Core.NetworkAnalyzer.estimateServerResponseTimeByOrigin(
+        [mainResource], {rttByOrigin: new Map([[origin, rtt]])}).get(origin);
+    if (!responseTimeSummary) return result;
+
+    const responseTimeCorrection = Math.max(0, responseTimeSummary.median - simulatedResponseTime);
+    if (!responseTimeCorrection) return result;
+
+    return {
+      ...result,
+      timing: result.timing + responseTimeCorrection,
+      optimisticEstimate: {
+        ...result.optimisticEstimate,
+        timeInMs: result.optimisticEstimate.timeInMs + responseTimeCorrection,
+      },
+      pessimisticEstimate: {
+        ...result.pessimisticEstimate,
+        timeInMs: result.pessimisticEstimate.timeInMs + responseTimeCorrection,
+      },
+    };
   }
 
   /**

--- a/core/test/computed/metrics/largest-contentful-paint-test.js
+++ b/core/test/computed/metrics/largest-contentful-paint-test.js
@@ -5,6 +5,8 @@
  */
 
 import {LargestContentfulPaint} from '../../../computed/metrics/largest-contentful-paint.js';
+import {ArbitraryEqualityMap} from '../../../lib/arbitrary-equality-map.js';
+import {NetworkRequest} from '../../../lib/network-request.js';
 import {getURLArtifactFromDevtoolsLog, readJson} from '../../test-utils.js';
 
 const trace = readJson('../../fixtures/artifacts/paul/trace.json', import.meta);
@@ -36,6 +38,60 @@ Object {
   "timing": 1524,
 }
 `);
+  });
+
+  it('should include a slow main document response in the predicted value', async () => {
+    const settings = {throttlingMethod: 'simulate', precomputedLanternData: null};
+    const URL = getURLArtifactFromDevtoolsLog(devtoolsLog);
+    const metricData = {
+      trace,
+      devtoolsLog,
+      gatherContext,
+      settings,
+      URL,
+      SourceMaps: [],
+      HostDPR: 1,
+      simulator: null,
+    };
+    const context = {settings, computedCache: new Map()};
+
+    const lanternResult = {
+      timing: 1000,
+      optimisticEstimate: {timeInMs: 900, nodeTimings: new Map()},
+      pessimisticEstimate: {timeInMs: 1100, nodeTimings: new Map()},
+      optimisticGraph: {},
+      pessimisticGraph: {},
+    };
+    const mainResource = Object.assign(new NetworkRequest(), {
+      parsedURL: {
+        scheme: 'https',
+        host: 'example.com',
+        securityOrigin: 'https://example.com',
+      },
+      serverResponseTime: 5000,
+      timing: {},
+    });
+    const networkAnalysis = {
+      rtt: 100,
+      additionalRttByOrigin: new Map([['https://example.com', 0]]),
+      serverResponseTimeByOrigin: new Map([['https://example.com', 50]]),
+      throughput: 1000,
+    };
+
+    const setCachedArtifact = (name, key, value) => {
+      const cache = new ArbitraryEqualityMap();
+      cache.set(key, Promise.resolve(value));
+      context.computedCache.set(name, cache);
+    };
+    setCachedArtifact('LanternLargestContentfulPaint', metricData, lanternResult);
+    setCachedArtifact('MainResource', {URL, devtoolsLog}, mainResource);
+    setCachedArtifact('NetworkAnalysis', devtoolsLog, networkAnalysis);
+
+    const result = await LargestContentfulPaint.computeSimulatedMetric(metricData, context);
+
+    expect(result.timing).toBe(5950);
+    expect(result.optimisticEstimate.timeInMs).toBe(5850);
+    expect(result.pessimisticEstimate.timeInMs).toBe(6050);
   });
 
   it('should compute an observed value', async () => {

--- a/core/test/computed/metrics/lcp-breakdown-test.js
+++ b/core/test/computed/metrics/lcp-breakdown-test.js
@@ -112,11 +112,11 @@ describe('LCPBreakdown', () => {
     expect(result.ttfb).toBeCloseTo(1245.5, 0.1);
     // TODO(15841): investigate difference.
     if (process.env.INTERNAL_LANTERN_USE_TRACE !== undefined) {
-      expect(result.loadDelay).toBeCloseTo(3429.1, 0.1);
-      expect(result.loadDuration).toBeCloseTo(3812.8, 0.1);
+      expect(result.loadDelay).toBeCloseTo(4306.6, 0.1);
+      expect(result.loadDuration).toBeCloseTo(4788.5, 0.1);
     } else {
-      expect(result.loadDelay).toBeCloseTo(3558.6, 0.1);
-      expect(result.loadDuration).toBeCloseTo(3956.8, 0.1);
+      expect(result.loadDelay).toBeCloseTo(4436.1, 0.1);
+      expect(result.loadDuration).toBeCloseTo(4932.4, 0.1);
     }
   });
 


### PR DESCRIPTION
**Summary**

Lantern estimates server response time using the median across an origin. When the main document is much slower than static resources on the same origin, that median can make simulated LCP occur before the observed TTFB.

Use the main document's estimated response time when it exceeds the response time used by the simulation. Apply the difference to the simulated LCP and its optimistic and pessimistic estimates.

Add regression coverage for a slow main document and update the expected LCP breakdown timings.


**Related Issues/PRs**

Fixes #16213
