### PR TITLE
core: fix insight audits picking the wrong navigation's data

### DIFF
--- a/core/audits/insights/insight-audit.js
+++ b/core/audits/insights/insight-audit.js
@@ -29,7 +29,7 @@ async function getInsightSet(artifacts, context) {
   const navigationId = processedTrace.timeOriginEvt.args.data?.navigationId;
   const insights = navigationId ?
     [...traceEngineResult.insights.values()]
-      .find(insightSet => insightSet.navigation?.args.data?.navigationId) :
+      .find(insightSet => insightSet.navigation?.args.data?.navigationId === navigationId) :
     traceEngineResult.insights.get(NO_NAVIGATION);
 
   return {insights, data: traceEngineResult.data};
@@ -225,5 +225,6 @@ function makeNodeItemForNodeId(traceElements, nodeId) {
 
 export {
   adaptInsightToAuditProduct,
+  getInsightSet,
   makeNodeItemForNodeId,
 };

--- a/core/test/audits/insights/insight-audit-test.js
+++ b/core/test/audits/insights/insight-audit-test.js
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {NO_NAVIGATION} from '@paulirish/trace_engine/models/trace/types/TraceEvents.js';
+
+import {getInsightSet} from '../../../audits/insights/insight-audit.js';
+import {defaultSettings} from '../../../config/constants.js';
+import {ArbitraryEqualityMap} from '../../../lib/arbitrary-equality-map.js';
+
+const settings = JSON.parse(JSON.stringify(defaultSettings));
+
+/**
+ * Seeds the computed artifact caches so getInsightSet doesn't run the real
+ * trace processing, just the insight-set selection.
+ * @param {{processedTrace: unknown, traceEngineResult: unknown}} stubs
+ */
+function makeContext(stubs) {
+  const computedCache = new Map();
+
+  const processedCache = new ArbitraryEqualityMap();
+  processedCache.set(stubs.trace, stubs.processedTrace);
+  computedCache.set('ProcessedTrace', processedCache);
+
+  const traceEngineCache = new ArbitraryEqualityMap();
+  traceEngineCache.set(
+    {
+      trace: stubs.trace,
+      settings: stubs.settings,
+      SourceMaps: stubs.SourceMaps,
+      HostDPR: stubs.HostDPR,
+    },
+    stubs.traceEngineResult
+  );
+  computedCache.set('TraceEngineResult', traceEngineCache);
+
+  return {context: {computedCache, settings}, cacheKeys: stubs};
+}
+
+function makeArtifacts(stubs) {
+  return {
+    Trace: stubs.trace,
+    SourceMaps: stubs.SourceMaps,
+    HostDPR: stubs.HostDPR,
+  };
+}
+
+describe('getInsightSet', () => {
+  const stubs = {
+    trace: {},
+    settings,
+    SourceMaps: [],
+    HostDPR: 1,
+    processedTrace: {
+      timeOriginEvt: {args: {data: {navigationId: '2'}}},
+    },
+    traceEngineResult: {
+      data: {},
+      insights: new Map([
+        ['NAVIGATION_1', {navigation: {args: {data: {navigationId: '1'}}}}],
+        ['NAVIGATION_2', {navigation: {args: {data: {navigationId: '2'}}}}],
+        [NO_NAVIGATION, {navigation: null}],
+      ]),
+    },
+  };
+
+  it('selects the insight set matching the trace navigationId', async () => {
+    const {context} = makeContext(stubs);
+    const {insights} = await getInsightSet(makeArtifacts(stubs), context);
+    expect(insights).toBe(stubs.traceEngineResult.insights.get('NAVIGATION_2'));
+  });
+
+  it('falls back to the NO_NAVIGATION insight set when there is no navigation', async () => {
+    const stubsWithoutNavigation = {
+      ...stubs,
+      processedTrace: {timeOriginEvt: {args: {data: {}}}},
+    };
+    const {context} = makeContext(stubsWithoutNavigation);
+    const {insights} = await getInsightSet(makeArtifacts(stubsWithoutNavigation), context);
+    expect(insights).toBe(stubsWithoutNavigation.traceEngineResult.insights.get(NO_NAVIGATION));
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `getInsightSet` in `core/audits/insights/insight-audit.js:32` to select the insight set whose `navigationId` **matches** the audited trace's `navigationId`
- Previously it used a truthiness check, so it picked the first insight set belonging to *any* navigation
- Export `getInsightSet` for unit testing
## Why it matters
A trace can contain multiple main-frame navigationStarts (client-side redirects — exactly what the `redirects` audit flags). Lighthouse's `timeOriginEvt` is the **last** navigation, but the old code selected the **first** one's insight set. Result: all ~17 insight audits (`lcp-discovery`, `lcp-breakdown`, `inp-breakdown`, `cls-culprits`, `font-display`, `render-blocking`, `document-latency`, `viewport`, etc.) showed the wrong navigation's advice on redirected pages — often empty/wrong LCP, INP, or CLS rows.
## Verification
- Reproduced the mismatch empirically: a 2-navigation trace with `timeOriginEvt → nav '2'` picked `NAVIGATION_1` before the fix, `NAVIGATION_2` after
- Matches the existing correct pattern in `core/computed/navigation-insights.js:30`
- Added regression tests (new `core/test/audits/insights/insight-audit-test.js`) that **fail on `main`** and pass with the fix
- `yarn mocha core/test/audits/insights/` (21 tests) green; `type-check` and `eslint` clean; `update:sample-json` produces no relevant diffs