### PR TITLE
misc(types): update JSDoc for TypeScript 7

### DIFF
--- a/cli/test/cli/bin-test.js
+++ b/cli/test/cli/bin-test.js
@@ -17,7 +17,7 @@ const mockAskPermission = fnAny();
 const mockSentryInit = fnAny();
 const mockLoggerSetLevel = fnAny();
 
-/** @type {import('../../bin.js')} */
+/** @type {typeof import('../../bin.js')} */
 let bin;
 before(async () => {
   await td.replaceEsm('../../run.js', {

--- a/cli/test/smokehouse/lighthouse-runners/bundle.js
+++ b/cli/test/smokehouse/lighthouse-runners/bundle.js
@@ -71,11 +71,11 @@ async function runBundledLighthouse(url, config, testRunnerOptions) {
   global.Buffer = originalBuffer;
   global.process = originalProcess;
 
-  /** @type {import('../../../../core/index.js')['default']} */
+  /** @type {typeof import('../../../../core/index.js')['default']} */
   // @ts-expect-error - not worth giving test global an actual type.
   const lighthouse = global.runBundledLighthouse;
 
-  /** @type {import('../../../../core/lib/third-party-web.js')['default']} */
+  /** @type {typeof import('../../../../core/lib/third-party-web.js')['default']} */
   // @ts-expect-error
   const thirdPartyWeb = global.thirdPartyWeb;
   thirdPartyWeb.provideThirdPartyWeb(thirdPartyWebLib);

--- a/core/audits/webmcp-schema-validity.js
+++ b/core/audits/webmcp-schema-validity.js
@@ -70,7 +70,7 @@ class WebMcpSchemaValidity extends Audit {
       WARNING: 2,
     };
 
-    /** @type {Record<string, {severity: Severity, description: LH.IcuMessage}>} */
+    /** @type {Record<string, {severity: number, description: LH.IcuMessage}>} */
     const issueConfigs = {
       'FormModelContextMissingToolName': {
         severity: Severity.ERROR,

--- a/core/audits/webmcp-schema-validity.js
+++ b/core/audits/webmcp-schema-validity.js
@@ -70,7 +70,7 @@ class WebMcpSchemaValidity extends Audit {
       WARNING: 2,
     };
 
-    /** @type {Record<string, {severity: number, description: LH.IcuMessage}>} */
+    /** @type {Record<string, {severity: typeof Severity[keyof typeof Severity], description: LH.IcuMessage}>} */
     const issueConfigs = {
       'FormModelContextMissingToolName': {
         severity: Severity.ERROR,

--- a/core/computed/metrics/interactive.js
+++ b/core/computed/metrics/interactive.js
@@ -88,7 +88,7 @@ class Interactive extends NavigationMetric {
   static findOverlappingQuietPeriods(longTasks, networkRecords, processedNavigation) {
     const FcpTsInMs = processedNavigation.timestamps.firstContentfulPaint / 1000;
 
-    /** @type {function(TimePeriod):boolean} */
+    /** @type {(period: TimePeriod) => boolean} */
     const isLongEnoughQuietPeriod = period =>
         period.end > FcpTsInMs + REQUIRED_QUIET_WINDOW &&
         period.end - period.start >= REQUIRED_QUIET_WINDOW;

--- a/core/computed/metrics/lantern-metric.js
+++ b/core/computed/metrics/lantern-metric.js
@@ -61,7 +61,7 @@ function lanternErrorAdapter(err) {
     throw err;
   }
 
-  const code = /** @type {keyof LighthouseError.errors} */ (err.message);
+  const code = /** @type {keyof typeof LighthouseError.errors} */ (err.message);
   if (LighthouseError.errors[code]) {
     throw new LighthouseError(LighthouseError.errors[code]);
   }

--- a/core/computed/trace-engine-result.js
+++ b/core/computed/trace-engine-result.js
@@ -76,7 +76,7 @@ class TraceEngineResult {
    *
    * @template {any[]} Args
    * @template {import('../lib/trace-engine.js').DevToolsIcuMessage} Ret
-   * @param {ReturnType<i18n.createIcuMessageFn>} str_
+   * @param {ReturnType<typeof i18n.createIcuMessageFn>} str_
    * @param {(...args: Args) => Ret} fn
    * @return {(...args: Args) => LH.IcuMessage}
    */
@@ -88,7 +88,7 @@ class TraceEngineResult {
    * Converts the input parameters given to `i18nString` usages in DevTools to a
    * LH.IcuMessage.
    *
-   * @param {ReturnType<i18n.createIcuMessageFn>} str_
+   * @param {ReturnType<typeof i18n.createIcuMessageFn>} str_
    * @param {import('../lib/trace-engine.js').DevToolsIcuMessage} traceEngineI18nObject
    * @return {LH.IcuMessage}
    */
@@ -121,7 +121,7 @@ class TraceEngineResult {
   /**
    * Recursively finds all DevToolsIcuMessage objects and replaces them with LH.IcuMessage.
    *
-   * @param {ReturnType<i18n.createIcuMessageFn>} str_
+   * @param {ReturnType<typeof i18n.createIcuMessageFn>} str_
    * @param {object} object
    */
   static localizeObject(str_, object) {

--- a/core/computed/unused-javascript-summary.js
+++ b/core/computed/unused-javascript-summary.js
@@ -24,7 +24,6 @@ import {makeComputedArtifact} from './computed-artifact.js';
  * @property {string} scriptId
  * @property {number} wastedBytes
  * @property {number} totalBytes
- * @property {number} wastedBytes
  * @property {number=} wastedPercent
  * @property {Record<string, number>=} sourcesWastedBytes Keyed by file name. Includes (unmapped) key too.
  */

--- a/core/gather/driver/wait-for-condition.js
+++ b/core/gather/driver/wait-for-condition.js
@@ -11,7 +11,7 @@ import log from 'lighthouse-logger';
 import {LighthouseError} from '../../lib/lh-error.js';
 import {ExecutionContext} from './execution-context.js';
 
-/** @typedef {InstanceType<import('./network-monitor.js')['NetworkMonitor']>} NetworkMonitor */
+/** @typedef {InstanceType<typeof import('./network-monitor.js')['NetworkMonitor']>} NetworkMonitor */
 /** @typedef {import('./network-monitor.js').NetworkMonitorEvent} NetworkMonitorEvent */
 
 /**
@@ -36,7 +36,7 @@ import {ExecutionContext} from './execution-context.js';
  * Returns a promise that resolves immediately.
  * Used for placeholder conditions that we don't want to start waiting for just yet, but still want
  * to satisfy the same interface.
- * @return {{promise: Promise<void>, cancel: function(): void}}
+ * @return {CancellableWait<void>}
  */
 function waitForNothing() {
   return {promise: Promise.resolve(), cancel() {}};

--- a/core/gather/gatherers/accessibility.js
+++ b/core/gather/gatherers/accessibility.js
@@ -15,7 +15,7 @@ import {pageFunctions} from '../../lib/page-functions.js';
  */
 /* c8 ignore start */
 async function runA11yChecks() {
-  /** @type {import('axe-core/axe')} */
+  /** @type {typeof import('axe-core/axe')} */
   // @ts-expect-error - axe defined by axeLibSource
   const axe = window.axe;
   const application = `lighthouse-${Math.random()}`;

--- a/core/gather/gatherers/image-elements.js
+++ b/core/gather/gatherers/image-elements.js
@@ -189,7 +189,7 @@ function findSizeDeclaration(rule, property) {
  * Finds the most specific directly matched CSS font-size rule from the list.
  *
  * @param {Array<LH.Crdp.CSS.RuleMatch>} matchedCSSRules
- * @param {function(LH.Crdp.CSS.CSSStyle):boolean|string|undefined} isDeclarationOfInterest
+ * @param {(style: LH.Crdp.CSS.CSSStyle) => boolean|string|undefined} isDeclarationOfInterest
  */
 function findMostSpecificMatchedCSSRule(matchedCSSRules = [], isDeclarationOfInterest) {
   let mostSpecificRule;

--- a/core/gather/gatherers/stacks.js
+++ b/core/gather/gatherers/stacks.js
@@ -32,7 +32,7 @@ const libDetectorSource = fs.readFileSync(
  * @property {string} icon
  * @property {string} url
  * @property {string|null} npm npm module name, if applicable to library.
- * @property {function(Window): JSLibraryDetectorTestResult | Promise<JSLibraryDetectorTestResult>} test Returns false if library is not present, otherwise returns an object that contains the library version (set to null if the version is not detected).
+ * @property {(w: Window) => JSLibraryDetectorTestResult | Promise<JSLibraryDetectorTestResult>} test Returns false if library is not present, otherwise returns an object that contains the library version (set to null if the version is not detected).
  */
 
 /**

--- a/core/index.cjs
+++ b/core/index.cjs
@@ -6,13 +6,13 @@
 
 /**
  * @typedef ExportType
- * @property {import('./index.js')['startFlow']} startFlow
- * @property {import('./index.js')['navigation']} navigation
- * @property {import('./index.js')['startTimespan']} startTimespan
- * @property {import('./index.js')['snapshot']} snapshot
+ * @property {typeof import('./index.js')['startFlow']} startFlow
+ * @property {typeof import('./index.js')['navigation']} navigation
+ * @property {typeof import('./index.js')['startTimespan']} startTimespan
+ * @property {typeof import('./index.js')['snapshot']} snapshot
  */
 
-/** @type {import('./index.js')['default'] & ExportType} */
+/** @type {typeof import('./index.js')['default'] & ExportType} */
 const lighthouse = async function lighthouse(...args) {
   const {default: lighthouse} = await import('./index.js');
   return lighthouse(...args);

--- a/core/lib/arbitrary-equality-map.js
+++ b/core/lib/arbitrary-equality-map.js
@@ -19,7 +19,7 @@ class ArbitraryEqualityMap {
   }
 
   /**
-   * @param {function(*,*):boolean} equalsFn
+   * @param {(a: any, b: any) => boolean} equalsFn
    */
   setEqualityFn(equalsFn) {
     this._equalsFn = equalsFn;

--- a/core/lib/deprecation-description.js
+++ b/core/lib/deprecation-description.js
@@ -33,7 +33,7 @@ const deprecationsStr_ = i18n.createIcuMessageFn(
  */
 function getIssueDetailDescription(issueDetails) {
   let message;
-  const type = /** @type {keyof DEPRECATIONS_METADATA} */ (issueDetails.type);
+  const type = /** @type {keyof typeof DEPRECATIONS_METADATA} */ (issueDetails.type);
   const maybeEnglishMessage = DeprecationUIStrings[type];
   if (maybeEnglishMessage) {
     message = deprecationsStr_(maybeEnglishMessage);

--- a/core/test/gather/driver/network-monitor-test.js
+++ b/core/test/gather/driver/network-monitor-test.js
@@ -13,7 +13,7 @@ import {TargetManager} from '../../../gather/driver/target-manager.js';
 const tscErr = new Error('Typecheck constraint failed');
 
 describe('NetworkMonitor', () => {
-  /** @type {ReturnType<createMockCdpSession>} */
+  /** @type {ReturnType<typeof createMockCdpSession>} */
   let rootCdpSessionMock;
   /**
    * Dispatch events on the root CDPSession.

--- a/core/test/gather/mock-commands.js
+++ b/core/test/gather/mock-commands.js
@@ -21,6 +21,16 @@ import {fnAny} from '../test-utils.js';
  */
 
 /**
+ * @template {keyof LH.CrdpCommands} [C=keyof LH.CrdpCommands]
+ * @typedef {{command: C|any, sessionId?: string, response?: MockResponse<C>, delay?: number}} MockSendCommandEntry
+ */
+
+/**
+ * @template {keyof LH.CrdpEvents} [E=keyof LH.CrdpEvents]
+ * @typedef {{event: E|any, response?: MockEvent<E>}} MockEventEntry
+ */
+
+/**
  * Creates a jest mock function whose implementation consumes mocked protocol responses matching the
  * requested command in the order they were mocked.
  *
@@ -36,8 +46,7 @@ function createMockSendCommandFn() {
    * Typescript fails to equate template type `C` here with `C` when pushing to this array.
    * Instead of sprinkling a couple ts-ignores, make `command` be any, but leave `C` for just
    * documentation purposes. This is an internal type, so it doesn't matter much.
-   * @template {keyof LH.CrdpCommands} C
-   * @type {Array<{command: C|any, sessionId?: string, response?: MockResponse<C>, delay?: number}>}
+   * @type {Array<MockSendCommandEntry>}
    */
   const mockResponses = [];
   const mockFnImpl = fnAny().mockImplementation(
@@ -112,8 +121,7 @@ function createMockSendCommandFn() {
  */
 function createMockOnceFn() {
   /**
-   * @template {keyof LH.CrdpEvents} E
-   * @type {Array<{event: E|any, response?: MockEvent<E>}>}
+   * @type {Array<MockEventEntry>}
    */
   const mockEvents = [];
   const mockFnImpl = fnAny().mockImplementation((eventName, listener) => {
@@ -161,8 +169,7 @@ function createMockOnceFn() {
  */
 function createMockOnFn() {
   /**
-   * @template {keyof LH.CrdpEvents} E
-   * @type {Array<{event: E|any, response?: MockEvent<E>}>}
+   * @type {Array<MockEventEntry>}
    */
   const mockEvents = [];
   const mockFnImpl = fnAny().mockImplementation((eventName, listener) => {

--- a/core/test/gather/mock-driver.js
+++ b/core/test/gather/mock-driver.js
@@ -21,7 +21,7 @@ import {fnAny} from '../test-utils.js';
 import {NetworkMonitor} from '../../gather/driver/network-monitor.js';
 
 /** @typedef {import('../../gather/driver.js').Driver} Driver */
-/** @typedef {import('../../gather/driver/execution-context.js')} ExecutionContext */
+/** @typedef {typeof import('../../gather/driver/execution-context.js')} ExecutionContext */
 
 function createMockSession() {
   const mockSendCommand = createMockSendCommandFn();

--- a/core/test/test-env/expect-setup.js
+++ b/core/test/test-env/expect-setup.js
@@ -83,7 +83,7 @@ expect.extend({
     * Asserts that an inspectable promise created by makePromiseInspectable is currently resolved or rejected.
     * This is useful for situations where we want to test that we are actually waiting for a particular event.
     *
-    * @param {ReturnType<import('../test-utils.js')['makePromiseInspectable']>} received
+    * @param {ReturnType<typeof import('../test-utils.js')['makePromiseInspectable']>} received
     * @param {string} failureMessage
     */
   toBeDone(received, failureMessage) {

--- a/core/test/test-env/mocha-setup.js
+++ b/core/test/test-env/mocha-setup.js
@@ -47,7 +47,7 @@ global.performance = undefined;
 await import('marky');
 global.performance = performance;
 
-/** @type {Map<string, SnapshotState['prototype']>} */
+/** @type {Map<string, InstanceType<typeof SnapshotState>>} */
 const snapshotStatesByTestFile = new Map();
 let snapshotTestFailed = false;
 

--- a/report/renderer/drop-down-menu.js
+++ b/report/renderer/drop-down-menu.js
@@ -32,7 +32,7 @@ export class DropDownMenu {
   }
 
   /**
-   * @param {function(MouseEvent): any} menuClickHandler
+   * @param {(e: MouseEvent) => any} menuClickHandler
    */
   setup(menuClickHandler) {
     this._toggleEl = this._dom.find('.lh-topbar button.lh-tools__button', this._dom.rootEl);

--- a/report/renderer/snippet-renderer.js
+++ b/report/renderer/snippet-renderer.js
@@ -33,9 +33,9 @@ const LineContentType = {
 /** @typedef {{
     content: string;
     lineNumber: string | number;
-    contentType: number;
+    contentType: typeof LineContentType[keyof typeof LineContentType];
     truncated?: boolean;
-    visibility?: number;
+    visibility?: typeof LineVisibility[keyof typeof LineVisibility];
 }} LineDetails */
 
 const classNamesByContentType = {
@@ -194,7 +194,7 @@ export class SnippetRenderer {
   /**
    * @param {DOM} dom
    * @param {DocumentFragment} tmpl
-   * @param {number} visibility
+   * @param {typeof LineVisibility[keyof typeof LineVisibility]} visibility
    * @return {Element}
    */
   static renderOmittedLinesPlaceholder(dom, tmpl, visibility) {

--- a/report/renderer/snippet-renderer.js
+++ b/report/renderer/snippet-renderer.js
@@ -33,9 +33,9 @@ const LineContentType = {
 /** @typedef {{
     content: string;
     lineNumber: string | number;
-    contentType: LineContentType;
+    contentType: number;
     truncated?: boolean;
-    visibility?: LineVisibility;
+    visibility?: number;
 }} LineDetails */
 
 const classNamesByContentType = {
@@ -194,7 +194,7 @@ export class SnippetRenderer {
   /**
    * @param {DOM} dom
    * @param {DocumentFragment} tmpl
-   * @param {LineVisibility} visibility
+   * @param {number} visibility
    * @return {Element}
    */
   static renderOmittedLinesPlaceholder(dom, tmpl, visibility) {

--- a/report/renderer/text-encoding.js
+++ b/report/renderer/text-encoding.js
@@ -34,7 +34,7 @@ async function toBase64(string, options) {
       const compAb = await new Response(cs.readable).arrayBuffer();
       bytes = new Uint8Array(compAb);
     } else {
-      /** @type {import('pako')=} */
+      /** @type {typeof import('pako')=} */
       const pako = window.pako;
       bytes = /** @type {any} */ (pako.gzip(string));
     }
@@ -60,7 +60,7 @@ function fromBase64(encoded, options) {
   const bytes = Uint8Array.from(binaryString, c => c.charCodeAt(0));
 
   if (options.gzip) {
-    /** @type {import('pako')=} */
+    /** @type {typeof import('pako')=} */
     const pako = window.pako;
     return pako.ungzip(bytes, {to: 'string'});
   } else {

--- a/report/test-assets/faux-psi.js
+++ b/report/test-assets/faux-psi.js
@@ -6,7 +6,7 @@
 
 /** @fileoverview This file exercises two LH reports within the same DOM. */
 
-/** @typedef {import('../clients/bundle.js')} lighthouseRenderer */
+/** @typedef {typeof import('../clients/bundle.js')} lighthouseRenderer */
 /** @type {lighthouseRenderer} */
 // @ts-expect-error
 const lighthouseRenderer = window['report'];

--- a/viewer/app/src/drag-and-drop.js
+++ b/viewer/app/src/drag-and-drop.js
@@ -11,7 +11,7 @@
  */
 export class DragAndDrop {
   /**
-   * @param {function(string): void} fileHandlerCallback Invoked when the user chooses a new file.
+   * @param {(file: string) => void} fileHandlerCallback Invoked when the user chooses a new file.
    */
   constructor(fileHandlerCallback) {
     const dropZone = document.querySelector('.drop_zone');

--- a/viewer/app/src/viewer-ui-features.js
+++ b/viewer/app/src/viewer-ui-features.js
@@ -17,7 +17,7 @@ import {SwapLocaleFeature} from '../../../report/renderer/swap-locale-feature.js
 export class ViewerUIFeatures extends ReportUIFeatures {
   /**
    * @param {DOM} dom
-   * @param {{saveGist?: (json: LH.Result) => Promise<string|undefined>, refresh: function(LH.Result): void, getStandaloneReportHTML: function(): string}} callbacks
+   * @param {{saveGist?: (json: LH.Result) => Promise<string|undefined>, refresh: (json: LH.Result) => void, getStandaloneReportHTML: () => string}} callbacks
    */
   constructor(dom, callbacks) {
     super(dom, {


### PR DESCRIPTION
bunch of jsdoc changes in preparation for tsc 7

---

Fixes strict JSDoc parsing and reference errors across the codebase to support TypeScript 7.0:

- Converts legacy closure-style function types to standard arrow signatures.
- Adds the `typeof` operator to inline `import()` modules and value-type references.
- Introduces formal generic `@typedef` rules in test mocks to preserve generic coupling.
- Removes duplicate `@property` declarations from JSDoc blocks.
