### PR TITLE
tests(smoke): remove order constraint in dbw render-blocking

### DIFF
--- a/cli/test/smokehouse/test-definitions/dobetterweb.js
+++ b/cli/test/smokehouse/test-definitions/dobetterweb.js
@@ -264,26 +264,17 @@ const expectations = {
           FCP: '>=50',
         },
         details: {
-          items: [
-            {
-              url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000',
-            },
-            {
-              url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped',
-            },
-            {
-              url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200',
-            },
-            {
-              url: 'http://localhost:10200/dobetterweb/dbw_tester.js',
-            },
-            {
-              url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200',
-            },
-            {
-              url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=100',
-            },
-          ],
+          items: {
+            _includes: [
+              {url: 'http://localhost:10200/dobetterweb/fcp-delayer.js?delay=5000'},
+              {url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=3000&capped'},
+              {url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=2200'},
+              {url: 'http://localhost:10200/dobetterweb/dbw_tester.js'},
+              {url: 'http://localhost:10200/dobetterweb/unknown404.css?delay=200'},
+              {url: 'http://localhost:10200/dobetterweb/dbw_tester.css?delay=100'},
+            ],
+            _excludes: [{}],
+          },
         },
       },
       'deprecations': {


### PR DESCRIPTION
This smoke test began failing recently in Chrome Canary. tldr is that `dur` on some network requests are different now, and the trace engine happens to order network requests on this insight by duration.

(the following is from AI)

```
The recent Chrome change that altered the network timing of the trace was committed yesterday (Wednesday, August 19, 2026):

* Commit: 5b830b03046dd
* Author: Helmut Januschka
* Subject: Skip disabled stylesheets in the HTML preload scanner
* Review Link: chromium-review.googlesource.com/c/chromium/src/+/8081940 (https://chromium-review.googlesource.com/c/chromium/src/+/8081940)

---

How This Commit Modified the Trace Timing

1. The Pre-Commit Behavior (The "Expected" Smoketest Order)
In dbw_tester.html (line 36), we define a disabled stylesheet:

1 <link rel="stylesheet" href="./dbw_disabled.css?delay=200&isdisabled" disabled>
Previously, Blink's HTML preload scanner speculatively preloaded this disabled stylesheet. 

Under HTTP/1.1 (the local static server), Chrome is limited to 6 concurrent connections. Because the preload scanner speculatively fetched
dbw_disabled.css, it occupied one of those precious connection slots, causing subsequent requests in the queue (including dbw_tester.js) to be
stalled / queued until older requests finished. This artificial queueing delay inflated the raw network request duration (dur) for dbw_tester.js in
the performance trace, which placed it at index 3 of the RenderBlocking insight's sorted list.

2. The Post-Commit Behavior (The "Found" Smoketest Order)
Helmust's commit completely discards the speculative preload for disabled stylesheets:

1 // From third_party/blink/renderer/core/html/parser/html_preload_scanner.cc (line 727)
2 bool ShouldPreloadLink(std::optional<ResourceType>& type) const {
3   if (link_is_style_sheet_) {
4     // Disabled stylesheets are not loaded by the tree builder either.
5     if (disabled_attr_set_) {
6       return false;
7     }
Because Chrome now completely skips loading dbw_disabled.css?delay=200&isdisabled, connection pool exhaustion is avoided. dbw_tester.js is sent in
the very first wave of requests without being queued. 

Its actual network transfer duration (dur) in the trace correctly drops to its real-world value of <10ms (since it has no delay parameter).
Consequently, when the Trace Engine sorts the render-blocking resources descendingly by dur, dbw_tester.js naturally drops to the end of the list
(index 5), below unknown404.css?delay=200 (duration ~200ms) and dbw_tester.css?delay=100 (duration ~100ms).
```