### PR TITLE
tests(devtools): fix device mode readiness check for latest devtools-frontend

### DIFF
--- a/core/scripts/pptr-run-devtools.js
+++ b/core/scripts/pptr-run-devtools.js
@@ -159,8 +159,6 @@ async function waitForLighthouseReady() {
   const {LighthousePanel} = await import('./panels/lighthouse/lighthouse.js');
   // @ts-expect-error import
   const {TargetManager} = await import('./core/sdk/sdk.js');
-  // @ts-expect-error import
-  const {AdvancedApp} = await import('./panels/emulation/emulation.js');
 
   // Undocking later in the function can cause hiccups when Lighthouse enables device emulation.
   DockController.DockController.instance().setDockSide('undocked');
@@ -187,9 +185,25 @@ async function waitForLighthouseReady() {
   }
 
   // Ensure the emulation model is ready before Lighthouse starts by enabling device emulation.
-  const {deviceModeView} = AdvancedApp.AdvancedApp.instance();
-  if (!deviceModeView.isDeviceModeOn()) {
-    deviceModeView.toggleDeviceMode();
+  let deviceModeModel;
+  try {
+    // @ts-expect-error import
+    const {DeviceModeModel} = await import('./models/emulation/emulation.js');
+    deviceModeModel = DeviceModeModel.DeviceModeModel.instance();
+  } catch {}
+
+  if (deviceModeModel && typeof deviceModeModel.isDeviceModeOn === 'function') {
+    if (!deviceModeModel.isDeviceModeOn()) {
+      deviceModeModel.toggleDeviceMode();
+    }
+  } else {
+    // @ts-expect-error import
+    const {AdvancedApp} = await import('./panels/emulation/emulation.js');
+    const app = AdvancedApp.AdvancedApp.instance();
+    const model = app.deviceModeModel || app.deviceModeView;
+    if (model && typeof model.isDeviceModeOn === 'function' && !model.isDeviceModeOn()) {
+      model.toggleDeviceMode();
+    }
   }
 }
 


### PR DESCRIPTION
fixes ci

### Rationale

In recent `devtools-frontend` refactors, device mode emulation state and toggling methods (`isDeviceModeOn()`, `toggleDeviceMode()`) reside on `DeviceModeModel.DeviceModeModel.instance()` rather than being exposed on `deviceModeView` via `AdvancedApp`.

When running DevTools smoke tests against Chromium ToT snapshots, `waitForLighthouseReady` threw `TypeError: deviceModeView.isDeviceModeOn is not a function`.

### Changes

- **`core/scripts/pptr-run-devtools.js`**: Attempt to import `DeviceModeModel` from `./models/emulation/emulation.js` first to check and toggle device emulation mode, falling back to `AdvancedApp.AdvancedApp.instance()` for older DevTools versions.