### PR TITLE
docs(readme): add AwesomeTechStack to non-Web Perf integrations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -381,6 +381,8 @@ This section details services that have integrated Lighthouse data. If you're wo
 
 * **[Wattspeed](https://wattspeed.com/)** — Wattspeed is a free tool that generates snapshots - historical captures of your web pages that include Lighthouse scores, a list of technologies, W3C HTML validator results, DOM size, mixed content info, and more.
 
+* **[AwesomeTechStack](https://awesometechstack.com)** — AwesomeTechStack analyzes a website's technology stack and rates it for security, up-to-dateness and quality. Lighthouse supplies the quality part of that rating, with performance, accessibility, best practices and SEO weighted equally, and scores are tracked over time and available through an audit API. AwesomeTechStack is offered via free and paid plans.
+
 ## Plugins
 
 * **[lighthouse-plugin-field-performance](https://github.com/treosh/lighthouse-plugin-field-performance)** - a plugin that adds real-user performance metrics for the URL using the data from [Chrome UX Report](https://developers.google.com/web/tools/chrome-user-experience-report/).


### PR DESCRIPTION
**Summary**

Adds AwesomeTechStack back to "Lighthouse Integrations in non-Web Perf services".

I know the history here: merged in #10475, removed in #14338, and you closed #14783 and #15904 — the last one with "I don't expect that to change." I'm not re-arguing the old case, and this is the last time I'll raise it either way.

What has changed since 2024 is the part you said you couldn't verify. The Lighthouse integration is documented publicly now instead of being buried in the product:

- https://awesometechstack.com/methodology — the quality sub-score is Lighthouse: performance, accessibility, best practices and SEO, weighted equally. PWA is excluded, so the score follows the four current categories.
- https://awesometechstack.com/products/website-analyzer/docs — audits, including their Lighthouse results, are available over a public API.

Sites are re-audited on a schedule and the scores are kept as history, so the Lighthouse data isn't a one-off render.

If it's still not a fit, just close it — genuinely no hard feelings, and thanks for the two replies you already took the time to write.
