### PR TITLE
core(ard): add support for partial scores audit results

### DIFF
--- a/report/renderer/report-utils.js
+++ b/report/renderer/report-utils.js
@@ -330,8 +330,11 @@ class ReportUtils {
 
       ++numPassableAudits;
       totalWeight += auditRef.weight;
-      if (auditPassed) numPassed++;
+      if (typeof auditRef.result.score === 'number' && auditRef.result.score > 0) {
+        numPassed += auditRef.result.score;
+      }
     }
+    numPassed = Math.round(numPassed * 100) / 100;
     return {numPassed, numPassableAudits, numInformative, totalWeight};
   }
 

--- a/report/test/renderer/report-utils-test.js
+++ b/report/test/renderer/report-utils-test.js
@@ -235,5 +235,23 @@ describe('util helpers', () => {
         totalWeight: 2,
       });
     });
+
+    it('supports partial scores in fraction calculation', () => {
+      const category = {
+        id: 'agentic-browsing',
+        auditRefs: [
+          {weight: 1, result: {score: 1, scoreDisplayMode: 'binary'}, group: 'a11y'},
+          {weight: 1, result: {score: 0.5, scoreDisplayMode: 'binary'}, group: 'ard'},
+          {weight: 1, result: {score: 0, scoreDisplayMode: 'binary'}, group: 'a11y'},
+        ],
+      };
+      const fraction = ReportUtils.calculateCategoryFraction(category);
+      expect(fraction).toEqual({
+        numPassableAudits: 3,
+        numPassed: 1.5,
+        numInformative: 0,
+        totalWeight: 3,
+      });
+    });
   });
 });


### PR DESCRIPTION

<img width="766" height="692" alt="Screenshot 2026-08-21 at 12 43 42 PM" src="https://github.com/user-attachments/assets/564e42af-3602-44c4-a97f-965f9fcdac15" />

Updates `ReportUtils.calculateCategoryFraction` to accumulate fractional audit scores rather than strictly binary integer counts. This allows categories using `categoryScoreDisplayMode: 'fraction'` (like Agentic Browsing) to accurately reflect partial credit (0.5 scores for warnings).
