### PR TITLE
core: add guidance about preferring secure canonical link

### DIFF
--- a/core/audits/seo/canonical.js
+++ b/core/audits/seo/canonical.js
@@ -39,6 +39,11 @@ const UIStrings = {
   /** Explanatory message stating that the page's canonical URL was pointing to the domain's root URL, which is a common mistake. "points" refers to the action of the 'rel=canonical' referencing another link. "root" refers to the starting/home page of the website. "domain" refers to the registered domain name of the website. */
   explanationRoot: 'Points to the domain\'s root URL (the homepage), ' +
     'instead of an equivalent page of content',
+  /**
+   * @description Explanatory message stating that the canonical URL uses HTTP when the current URL uses HTTPS. "protocol" refers to the scheme part of a URL (http or https).
+   * @example {http://example.com} url
+   */
+  explanationInsecure: 'Canonical URL uses HTTP ({url}) instead of HTTPS',
 };
 
 const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
@@ -189,6 +194,14 @@ class Canonical extends Audit {
       return {
         score: 0,
         explanation: str_(UIStrings.explanationRoot),
+      };
+    }
+
+    // canonical URL should prefer HTTPS over HTTP
+    if (baseURL.protocol === 'https:' && canonicalURL.protocol === 'http:') {
+      return {
+        score: 0,
+        explanation: str_(UIStrings.explanationInsecure, {url: canonicalURL.href}),
       };
     }
   }

--- a/core/test/audits/seo/canonical-test.js
+++ b/core/test/audits/seo/canonical-test.js
@@ -258,4 +258,60 @@ describe('SEO: Document has valid canonical link', () => {
       assert.equal(auditResult.score, 1);
     });
   });
+
+  it('fails when canonical URL uses HTTP while current URL uses HTTPS', () => {
+    const mainDocumentUrl = 'https://example.com/articles/cats-and-you';
+    const mainResource = {url: mainDocumentUrl};
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = {
+      DevtoolsLog: devtoolsLog,
+      URL: {mainDocumentUrl},
+      LinkElements: [
+        link({rel: 'canonical', source: 'head', href: 'http://example.com/articles/cats-and-you'}),
+      ],
+    };
+
+    const context = {computedCache: new Map()};
+    return CanonicalAudit.audit(artifacts, context).then(auditResult => {
+      assert.equal(auditResult.score, 0);
+      expect(auditResult.explanation)
+        .toBeDisplayString('Canonical URL uses HTTP (http://example.com/articles/cats-and-you) instead of HTTPS');
+    });
+  });
+
+  it('succeeds when both canonical and current URL use HTTPS', () => {
+    const mainDocumentUrl = 'https://example.com/articles/cats-and-you';
+    const mainResource = {url: mainDocumentUrl};
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = {
+      DevtoolsLog: devtoolsLog,
+      URL: {mainDocumentUrl},
+      LinkElements: [
+        link({rel: 'canonical', source: 'head', href: 'https://example.com/articles/cats-and-you'}),
+      ],
+    };
+
+    const context = {computedCache: new Map()};
+    return CanonicalAudit.audit(artifacts, context).then(auditResult => {
+      assert.equal(auditResult.score, 1);
+    });
+  });
+
+  it('succeeds when both canonical and current URL use HTTP', () => {
+    const mainDocumentUrl = 'http://example.com/articles/cats-and-you';
+    const mainResource = {url: mainDocumentUrl};
+    const devtoolsLog = networkRecordsToDevtoolsLog([mainResource]);
+    const artifacts = {
+      DevtoolsLog: devtoolsLog,
+      URL: {mainDocumentUrl},
+      LinkElements: [
+        link({rel: 'canonical', source: 'head', href: 'http://example.com/articles/cats-and-you'}),
+      ],
+    };
+
+    const context = {computedCache: new Map()};
+    return CanonicalAudit.audit(artifacts, context).then(auditResult => {
+      assert.equal(auditResult.score, 1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Adds a check to flag when canonical URLs use HTTP while the current URL uses HTTPS. This aligns with Google Search's preference for HTTPS canonical links as mentioned in the Consolidate duplicate URLs documentation.

## Changes
- Added `explanationInsecure` UIString to flag insecure canonical URLs
- Added protocol check in `findCommonCanonicalURLMistakes()` to detect HTTP canonical URLs on HTTPS pages
- Added 3 new test cases to verify the new behavior

## Testing
- Added tests for insecure canonical URL detection
- Tests follow existing test patterns and conventions
- Tests verify both failure and success scenarios

Fixes #4700