### PR TITLE
core(fetcher): add response header capture support

### DIFF
--- a/core/gather/fetcher.js
+++ b/core/gather/fetcher.js
@@ -10,7 +10,7 @@ import * as LH from '../../types/lh.js';
  * ignoring normal browser constraints such as CORS.
  */
 
-/** @typedef {{content: string|null, status: number|null}} FetchResponse */
+/** @typedef {{content: string|null, status: number|null, headers?: Record<string, string>|null}} FetchResponse */
 
 class Fetcher {
   /**
@@ -38,6 +38,26 @@ class Fetcher {
   }
 
   /**
+   * @param {Headers|Record<string, string|number|boolean>|null|undefined} rawHeaders
+   * @return {Record<string, string>|null}
+   */
+  _normalizeHeaders(rawHeaders) {
+    if (!rawHeaders) return null;
+
+    /** @type {Record<string, string>} */
+    const headers = {};
+    const entries = typeof /** @type {Headers} */ (rawHeaders).entries === 'function' ?
+    /** @type {Headers} */ (rawHeaders).entries() :
+      Object.entries(rawHeaders);
+
+    for (const [key, value] of entries) {
+      headers[key.toLowerCase()] = String(value);
+    }
+
+    return headers;
+  }
+
+  /**
    * @param {string} url
    * @return {Promise<FetchResponse>}
    */
@@ -49,9 +69,12 @@ class Fetcher {
       content = await response.text();
     } catch {}
 
+    const headers = this._normalizeHeaders(response.headers);
+
     return {
       content,
       status: response.status,
+      headers,
     };
   }
 
@@ -82,7 +105,7 @@ class Fetcher {
 
   /**
    * @param {string} url
-   * @return {Promise<{stream: LH.Crdp.IO.StreamHandle|null, status: number|null}>}
+   * @return {Promise<{stream: LH.Crdp.IO.StreamHandle|null, status: number|null, headers?: Record<string, string>|null}>}
    */
   async _loadNetworkResource(url) {
     const frameTreeResponse = await this.session.sendCommand('Page.getFrameTree');
@@ -98,6 +121,7 @@ class Fetcher {
     return {
       stream: networkResponse.resource.success ? (networkResponse.resource.stream || null) : null,
       status: networkResponse.resource.httpStatusCode || null,
+      headers: networkResponse.resource.headers || null,
     };
   }
 
@@ -110,12 +134,14 @@ class Fetcher {
     const startTime = Date.now();
     const response = await this._wrapWithTimeout(this._loadNetworkResource(url), options.timeout);
 
+    const headers = this._normalizeHeaders(response.headers);
+
     const isOk = response.status && response.status >= 200 && response.status <= 299;
-    if (!response.stream || !isOk) return {status: response.status, content: null};
+    if (!response.stream || !isOk) return {status: response.status, content: null, headers};
 
     const timeout = options.timeout - (Date.now() - startTime);
     const content = await this._readIOStream(response.stream, {timeout});
-    return {status: response.status, content};
+    return {status: response.status, content, headers};
   }
 
   /**

--- a/core/test/gather/fetcher-test.js
+++ b/core/test/gather/fetcher-test.js
@@ -84,7 +84,27 @@ describe('._fetchResourceOverProtocol', () => {
       });
 
     const data = await fetcher._fetchResourceOverProtocol('https://example.com', {timeout: 500});
-    expect(data).toEqual({content: streamContents, status: 200});
+    expect(data).toEqual({content: streamContents, status: 200, headers: null});
+  });
+
+  it('fetches a file with headers', async () => {
+    mockSession.sendCommand
+      .mockResponse('Page.getFrameTree', {frameTree: {frame: {id: 'FRAME'}}})
+      .mockResponse('Network.loadNetworkResource', {
+        resource: {
+          success: true,
+          httpStatusCode: 200,
+          stream: '1',
+          headers: {'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*'},
+        },
+      });
+
+    const data = await fetcher._fetchResourceOverProtocol('https://example.com', {timeout: 500});
+    expect(data).toEqual({
+      content: streamContents,
+      status: 200,
+      headers: {'content-type': 'application/json', 'access-control-allow-origin': '*'},
+    });
   });
 
   it('returns null when resource could not be fetched', async () => {
@@ -95,7 +115,7 @@ describe('._fetchResourceOverProtocol', () => {
       });
 
     const data = await fetcher._fetchResourceOverProtocol('https://example.com', {timeout: 500});
-    expect(data).toEqual({content: null, status: 404});
+    expect(data).toEqual({content: null, status: 404, headers: null});
   });
 
   it('throws on timeout', async () => {
@@ -125,3 +145,34 @@ describe('._fetchResourceOverProtocol', () => {
     expect(timeout).toBeCloseTo(500, -2);
   });
 });
+
+describe('._normalizeHeaders', () => {
+  it('returns null when passed null or undefined', () => {
+    expect(fetcher._normalizeHeaders(null)).toBeNull();
+    expect(fetcher._normalizeHeaders(undefined)).toBeNull();
+  });
+
+  it('normalizes plain object headers with lowercase keys and string values', () => {
+    const raw = {
+      'Content-Type': 'application/json',
+      'Content-Length': 1234,
+      'X-Custom-Header': 'CustomValue',
+    };
+    expect(fetcher._normalizeHeaders(raw)).toEqual({
+      'content-type': 'application/json',
+      'content-length': '1234',
+      'x-custom-header': 'CustomValue',
+    });
+  });
+
+  it('normalizes Headers instance with lowercase keys', () => {
+    const headers = new Headers();
+    headers.append('Content-Type', 'text/html');
+    headers.append('X-Rate-Limit', '100');
+    expect(fetcher._normalizeHeaders(headers)).toEqual({
+      'content-type': 'text/html',
+      'x-rate-limit': '100',
+    });
+  });
+});
+


### PR DESCRIPTION
Adds support for capturing and returning raw HTTP response headers in the core `fetcher`, which is required for ARD implementation.