### PR TITLE
core(webmcp-registered-tools): warn when exceeding recommended limit

### DIFF
--- a/core/audits/webmcp-registered-tools.js
+++ b/core/audits/webmcp-registered-tools.js
@@ -30,9 +30,18 @@ const UIStrings = {
   titleImperativeTools: 'Imperative Tools',
   /** Title for the table listing declarative WebMCP tools. */
   titleDeclarativeTools: 'Declarative Tools',
+  /**
+   * @description Warning message shown when the number of registered tools exceeds the recommended limit.
+   * @example {40} maxTools
+   */
+  warningMaxRecommendedTools: 'Lighthouse recommends registering at most {maxTools} tools. ' +
+    'Exceeding this recommendation consumes model context tokens, adds latency, ' +
+    'and increases the risk of tool confusion.',
 };
 
 const str_ = i18n.createIcuMessageFn(import.meta.url, UIStrings);
+
+const MAX_RECOMMENDED_TOOLS = 40;
 
 class WebMCPRegisteredTools extends Audit {
   /**
@@ -138,12 +147,18 @@ class WebMCPRegisteredTools extends Audit {
       };
     }
 
+    const warnings = [];
+    if (imperativeResults.length + declarativeResults.length > MAX_RECOMMENDED_TOOLS) {
+      warnings.push(str_(UIStrings.warningMaxRecommendedTools, {maxTools: MAX_RECOMMENDED_TOOLS}));
+    }
+
     return {
       score: 1,
       details: Audit.makeListDetails(list),
+      warnings: warnings.length ? warnings : undefined,
     };
   }
 }
 
 export default WebMCPRegisteredTools;
-export {UIStrings};
+export {UIStrings, MAX_RECOMMENDED_TOOLS};

--- a/core/test/audits/webmcp-registered-tools-test.js
+++ b/core/test/audits/webmcp-registered-tools-test.js
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import WebMCPRegisteredTools from '../../audits/webmcp-registered-tools.js';
+import WebMCPRegisteredTools, {
+  MAX_RECOMMENDED_TOOLS,
+} from '../../audits/webmcp-registered-tools.js';
 
 describe('WebMCPRegisteredTools Audit', () => {
   it('renders a table with registered tools', async () => {
@@ -108,5 +110,50 @@ describe('WebMCPRegisteredTools Audit', () => {
 
     expect(result.score).toEqual(1);
     expect(result.notApplicable).toEqual(true);
+  });
+
+  it('does not warn when number of tools does not exceed threshold', async () => {
+    const tools = Array.from({length: MAX_RECOMMENDED_TOOLS}, (_, i) => ({
+      name: `tool_${i}`,
+      description: `Description ${i}`,
+      inputSchema: {type: 'object'},
+      frameId: 'F1',
+      ...(i % 2 === 0
+        ? {backendNodeId: i}
+        : {stackTrace: {callFrames: [{url: 'https://example.com/test.js', lineNumber: 1}]}}),
+    }));
+
+    const artifacts = {
+      WebMCP: {isSupported: true, tools},
+    };
+
+    const result = await WebMCPRegisteredTools.audit(artifacts);
+
+    expect(result.score).toEqual(1);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('warns when the number of imperative and declarative tools exceeds threshold', async () => {
+    const tools = Array.from({length: MAX_RECOMMENDED_TOOLS + 1}, (_, i) => ({
+      name: `tool_${i}`,
+      description: `Description ${i}`,
+      inputSchema: {type: 'object'},
+      frameId: 'F1',
+      ...(i % 2 === 0
+        ? {backendNodeId: i}
+        : {stackTrace: {callFrames: [{url: 'https://example.com/test.js', lineNumber: 1}]}}),
+    }));
+
+    const artifacts = {
+      WebMCP: {isSupported: true, tools},
+    };
+
+    const result = await WebMCPRegisteredTools.audit(artifacts);
+
+    expect(result.score).toEqual(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings?.[0]).toBeDisplayString(
+      new RegExp(`Lighthouse recommends registering at most ${MAX_RECOMMENDED_TOOLS} tools`)
+    );
   });
 });

--- a/shared/localization/locales/en-US.json
+++ b/shared/localization/locales/en-US.json
@@ -1412,6 +1412,9 @@
   "core/audits/webmcp-registered-tools.js | titleImperativeTools": {
     "message": "Imperative Tools"
   },
+  "core/audits/webmcp-registered-tools.js | warningMaxRecommendedTools": {
+    "message": "Lighthouse recommends registering at most {maxTools} tools. Exceeding this recommendation consumes model context tokens, adds latency, and increases the risk of tool confusion."
+  },
   "core/audits/webmcp-schema-validity.js | columnElement": {
     "message": "Element"
   },

--- a/shared/localization/locales/en-XL.json
+++ b/shared/localization/locales/en-XL.json
@@ -1412,6 +1412,9 @@
   "core/audits/webmcp-registered-tools.js | titleImperativeTools": {
     "message": "Îḿp̂ér̂át̂ív̂é T̂óôĺŝ"
   },
+  "core/audits/webmcp-registered-tools.js | warningMaxRecommendedTools": {
+    "message": "L̂íĝh́t̂h́ôúŝé r̂éĉóm̂ḿêńd̂ś r̂éĝíŝt́êŕîńĝ át̂ ḿôśt̂ {maxTools} t́ôól̂ś. Êx́ĉéêd́îńĝ t́ĥíŝ ŕêćôḿm̂én̂d́ât́îón̂ ćôńŝúm̂éŝ ḿôd́êĺ ĉón̂t́êx́t̂ t́ôḱêńŝ, ád̂d́ŝ ĺât́êńĉý, âńd̂ ín̂ćr̂éâśêś t̂h́ê ŕîśk̂ óf̂ t́ôól̂ ćôńf̂úŝíôń."
+  },
   "core/audits/webmcp-schema-validity.js | columnElement": {
     "message": "Êĺêḿêńt̂"
   },


### PR DESCRIPTION
Following WebMCP spec discussion at https://github.com/webmachinelearning/webmcp/issues/293#issuecomment-5539780216, we thought we should have a warning when WebMCP tools exceed a recommended limit. It's 40 in this current PR but there's no hard number.


<img width="836" height="894" alt="image" src="https://github.com/user-attachments/assets/0bfa07c5-895d-47c7-900b-bd7cfb9a4d3b" />
