### PR TITLE
core(gather): fix broken cycle detection in recurse functions

### DIFF
--- a/core/computed/trace-engine-result.js
+++ b/core/computed/trace-engine-result.js
@@ -133,7 +133,7 @@ class TraceEngineResult {
      * @param {Set<object>} seen
      */
     function recursiveReplaceLocalizableStrings(obj, cb, seen) {
-      if (seen.has(seen)) {
+      if (seen.has(obj)) {
         return;
       }
 

--- a/core/gather/gatherers/trace-elements.js
+++ b/core/gather/gatherers/trace-elements.js
@@ -98,7 +98,7 @@ class TraceElements extends BaseGatherer {
      * @param {Set<object>} seen
      */
     function recursiveObjectEnumerate(obj, cb, seen) {
-      if (seen.has(seen)) {
+      if (seen.has(obj)) {
         return;
       }
 

--- a/core/test/computed/trace-engine-result-test.js
+++ b/core/test/computed/trace-engine-result-test.js
@@ -24,6 +24,25 @@ describe('TraceEngineResult', () => {
     settings = JSON.parse(JSON.stringify(defaultSettings));
   });
 
+  describe('localizeObject', () => {
+    it('handles circular references without infinite recursion', () => {
+      const circular = {};
+      circular.self = circular;
+      expect(() => {
+        TraceEngineResult.localizeObject(() => ({formattedDefault: 'x'}), circular);
+      }).not.toThrow();
+    });
+
+    it('localizes nested i18nId objects', () => {
+      const object = {foo: {i18nId: 'a.b', values: {count: 3}}};
+      TraceEngineResult.localizeObject(
+        (id, values) => ({formattedDefault: `${id}:${values?.count ?? 0}`}),
+        object
+      );
+      assert.equal(object.foo.formattedDefault, 'a.b:3');
+    });
+  });
+
   describe('compute_', () => {
     it('works on a basic trace', async () => {
       const result = await TraceEngineResult.request(

--- a/core/test/gather/gatherers/trace-elements-test.js
+++ b/core/test/gather/gatherers/trace-elements-test.js
@@ -73,6 +73,16 @@ function makeLCPTraceEvent(nodeId) {
 }
 
 describe('Trace Elements gatherer - Animated Elements', () => {
+  it('handles circular insight model references without infinite recursion', async () => {
+    const model = {};
+    model.self = model;
+    const result = await TraceElementsGatherer.getTraceEngineElements(
+      {insights: new Map([['nav', {model}]]), data: {}},
+      undefined
+    );
+    expect(result).toEqual([]);
+  });
+
   it('gets animated node ids with non-composited animations', async () => {
     const traceEvents = [
       makeAnimationTraceEvent('0x363db876c1', 'b', {id: '1', nodeId: 5}),


### PR DESCRIPTION
## Summary
- Fix cycle detection in `recursiveReplaceLocalizableStrings` (`core/computed/trace-engine-result.js:136`) and `recursiveObjectEnumerate` (`core/gather/gatherers/trace-elements.js:101`)
- Both guarded against circular references with `seen.has(seen)`, which is always `false` (a Set can't contain itself), so the `seen` set was dead code
- With `seen.has(obj)`, revisits short-circuit and circular insight data no longer causes `Maximum call stack size exceeded`
## Why it matters
Both functions walk trace-engine insight models on every run. Trace-engine data is graph-like (parent/child back-references), so a single circular reference currently crashes the entire audit run with a raw stack overflow instead of a catchable error.
## Tests
- `core/test/computed/trace-engine-result-test.js`: circular object passed to `localizeObject` no longer overflows; nested `i18nId` objects still localize
- `core/test/gather/gatherers/trace-elements-test.js`: circular insight `model` in `getTraceEngineElements` returns cleanly
- Verified both tests **fail (stack overflow) on `main`** and pass with the fix
- `yarn type-check` and `yarn lint` clean; `update:sample-json` produces no relevant diffs
Note: repo style appends (#NNNN) to commit/PR titles once you open the PR. Want me to commit on the branch?