### PR TITLE
core: change render-blocking insight from error to warning

### DIFF
--- a/core/audits/insights/render-blocking-insight.js
+++ b/core/audits/insights/render-blocking-insight.js
@@ -23,7 +23,7 @@ class RenderBlockingInsight extends Audit {
       title: str_(UIStrings.title),
       failureTitle: str_(UIStrings.title),
       description: str_(UIStrings.description),
-      guidanceLevel: 3,
+      guidanceLevel: 2,
       requiredArtifacts: ['Trace', 'TraceElements', 'SourceMaps', 'HostDPR'],
       replacesAudits: ['render-blocking-resources'],
     };


### PR DESCRIPTION
## Summary

Downgrades the render-blocking resources insight from guidance level 3 (error) to guidance level 2 (warning).

This avoids over-incentivizing complex performance solutions such as critical CSS inlining. This aligns with Lighthouse's written guidance that most sites should be able to achieve their performance targets without implementing this advanced technique.

## Changes

- Change `guidanceLevel` from `3` (error) to `2` (warning) for the render-blocking insight.
- Preserve the existing audit behavior and guidance.
- No changes to the underlying render-blocking detection logic.

## Testing

- Existing Lighthouse tests pass.
- Verified that the change only affects the guidance severity level.

Fixes #17081