### PR TITLE
core: link Baseline audit description to Chrome docs

### DIFF
--- a/core/audits/baseline.js
+++ b/core/audits/baseline.js
@@ -18,7 +18,7 @@ const UIStrings = {
    */
   description:
     'Lists web features used on the page and their Baseline status as of {date}. ' +
-    '[Learn more about Baseline](https://webstatus.dev/).',
+    '[Learn more about the Baseline Features audit](https://developer.chrome.com/docs/lighthouse/best-practices/baseline-features).',
   /** Label for the column displaying the feature ID. */
   columnFeature: 'Web-features',
   /** Label for the column displaying the feature\'s baseline status. */

--- a/core/test/fixtures/user-flows/reports/sample-flow-result.json
+++ b/core/test/fixtures/user-flows/reports/sample-flow-result.json
@@ -2989,7 +2989,7 @@
           "baseline": {
             "id": "baseline",
             "title": "Baseline Features",
-            "description": "Lists web features used on the page and their Baseline status as of 2026-07-15. [Learn more about Baseline](https://webstatus.dev/).",
+            "description": "Lists web features used on the page and their Baseline status as of 2026-07-15. [Learn more about the Baseline Features audit](https://developer.chrome.com/docs/lighthouse/best-practices/baseline-features).",
             "score": 1,
             "scoreDisplayMode": "informative",
             "details": {
@@ -9487,7 +9487,7 @@
           "baseline": {
             "id": "baseline",
             "title": "Baseline Features",
-            "description": "Lists web features used on the page and their Baseline status as of 2026-07-15. [Learn more about Baseline](https://webstatus.dev/).",
+            "description": "Lists web features used on the page and their Baseline status as of 2026-07-15. [Learn more about the Baseline Features audit](https://developer.chrome.com/docs/lighthouse/best-practices/baseline-features).",
             "score": 1,
             "scoreDisplayMode": "informative",
             "details": {
@@ -20617,7 +20617,7 @@
           "baseline": {
             "id": "baseline",
             "title": "Baseline Features",
-            "description": "Lists web features used on the page and their Baseline status as of 2026-07-15. [Learn more about Baseline](https://webstatus.dev/).",
+            "description": "Lists web features used on the page and their Baseline status as of 2026-07-15. [Learn more about the Baseline Features audit](https://developer.chrome.com/docs/lighthouse/best-practices/baseline-features).",
             "score": 1,
             "scoreDisplayMode": "informative",
             "details": {

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -4332,7 +4332,7 @@
     "baseline": {
       "id": "baseline",
       "title": "Baseline Features",
-      "description": "Lists web features used on the page and their Baseline status as of 2026-07-15. [Learn more about Baseline](https://webstatus.dev/).",
+      "description": "Lists web features used on the page and their Baseline status as of 2026-07-15. [Learn more about the Baseline Features audit](https://developer.chrome.com/docs/lighthouse/best-practices/baseline-features).",
       "score": 1,
       "scoreDisplayMode": "informative",
       "details": {

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -678,7 +678,7 @@
     "message": "Baseline Status"
   },
   "core/audits/baseline.js | description": {
-    "message": "Lists web features used on the page and their Baseline status as of {date}. [Learn more about Baseline](https://webstatus.dev/)."
+    "message": "Lists web features used on the page and their Baseline status as of {date}. [Learn more about the Baseline Features audit](https://developer.chrome.com/docs/lighthouse/best-practices/baseline-features)."
   },
   "core/audits/baseline.js | title": {
     "message": "Baseline Features"

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -678,7 +678,7 @@
     "message": "B̂áŝél̂ín̂é Ŝt́ât́ûś"
   },
   "core/audits/baseline.js | description": {
-    "message": "L̂íŝt́ŝ ẃêb́ f̂éât́ûŕêś ûśêd́ ôń t̂h́ê ṕâǵê án̂d́ t̂h́êír̂ B́âśêĺîńê śt̂át̂úŝ áŝ óf̂ {date}. [Ĺêár̂ń m̂ór̂é âb́ôút̂ B́âśêĺîńê](https://webstatus.dev/)."
+    "message": "L̂íŝt́ŝ ẃêb́ f̂éât́ûŕêś ûśêd́ ôń t̂h́ê ṕâǵê án̂d́ t̂h́êír̂ B́âśêĺîńê śt̂át̂úŝ áŝ óf̂ {date}. [Ĺêár̂ń m̂ór̂é âb́ôút̂ t́ĥé B̂áŝél̂ín̂é F̂éât́ûŕêś âúd̂ít̂](https://developer.chrome.com/docs/lighthouse/best-practices/baseline-features)."
   },
   "core/audits/baseline.js | title": {
     "message": "B̂áŝél̂ín̂é F̂éât́ûŕêś"


### PR DESCRIPTION
## Summary
- Update the Baseline Features audit description to link to the Chrome docs page (`developer.chrome.com/docs/lighthouse/best-practices/baseline-features`) instead of `webstatus.dev`.
- Sync `en-US` / `en-XL` strings and sample report fixtures.

This finishes the remaining item from #17089 after #17108 (llms-txt / agentic / webmcp links). The docs URL was confirmed in the issue discussion.

Addresses #17089

## Test plan
- [ ] Confirm the Baseline audit description shows the new learn-more link in a local report
- [ ] Spot-check that `en-US.json` / `en-XL.json` and sample JSON fixtures match the audit string
