### PR TITLE
tests(llms-txt): add passing and failing smoke tests and fixtures

### DIFF
--- a/cli/test/fixtures/agentic/llms-invalid.txt
+++ b/cli/test/fixtures/agentic/llms-invalid.txt
@@ -1,0 +1,1 @@
+Bad llms txt file content

--- a/cli/test/fixtures/agentic/llms_tester_invalid.html
+++ b/cli/test/fixtures/agentic/llms_tester_invalid.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2026 Google LLC
+  SPDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>llms.txt Invalid Tester</title>
+</head>
+<body>
+  <h1>llms.txt Invalid Tester</h1>
+  <p>This page is used to test llms.txt invalid content E2E.</p>
+</body>
+</html>

--- a/cli/test/fixtures/llms.txt
+++ b/cli/test/fixtures/llms.txt
@@ -1,1 +1,5 @@
-Bad llms txt file content
+# Lighthouse
+
+> Lighthouse is an open-source, automated tool for improving the quality of web pages.
+
+For more information, see the [Lighthouse documentation](https://developer.chrome.com/docs/lighthouse/).

--- a/cli/test/fixtures/static-server.js
+++ b/cli/test/fixtures/static-server.js
@@ -99,6 +99,9 @@ class Server {
     const filePath = requestUrl.pathname;
     const queryString = requestUrl.search && parseQueryString(requestUrl.search.slice(1));
     let absoluteFilePath = path.join(this.baseDir, filePath);
+    if (this._port === 10503 && filePath === '/llms.txt') {
+      absoluteFilePath = path.join(this.baseDir, 'agentic/llms-invalid.txt');
+    }
     const sendResponse = (statusCode, data) => {
       // Used by Smokerider.
       if (this._dataTransformer) data = this._dataTransformer(data);

--- a/cli/test/smokehouse/core-tests.js
+++ b/cli/test/smokehouse/core-tests.js
@@ -69,6 +69,7 @@ import timing from './test-definitions/timing.js';
 import trustedTypesDirectivePresent from './test-definitions/trusted-types-directive-present.js';
 import trustedTypesDirectiveMissingDirective from './test-definitions/trusted-types-missing-directives.js';
 import llmsTxt from './test-definitions/llms-txt.js';
+import llmsTxtInvalid from './test-definitions/llms-txt-invalid.js';
 import webmcp from './test-definitions/webmcp.js';
 
 /** @type {ReadonlyArray<Smokehouse.TestDfn>} */
@@ -103,6 +104,7 @@ const smokeTests = [
   lanternXhr,
   legacyJavascript,
   llmsTxt,
+  llmsTxtInvalid,
   metricsDebugger,
   metricsDelayedFcp,
   metricsDelayedLcp,

--- a/cli/test/smokehouse/test-definitions/llms-txt-invalid.js
+++ b/cli/test/smokehouse/test-definitions/llms-txt-invalid.js
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @type {LH.Config}
+ */
+const config = {
+  extends: 'lighthouse:default',
+  settings: {
+    onlyAudits: [
+      'llms-txt',
+    ],
+  },
+};
+
+/**
+ * @type {Smokehouse.ExpectedRunnerResult}
+ */
+const expectations = {
+  lhr: {
+    requestedUrl: 'http://localhost:10503/agentic/llms_tester_invalid.html',
+    finalDisplayedUrl: 'http://localhost:10503/agentic/llms_tester_invalid.html',
+    audits: {
+      'llms-txt': {
+        score: 0,
+        scoreDisplayMode: 'binary',
+        details: {
+          type: 'table',
+          items: [
+            {message: 'File is missing a required H1 header (e.g., "# Title").'},
+            {message: 'File does not appear to contain any links.'},
+            {message: 'File is suspiciously short.'},
+          ],
+        },
+      },
+    },
+  },
+};
+
+/** @type {Smokehouse.TestDfn} */
+export default {
+  id: 'llms-txt-invalid',
+  config,
+  expectations,
+};

--- a/cli/test/smokehouse/test-definitions/llms-txt.js
+++ b/cli/test/smokehouse/test-definitions/llms-txt.js
@@ -26,16 +26,8 @@ const expectations = {
     finalDisplayedUrl: 'http://localhost:10200/agentic/llms_tester.html',
     audits: {
       'llms-txt': {
-        score: 0,
+        score: 1,
         scoreDisplayMode: 'binary',
-        details: {
-          type: 'table',
-          items: [
-            {message: 'File is missing a required H1 header (e.g., "# Title").'},
-            {message: 'File does not appear to contain any links.'},
-            {message: 'File is suspiciously short.'},
-          ],
-        },
       },
     },
   },

--- a/core/test/results/artifacts/artifacts.json
+++ b/core/test/results/artifacts/artifacts.json
@@ -8375,8 +8375,8 @@
     }
   ],
   "LlmsTxt": {
-    "status": 404,
-    "content": null
+    "status": 200,
+    "content": "Bad llms txt file content\n"
   },
   "AgentResourceDiscovery": {
     "status": 404,

--- a/core/test/results/sample_v2.json
+++ b/core/test/results/sample_v2.json
@@ -4860,10 +4860,31 @@
     },
     "llms-txt": {
       "id": "llms-txt",
-      "title": "llms.txt follows recommendations",
+      "title": "llms.txt does not follow recommendations",
       "description": "If your llms.txt file does not follow recommendations, large language models may not be able to understand how you want your website to be crawled or used for training. The [llms.txt](https://llmstxt.org/) file should be a Markdown file containing at least one H1 header. [Learn more about the llms.txt audit](https://developer.chrome.com/docs/lighthouse/agentic-browsing/llms-txt).",
-      "score": null,
-      "scoreDisplayMode": "notApplicable"
+      "score": 0,
+      "scoreDisplayMode": "binary",
+      "details": {
+        "type": "table",
+        "headings": [
+          {
+            "key": "message",
+            "valueType": "text",
+            "label": "Error"
+          }
+        ],
+        "items": [
+          {
+            "message": "File is missing a required H1 header (e.g., \"# Title\")."
+          },
+          {
+            "message": "File does not appear to contain any links."
+          },
+          {
+            "message": "File is suspiciously short."
+          }
+        ]
+      }
     },
     "ard-schema": {
       "id": "ard-schema",
@@ -7009,7 +7030,7 @@
         },
         {
           "id": "llms-txt",
-          "weight": 0,
+          "weight": 1,
           "group": "agent-discoverability"
         },
         {
@@ -7019,7 +7040,7 @@
         }
       ],
       "id": "agentic-browsing",
-      "score": 0.3
+      "score": 0.23
     }
   },
   "categoryGroups": {
@@ -11400,11 +11421,20 @@
       "core/audits/webmcp-schema-validity.js | missingParamDescription": [
         "audits[webmcp-schema-validity].details.items[1].issue"
       ],
-      "core/audits/agentic/llms-txt.js | title": [
+      "core/audits/agentic/llms-txt.js | failureTitle": [
         "audits[llms-txt].title"
       ],
       "core/audits/agentic/llms-txt.js | description": [
         "audits[llms-txt].description"
+      ],
+      "core/audits/agentic/llms-txt.js | missingH1": [
+        "audits[llms-txt].details.items[0].message"
+      ],
+      "core/audits/agentic/llms-txt.js | missingLinks": [
+        "audits[llms-txt].details.items[1].message"
+      ],
+      "core/audits/agentic/llms-txt.js | tooShort": [
+        "audits[llms-txt].details.items[2].message"
       ],
       "core/audits/agentic/ard-schema.js | title": [
         "audits[ard-schema].title"

--- a/report/test/generator/report-generator-test.js
+++ b/report/test/generator/report-generator-test.js
@@ -110,7 +110,7 @@ category,score
 \\"accessibility\\",\\"0.75\\"
 \\"best-practices\\",\\"0.31\\"
 \\"seo\\",\\"0.75\\"
-\\"agentic-browsing\\",\\"0.3\\"
+\\"agentic-browsing\\",\\"0.23\\"
 
 category,audit,score,displayValue,description
 \\"performance\\",\\"first-contentful-paint\\",\\"0.02\\",\\"6.8 s\\",\\"First Contentful Paint marks the time at which the first text or image is painted. [Learn more about the First Contentful Paint metric](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint/).\\"


### PR DESCRIPTION
Implements positive and negative smoke tests for llms.txt using new static fixtures and test server routing. Verifies that valid Markdown passes while malformed files correctly trigger header, link, and length validation errors. Updates generated sample JSON and CSV test snapshots.