### PR TITLE
tests(core): add unit tests for LighthouseError

### DIFF
--- a/core/test/lib/lh-error-test.js
+++ b/core/test/lib/lh-error-test.js
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {LighthouseError} from '../../lib/lh-error.js';
+
+describe('LighthouseError', () => {
+  describe('#constructor', () => {
+    it('sets code, name, message, and a friendlyMessage containing the code', () => {
+      const err = new LighthouseError(LighthouseError.errors.NO_FCP);
+
+      expect(err).toBeInstanceOf(LighthouseError);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.code).toBe('NO_FCP');
+      expect(err.name).toBe('LighthouseError');
+      // `super(code, options)` makes the raw Error message the code.
+      expect(err.message).toBe('NO_FCP');
+      // The friendly message is the ICU-stringified definition, with `errorCode` auto-filled.
+      expect(err.friendlyMessage).toContain('NO_FCP');
+    });
+
+    it('reflects lhrRuntimeError from the error definition', () => {
+      const runtimeErr = new LighthouseError(LighthouseError.errors.NO_SPEEDLINE_FRAMES);
+      expect(runtimeErr.lhrRuntimeError).toBe(true);
+
+      // NO_FCP has no `lhrRuntimeError`, so it must default to false.
+      const nonRuntimeErr = new LighthouseError(LighthouseError.errors.NO_FCP);
+      expect(nonRuntimeErr.lhrRuntimeError).toBe(false);
+    });
+
+    it('assigns custom properties and substitutes them into the friendlyMessage', () => {
+      const err = new LighthouseError(LighthouseError.errors.ERRORED_DOCUMENT_REQUEST,
+          {statusCode: '404'});
+
+      expect(err.statusCode).toBe('404');
+      expect(err.friendlyMessage).toContain('404');
+    });
+
+    it('preserves the cause passed via ErrorOptions', () => {
+      const cause = new Error('root cause');
+      const err = new LighthouseError(LighthouseError.errors.NO_FCP, undefined, {cause});
+
+      expect(err.cause).toBe(cause);
+    });
+  });
+
+  describe('.errors', () => {
+    it('has a code that matches each registry key', () => {
+      for (const [key, definition] of Object.entries(LighthouseError.errors)) {
+        expect(definition.code).toBe(key);
+      }
+    });
+  });
+
+  describe('static constants', () => {
+    it('exposes the NO_ERROR and UNKNOWN_ERROR sentinels', () => {
+      expect(LighthouseError.NO_ERROR).toBe('NO_ERROR');
+      expect(LighthouseError.UNKNOWN_ERROR).toBe('UNKNOWN_ERROR');
+    });
+  });
+
+  describe('#fromProtocolMessage', () => {
+    it('returns a LighthouseError when a definition pattern matches', () => {
+      const err = LighthouseError.fromProtocolMessage('Tracing.start',
+          {message: 'Tracing already started'});
+
+      expect(err).toBeInstanceOf(LighthouseError);
+      expect(err.code).toBe('TRACING_ALREADY_STARTED');
+    });
+
+    it('falls back to a generic Error when no pattern matches', () => {
+      const err = LighthouseError.fromProtocolMessage('Page.navigate',
+          {message: 'something unexpected'});
+
+      expect(err).not.toBeInstanceOf(LighthouseError);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('Protocol error (Page.navigate): something unexpected');
+      expect(err.protocolMethod).toBe('Page.navigate');
+      expect(err.protocolError).toBe('something unexpected');
+    });
+
+    it('appends protocolError.data to the fallback message', () => {
+      const err = LighthouseError.fromProtocolMessage('Page.navigate',
+          {message: 'boom', data: 'extra details'});
+
+      expect(err.message).toBe('Protocol error (Page.navigate): boom (extra details)');
+    });
+  });
+
+  describe('#stringifyReplacer', () => {
+    it('serializes a LighthouseError with only its custom properties', () => {
+      const err = new LighthouseError(LighthouseError.errors.ERRORED_DOCUMENT_REQUEST,
+          {statusCode: '404'});
+
+      const serialized = LighthouseError.stringifyReplacer(err);
+
+      expect(serialized.sentinel).toBe('__LighthouseErrorSentinel');
+      expect(serialized.code).toBe('ERRORED_DOCUMENT_REQUEST');
+      // Class-internal fields must not leak into `properties`.
+      expect(serialized.properties).toEqual({statusCode: '404'});
+      expect(typeof serialized.stack).toBe('string');
+    });
+
+    it('serializes a plain Error with the Error sentinel', () => {
+      const baseErr = new Error('base failure');
+      const serialized = LighthouseError.stringifyReplacer(baseErr);
+
+      expect(serialized.sentinel).toBe('__ErrorSentinel');
+      expect(serialized.message).toBe('base failure');
+    });
+
+    it('throws on a non-error value', () => {
+      expect(() => LighthouseError.stringifyReplacer({notAnError: true})).toThrow();
+    });
+  });
+
+  describe('#parseReviver', () => {
+    it('round-trips a LighthouseError including custom properties', () => {
+      const err = new LighthouseError(LighthouseError.errors.ERRORED_DOCUMENT_REQUEST,
+          {statusCode: '404'});
+
+      const json = JSON.stringify(err, LighthouseError.stringifyReplacer);
+      const revived = JSON.parse(json, LighthouseError.parseReviver);
+
+      expect(revived).toBeInstanceOf(LighthouseError);
+      expect(revived).not.toBe(err);
+      expect(revived.code).toBe('ERRORED_DOCUMENT_REQUEST');
+      expect(revived.statusCode).toBe('404');
+      expect(revived.friendlyMessage).toContain('404');
+    });
+
+    it('round-trips a plain Error', () => {
+      const baseErr = new Error('base failure');
+
+      const json = JSON.stringify(baseErr, LighthouseError.stringifyReplacer);
+      const revived = JSON.parse(json, LighthouseError.parseReviver);
+
+      expect(revived).toBeInstanceOf(Error);
+      expect(revived.message).toBe('base failure');
+    });
+
+    it('returns non-sentinel values unchanged', () => {
+      const value = {some: 'object'};
+      expect(LighthouseError.parseReviver('key', value)).toBe(value);
+    });
+  });
+});

