### PR TITLE
tests(smoke): add ARD smoke tests

### DIFF
--- a/build/build-bundle-mcp.js
+++ b/build/build-bundle-mcp.js
@@ -72,7 +72,7 @@ function getMcpRequiredGathererNames() {
     'MainDocumentContent', 'MetaElements', 'Stacks', 'Trace',
   ];
   const a11yArtifacts = ['Accessibility'];
-  const agenticArtifacts = ['WebMCP', 'LlmsTxt', 'WebMcpSchemaIssues'];
+  const agenticArtifacts = ['WebMCP', 'LlmsTxt', 'WebMcpSchemaIssues', 'AgentResourceDiscovery'];
   for (const id of
     [...seoArtifacts, ...bestPracticesArtifacts, ...a11yArtifacts, ...agenticArtifacts]) {
     const g = artifactToGatherer.get(id);

--- a/cli/test/fixtures/agentic/ai-catalog-invalid.json
+++ b/cli/test/fixtures/agentic/ai-catalog-invalid.json
@@ -1,0 +1,11 @@
+{
+  "specVersion": "1.0",
+  "entries": [
+    {
+      "identifier": "invalid-urn-format",
+      "displayName": "Invalid Service",
+      "type": "application/json",
+      "url": "http://example.com/insecure-api"
+    }
+  ]
+}

--- a/cli/test/fixtures/agentic/ai-catalog.json
+++ b/cli/test/fixtures/agentic/ai-catalog.json
@@ -1,0 +1,15 @@
+{
+  "specVersion": "1.0",
+  "entries": [
+    {
+      "identifier": "urn:air:google:search:web-search",
+      "displayName": "Web Search API",
+      "type": "application/ai-catalog+json",
+      "url": "https://example.com/api/search",
+      "representativeQueries": [
+        "search the web",
+        "find latest news"
+      ]
+    }
+  ]
+}

--- a/cli/test/fixtures/agentic/ard_tester.html
+++ b/cli/test/fixtures/agentic/ard_tester.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>ARD Tester</title>
+  <link rel="ai-catalog" href="/agentic/ai-catalog.json">
+</head>
+<body>
+  <h1>ARD Tester</h1>
+  <p>This page is used to test ARD E2E.</p>
+</body>
+</html>

--- a/cli/test/fixtures/agentic/ard_tester_invalid.html
+++ b/cli/test/fixtures/agentic/ard_tester_invalid.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>ARD Invalid Tester</title>
+  <link rel="ai-catalog" href="/agentic/ai-catalog-invalid.json">
+</head>
+<body>
+  <h1>ARD Invalid Tester</h1>
+  <p>This page is used to test ARD invalid schema E2E.</p>
+</body>
+</html>

--- a/cli/test/smokehouse/core-tests.js
+++ b/cli/test/smokehouse/core-tests.js
@@ -5,6 +5,8 @@
  */
 
 import a11y from './test-definitions/a11y.js';
+import ard from './test-definitions/ard.js';
+import ardInvalid from './test-definitions/ard-invalid.js';
 import baseline from './test-definitions/baseline.js';
 import byteEfficiency from './test-definitions/byte-efficiency.js';
 import byteGzip from './test-definitions/byte-gzip.js';
@@ -72,6 +74,8 @@ import webmcp from './test-definitions/webmcp.js';
 /** @type {ReadonlyArray<Smokehouse.TestDfn>} */
 const smokeTests = [
   a11y,
+  ard,
+  ardInvalid,
   baseline,
   byteEfficiency,
   byteGzip,

--- a/cli/test/smokehouse/test-definitions/ard-invalid.js
+++ b/cli/test/smokehouse/test-definitions/ard-invalid.js
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @type {LH.Config} */
+const config = {
+  extends: 'lighthouse:default',
+  settings: {
+    onlyAudits: [
+      'ard-schema',
+    ],
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const expectations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/agentic/ard_tester_invalid.html',
+    finalDisplayedUrl: 'http://localhost:10200/agentic/ard_tester_invalid.html',
+    audits: {
+      'ard-schema': {
+        score: 0,
+        scoreDisplayMode: 'binary',
+        details: {
+          type: 'table',
+          items: [
+            {
+              element: 'Root',
+              issue: /JSON Schema Validation Failed/,
+              severity: 'Error',
+            },
+            {
+              element: 'Invalid Service',
+              issue: /Identifier 'invalid-urn-format' does not match RFC 8141 URN pattern/,
+              severity: 'Error',
+            },
+            {
+              element: 'Invalid Service',
+              issue: /Media type 'application\/json' is not one of standard discovery types/,
+              severity: 'Low',
+            },
+            {
+              element: 'Invalid Service',
+              issue: /Missing ['`]representativeQueries['`]/,
+              severity: 'Low',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+/** @type {Smokehouse.TestDfn} */
+export default {
+  id: 'ardInvalid',
+  config,
+  expectations,
+};

--- a/cli/test/smokehouse/test-definitions/ard.js
+++ b/cli/test/smokehouse/test-definitions/ard.js
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @type {LH.Config} */
+const config = {
+  extends: 'lighthouse:default',
+  settings: {
+    onlyAudits: [
+      'ard-schema',
+    ],
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const expectations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10200/agentic/ard_tester.html',
+    finalDisplayedUrl: 'http://localhost:10200/agentic/ard_tester.html',
+    audits: {
+      'ard-schema': {
+        score: 1,
+        scoreDisplayMode: 'binary',
+      },
+    },
+  },
+};
+
+/** @type {Smokehouse.TestDfn} */
+export default {
+  id: 'ard',
+  config,
+  expectations,
+};


### PR DESCRIPTION
This is part 4 of the ARD implementation, adding smoke tests. Stacked on top of #17158