--- a/core/test/lib/lh-error-test.js
+++ b/core/test/lib/lh-error-test.js
@@ -6,6 +6,19 @@
 
 import {LighthouseError} from '../../lib/lh-error.js';
 
+/**
+ * `LighthouseError.stringifyReplacer` takes just the error value, not the
+ * `(key, value)` pair that `JSON.stringify` passes to a replacer, so it must be
+ * wrapped before use. This mirrors the production helper in
+ * `core/lib/asset-saver.js`.
+ * @param {string} key
+ * @param {any} value
+ */
+function errorReplacer(key, value) {
+  if (value instanceof Error) return LighthouseError.stringifyReplacer(value);
+  return value;
+}
+
 describe('LighthouseError', () => {
   describe('#constructor', () => {
     it('sets code, name, message, and a friendlyMessage containing the code', () => {
@@ -17,16 +30,17 @@ describe('LighthouseError', () => {
       expect(err.name).toBe('LighthouseError');
       // `super(code, options)` makes the raw Error message the code.
       expect(err.message).toBe('NO_FCP');
-      // The friendly message is the ICU-stringified definition, with `errorCode` auto-filled.
-      expect(err.friendlyMessage).toContain('NO_FCP');
+      // The friendly message is an i18n object, with `errorCode` auto-filled from the code.
+      expect(err.friendlyMessage.formattedDefault).toContain('NO_FCP');
+      expect(err.friendlyMessage.values).toEqual({errorCode: 'NO_FCP'});
     });
 
     it('reflects lhrRuntimeError from the error definition', () => {
       const runtimeErr = new LighthouseError(LighthouseError.errors.NO_SPEEDLINE_FRAMES);
       expect(runtimeErr.lhrRuntimeError).toBe(true);
 
-      // NO_FCP has no `lhrRuntimeError`, so it must default to false.
-      const nonRuntimeErr = new LighthouseError(LighthouseError.errors.NO_FCP);
+      // NO_LCP omits `lhrRuntimeError`, so the constructor must default it to false.
+      const nonRuntimeErr = new LighthouseError(LighthouseError.errors.NO_LCP);
       expect(nonRuntimeErr.lhrRuntimeError).toBe(false);
     });
 
@@ -35,7 +49,12 @@ describe('LighthouseError', () => {
           {statusCode: '404'});
 
       expect(err.statusCode).toBe('404');
-      expect(err.friendlyMessage).toContain('404');
+      // Custom properties are substituted into the ICU message.
+      expect(err.friendlyMessage.formattedDefault).toContain('Status code: 404');
+      expect(err.friendlyMessage.values).toEqual({
+        errorCode: 'ERRORED_DOCUMENT_REQUEST',
+        statusCode: '404',
+      });
     });
 
     it('preserves the cause passed via ErrorOptions', () => {
@@ -121,24 +140,28 @@ describe('LighthouseError', () => {
       const err = new LighthouseError(LighthouseError.errors.ERRORED_DOCUMENT_REQUEST,
           {statusCode: '404'});
 
-      const json = JSON.stringify(err, LighthouseError.stringifyReplacer);
+      const json = JSON.stringify(err, errorReplacer);
       const revived = JSON.parse(json, LighthouseError.parseReviver);
 
       expect(revived).toBeInstanceOf(LighthouseError);
       expect(revived).not.toBe(err);
       expect(revived.code).toBe('ERRORED_DOCUMENT_REQUEST');
+      // Custom properties survive the round trip.
       expect(revived.statusCode).toBe('404');
-      expect(revived.friendlyMessage).toContain('404');
+      expect(revived.friendlyMessage.formattedDefault).toContain('Status code: 404');
+      expect(revived.lhrRuntimeError).toBe(true);
     });
 
     it('round-trips a plain Error', () => {
       const baseErr = new Error('base failure');
 
-      const json = JSON.stringify(baseErr, LighthouseError.stringifyReplacer);
+      const json = JSON.stringify(baseErr, errorReplacer);
       const revived = JSON.parse(json, LighthouseError.parseReviver);
 
       expect(revived).toBeInstanceOf(Error);
+      expect(revived).not.toBeInstanceOf(LighthouseError);
       expect(revived.message).toBe('base failure');
+      expect(revived.stack).toBe(baseErr.stack);
     });
 
     it('returns non-sentinel values unchanged', () => {


### PR DESCRIPTION
**Summary**

This PR adds a dedicated unit test suite for `core/lib/lh-error.js` (`LighthouseError`),
which currently has **no dedicated unit test coverage** despite being core error
infrastructure used for cross-process error propagation (between the runner, workers,
and the report).

- **Type of change:** test supplementation only. No production logic is modified, so this
  change cannot affect any other feature or audit.
- **What is covered:**
  - `#constructor` — sets `code`/`name`/`message`/`friendlyMessage`; reflects
    `lhrRuntimeError` from the error definition; assigns custom message-substitution
    properties (e.g. `statusCode`); preserves `cause` from `ErrorOptions`.
  - `.errors` registry invariant — every entry's `code` matches its registry key.
  - static `NO_ERROR` / `UNKNOWN_ERROR` constants.
  - `#fromProtocolMessage` — matches a definition `pattern` and returns a `LighthouseError`,
    and falls back to a generic `Error` carrying `protocolMethod`/`protocolError` when no
    pattern matches (including the `data` suffix).
  - `#stringifyReplacer` / `#parseReviver` — serializes `LighthouseError` and plain `Error`,
    keeps only custom properties (no class-internal leakage), throws on non-error input,
    and round-trips both error kinds losslessly through `JSON.stringify`/`JSON.parse`.
- **Why it is valuable:** the serialize/deserialize pair guards how errors survive process
  boundaries; a regression there surfaces as cryptic, hard-to-trace failures. Dedicated
  coverage makes that path safe to refactor. This is a beginner-friendly, low-risk,
  single-purpose test addition.

## Verification

- `yarn mocha core/test/lib/lh-error-test.js` → **15 passing, 0 failing** (run on
  Node 24 with mocha + the repo's `core/test/test-env/mocha-setup.js` rootHooks).
- `yarn eslint core/test/lib/lh-error-test.js` → exit 0, no warnings.
- The only change is an added test file, so `yarn lint`, `yarn type-check`, and the
  existing unit suite are unaffected except for the new passing tests. No
  `sample_v2.json` / smoke updates are needed (this is a pure `core/lib` unit test,
  not an audit or gatherer).